### PR TITLE
Move the logs storage account into the same region as Kubernetes

### DIFF
--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "logs" {
     name     = "${var.prefix}logs"
-    location = "${var.logslocation}"
+    location = "${var.location}"
     tags {
         env = "${var.prefix}"
     }
@@ -9,7 +9,7 @@ resource "azurerm_resource_group" "logs" {
 resource "azurerm_storage_account" "logs" {
     name                = "${var.prefix}jenkinslogs"
     resource_group_name = "${azurerm_resource_group.logs.name}"
-    location            = "${var.logslocation}"
+    location            = "${var.location}"
     account_type        = "Standard_GRS"
     depends_on          = ["azurerm_resource_group.logs"]
     tags {


### PR DESCRIPTION
After some triaging by @olblak, it appears that file volumes cannot be mounted
in k8s unless the storage account is in the same region as the k8s cluster.

This commit forces the creation of a new resource, which as @olblak and I
discussed in the ticket, is acceptable in this case since nothing is using this
storage account yet

Fixes INFRA-1186