### PR TITLE
Add logs resources provisionning v2.0

### DIFF
--- a/arm_templates/logs.yaml
+++ b/arm_templates/logs.yaml
@@ -1,0 +1,81 @@
+$schema: https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json
+contentVersion: 1.0.0.0
+parameters:
+  omsWorkspaceName:
+    type: string
+    defaultValue: omsws01
+    metadata:
+      description: Specify name of your OMS workspace
+  omsRegion:
+    type: string
+    defaultValue: West Europe
+    allowedValues:
+    - West Europe
+    - East US
+    - Southeast Asia
+    metadata:
+      description: Select OMS region
+  existingStorageAccountName:
+    type: string
+    defaultValue: mystorage
+    metadata:
+      description: Specify the name of the existing storage account to add to OMS
+  existingStorageAccountResourceGroupName:
+    type: string
+    defaultValue: myrgname
+    metadata:
+      description: Resource group containing the storage account
+  table:
+    type: string
+    defaultValue: WADServiceFabric*EventTable
+    allowedValues:
+    - WADWindowsEventLogsTable
+    - WADServiceFabric*EventTable
+    - wad-iis-logfiles
+    - WADETWEventTable
+    metadata:
+      description: Select the table to add to OMS
+variables:
+  solution: '[concat(''ServiceFabric'', ''('', parameters(''omsWorkspaceName''), '')'')]'
+  solutionName: ServiceFabric
+resources:
+- apiVersion: 2015-11-01-preview
+  location: '[parameters(''omsRegion'')]'
+  name: '[variables(''solution'')]'
+  type: Microsoft.OperationsManagement/solutions
+  id: '[concat(''/subscriptions/'', subscription().subscriptionId, ''/resourceGroups/'',
+    resourceGroup().name, ''/providers/Microsoft.OperationsManagement/solutions/'',
+    variables(''solution''))]'
+  dependsOn:
+  - '[concat(''Microsoft.OperationalInsights/workspaces/'', parameters(''omsWorkspaceName''))]'
+  properties:
+    workspaceResourceId: '[resourceId(''Microsoft.OperationalInsights/workspaces/'',
+      parameters(''omsWorkspaceName''))]'
+  plan:
+    name: '[variables(''solution'')]'
+    publisher: Microsoft
+    product: '[Concat(''OMSGallery/'', variables(''solutionName''))]'
+    promotionCode: ''
+- apiVersion: 2015-11-01-preview
+  name: '[parameters(''omsWorkspaceName'')]'
+  location: '[parameters(''omsRegion'')]'
+  type: Microsoft.OperationalInsights/workspaces
+  properties:
+    sku:
+      name: Free
+  resources:
+  - apiVersion: 2015-11-01-preview
+    name: '[concat(parameters(''existingstorageaccountName''),parameters(''omsWorkspaceName''))]'
+    type: storageinsightconfigs
+    dependsOn:
+    - '[concat(''Microsoft.OperationalInsights/workspaces/'', parameters(''omsWorkspaceName''))]'
+    properties:
+      containers: []
+      tables:
+      - '[parameters(''table'')]'
+      storageAccount:
+        id: '[resourceId(parameters(''existingStorageAccountResourceGroupName''),''Microsoft.Storage/storageaccounts/'',
+          parameters(''existingStorageAccountName''))]'
+        key: '[listKeys(resourceId(parameters(''existingStorageAccountResourceGroupName''),''Microsoft.Storage/storageAccounts'',
+          parameters(''existingStorageAccountName'')),''2015-06-15'').key1]'
+outputs: {}

--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -1,0 +1,42 @@
+resource "azurerm_resource_group" "logs" {
+    name     = "${var.prefix}logs"
+    location = "${var.logslocation}"
+    tags {
+        env = "${var.prefix}"
+    }
+}
+
+resource "azurerm_storage_account" "logs" {
+    name                = "${var.prefix}logs"
+    resource_group_name = "${azurerm_resource_group.logs.name}"
+    location            = "${var.logslocation}"
+    account_type        = "Standard_GRS"
+    depends_on          = ["azurerm_resource_group.logs"]
+    tags {
+        env = "${var.prefix}"
+    }
+}
+
+
+resource "azurerm_storage_share" "logs" {
+    name = "logs"
+    resource_group_name     = "${azurerm_resource_group.logs.name}"
+    storage_account_name    = "${azurerm_storage_account.logs.name}"
+    quota                   = 200
+    depends_on              = ["azurerm_resource_group.logs","azurerm_storage_account.logs"]
+}
+
+resource "azurerm_template_deployment" "logs"{
+    name  = "${var.prefix}logs"
+    resource_group_name = "${ azurerm_resource_group.logs.name }"
+    depends_on          = ["azurerm_resource_group.logs"]
+    parameters = {
+        omsWorkspaceName = "${var.prefix}logs"
+        omsRegion = "${var.logslocation}"
+        existingStorageAccountName = "${azurerm_storage_account.logs.name}"
+        existingStorageAccountResourceGroupName = "${azurerm_resource_group.logs.name}"
+        table = "WADWindowsEventLogsTable"
+    }
+    deployment_mode = "Incremental"
+    template_body = "${file("./arm_templates/logs.json")}"
+}

--- a/plans/variables.tf
+++ b/plans/variables.tf
@@ -25,3 +25,8 @@ variable "ssh_pubkey_path"{
     type = "string"
     default = "./ssh_key/dummyk8s_rsa.pub"
 }
+
+variable "logslocation" {
+    type    = "string"
+    default = "East US"
+}


### PR DESCRIPTION
Add azure resources for kubernetes logging workflow.

	* Create logs resource group
	* Create logs storage account
	* Create logs shared disk storage
	* Create OMS workspace

	More informations can be found within this project
	-> [IEP-004](https://github.com/jenkins-infra/iep/pull/5)

We can use this [Project](https://github.com/olblak/k8s) to test this PR.
Keep in mind that we will have to configure secrets properly

N.B.: 
Due to some issues in [fluent-plugin-azurestorage](https://github.com/htgc/fluent-plugin-azurestorage/issues), I choose to use an azure shared disk that I mount at kubernetes level.
We should switch to an azure blob storage if the plugin work as expected.

[This docker image](https://github.com/olblak/fluentd-k8s-azure) implement the logging workflow explain 
[here - IEP4](https://github.com/jenkins-infra/iep/pull/5)  (logtype: archive, logtype:stream,...)


I add two screenshots on this [repository](https://github.com/olblak/k8s/tree/master/doc)
-> [enable_azure_custom_logs](https://github.com/olblak/k8s/blob/master/doc/enable_azure_custom_logs.png)
Should we add them here? in IEP?