### PR TITLE
Change the tfPrefix for pull requests to ensure that no two are the same

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ else if (env.CHANGE_ID) {
     /* When handling pull requests, ensure everything is denoted by the pull
      * request
      */
-    tfPrefix = "pr${env.CHANGE_ID}"
+    tfPrefix = "pr${env.BUILD_NUMBER}"
 }
 else {
     /* Any branches or anything else that might execute this Pipeline should


### PR DESCRIPTION
This will help prevent an error in one Pipeline run from negatively impacting
successive runs for the same pull request.

The downside of this is that resources might be left running in Azure if they
were not capable of being destroyed properly