### PR TITLE
[INFRA-1015] Logs resources

### DIFF
--- a/arm_templates/logs.json
+++ b/arm_templates/logs.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "omsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "omsws01",
+      "metadata": {
+        "description": "Specify name of your OMS workspace"
+      }
+    },
+    "omsRegion": {
+      "type": "string",
+      "defaultValue": "West Europe",
+      "allowedValues": [
+        "West Europe",
+        "East US",
+        "Southeast Asia"
+      ],
+      "metadata": {
+        "description": "Select OMS region"
+      }
+    },
+    "existingStorageAccountName": {
+      "type": "string",
+      "defaultValue": "mystorage",
+      "metadata": {
+        "description": "Specify the name of the existing storage account to add to OMS"
+      }
+    },
+    "existingStorageAccountResourceGroupName": {
+      "type": "string",
+      "defaultValue": "myrgname",
+      "metadata": {
+        "description": "Resource group containing the storage account"
+      }
+    },
+    "table": {
+      "type": "string",
+      "defaultValue": "WADServiceFabric*EventTable",
+      "allowedValues": [
+        "WADWindowsEventLogsTable",
+        "WADServiceFabric*EventTable",
+        "wad-iis-logfiles",
+        "WADETWEventTable"
+      ],
+      "metadata": {
+        "description": "Select the table to add to OMS"
+      }
+    }
+  },
+  "variables": {
+    "solution": "[concat('ServiceFabric', '(', parameters('omsWorkspaceName'), ')')]",
+    "solutionName": "ServiceFabric"      
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-11-01-preview",
+      "location": "[parameters('omsRegion')]",
+      "name": "[variables('solution')]",
+      "type": "Microsoft.OperationsManagement/solutions",
+      "id": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationsManagement/solutions/', variables('solution'))]",
+      "dependsOn": [
+        "[concat('Microsoft.OperationalInsights/workspaces/', parameters('omsWorkspaceName'))]"
+      ],
+      "properties": {
+        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('omsWorkspaceName'))]"
+      },
+      "plan": {
+        "name": "[variables('solution')]",
+        "publisher": "Microsoft",
+        "product": "[Concat('OMSGallery/', variables('solutionName'))]",
+        "promotionCode": ""
+      }
+    },
+    {
+      "apiVersion": "2015-11-01-preview",
+      "name": "[parameters('omsWorkspaceName')]",
+      "location": "[parameters('omsRegion')]",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "properties": {
+        "sku": {
+          "name": "Free"
+        }
+      },
+      "resources": [
+        {
+          "apiVersion": "2015-11-01-preview",
+          "name": "[concat(parameters('existingstorageaccountName'),parameters('omsWorkspaceName'))]",
+          "type": "storageinsightconfigs",
+          "dependsOn": [
+            "[concat('Microsoft.OperationalInsights/workspaces/', parameters('omsWorkspaceName'))]"
+          ],
+          "properties": {
+            "containers": [ ],
+            "tables": [
+              "[parameters('table')]"
+            ],
+            "storageAccount": {
+              "id": "[resourceId(parameters('existingStorageAccountResourceGroupName'),'Microsoft.Storage/storageaccounts/', parameters('existingStorageAccountName'))]",
+              "key": "[listKeys(resourceId(parameters('existingStorageAccountResourceGroupName'),'Microsoft.Storage/storageAccounts', parameters('existingStorageAccountName')),'2015-06-15').key1]"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": { }
+}

--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "logs" {
     name     = "${var.prefix}logs"
-    location = "${var.location}"
+    location = "${var.logslocation}"
     tags {
         env = "${var.prefix}"
     }
@@ -9,7 +9,7 @@ resource "azurerm_resource_group" "logs" {
 resource "azurerm_storage_account" "logs" {
     name                = "${var.prefix}logs"
     resource_group_name = "${azurerm_resource_group.logs.name}"
-    location            = "${var.location}"
+    location            = "${var.logslocation}"
     account_type        = "Standard_GRS"
     depends_on          = ["azurerm_resource_group.logs"]
     tags {
@@ -23,7 +23,7 @@ resource "azurerm_template_deployment" "logs"{
     depends_on          = ["azurerm_resource_group.logs"]
     parameters = {
         omsWorkspaceName = "${var.prefix}logs"
-        omsRegion = "${var.location}"
+        omsRegion = "${var.logslocation}"
         existingStorageAccountName = "${azurerm_storage_account.logs.name}"
         existingStorageAccountResourceGroupName = "${azurerm_resource_group.logs.name}"
         table = "WADWindowsEventLogsTable"

--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -34,7 +34,7 @@ resource "azurerm_template_deployment" "logs"{
         omsRegion = "${var.location}"
         existingStorageAccountName = "${azurerm_storage_account.logs.name}"
         existingStorageAccountResourceGroupName = "${azurerm_resource_group.logs.name}"
-        table = "WADServiceFabric*EventTable"
+        table = "WADWindowsEventLogsTable"
     }
     deployment_mode = "Incremental"
     template_body = "${file("./arm_templates/logs.json")}"

--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -34,9 +34,8 @@ resource "azurerm_template_deployment" "logs"{
         omsRegion = "${var.location}"
         existingStorageAccountName = "${azurerm_storage_account.logs.name}"
         existingStorageAccountResourceGroupName = "${azurerm_resource_group.logs.name}"
-        #table = ""
+        table = "WADServiceFabric*EventTable"
     }
-    #deployment_mode = "Complete"
     deployment_mode = "Incremental"
     template_body = "${file("./arm_templates/logs.json")}"
 }

--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -17,14 +17,6 @@ resource "azurerm_storage_account" "logs" {
     }
 }
 
-resource "azurerm_storage_share" "logs" {
-    name = "logs"
-    resource_group_name     = "${azurerm_resource_group.logs.name}"
-    storage_account_name    = "${azurerm_storage_account.logs.name}"
-    quota                   = 50
-    depends_on              = ["azurerm_resource_group.logs","azurerm_storage_account.logs"]
-}
-
 resource "azurerm_template_deployment" "logs"{
     name  = "${var.prefix}logs"
     resource_group_name = "${ azurerm_resource_group.logs.name }"

--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -1,0 +1,42 @@
+resource "azurerm_resource_group" "logs" {
+    name     = "${var.prefix}logs"
+    location = "${var.location}"
+    tags {
+        env = "${var.prefix}"
+    }
+}
+
+resource "azurerm_storage_account" "logs" {
+    name                = "${var.prefix}logs"
+    resource_group_name = "${azurerm_resource_group.logs.name}"
+    location            = "${var.location}"
+    account_type        = "Standard_GRS"
+    depends_on          = ["azurerm_resource_group.logs"]
+    tags {
+        env = "${var.prefix}"
+    }
+}
+
+resource "azurerm_storage_share" "logs" {
+    name = "logs"
+    resource_group_name     = "${azurerm_resource_group.logs.name}"
+    storage_account_name    = "${azurerm_storage_account.logs.name}"
+    quota                   = 50
+    depends_on              = ["azurerm_resource_group.logs","azurerm_storage_account.logs"]
+}
+
+resource "azurerm_template_deployment" "logs"{
+    name  = "${var.prefix}logs"
+    resource_group_name = "${ azurerm_resource_group.logs.name }"
+    depends_on          = ["azurerm_resource_group.logs"]
+    parameters = {
+        omsWorkspaceName = "${var.prefix}logs"
+        omsRegion = "${var.location}"
+        existingStorageAccountName = "${azurerm_storage_account.logs.name}"
+        existingStorageAccountResourceGroupName = "${azurerm_resource_group.logs.name}"
+        #table = ""
+    }
+    #deployment_mode = "Complete"
+    deployment_mode = "Incremental"
+    template_body = "${file("./arm_templates/logs.json")}"
+}

--- a/plans/variables.tf
+++ b/plans/variables.tf
@@ -8,6 +8,10 @@ variable "location" {
     type    = "string"
     default = "East US 2"
 }
+variable "logslocation" {
+    type    = "string"
+    default = "East US"
+}
 
 # Port used for Puppet agents to connect to a Puppet master
 variable "puppet_master_port" {


### PR DESCRIPTION
This PR add followings resources creation

- resource groupe ${PREFIX}logs
- storage account ${PREFIX}logs
- OMS workspace linked '${PREFIX}logs' storage account

Create Log analytics resources to display logs generated by kubernetes + fluentd.
Following resources were tested by this image -> https://github.com/olblak/fluentd-k8s-azure
On a kubernetes azure container service.

Log architecture work as follow:
|Kubernetes | -> |Fluentd| -> |Log Analytics|

N.B.: With this approach we don't use blob storage