### PR TITLE
[INFRA-1131] Add azure shared storage for ldap

### DIFF
--- a/plans/bean.tf
+++ b/plans/bean.tf
@@ -20,6 +20,18 @@ resource "azurerm_public_ip" "bean" {
   }
 }
 
+# Public IP used for ldap on Kubernetes cluster
+resource "azurerm_public_ip" "ldap" {
+  name                         = "${var.prefix}ldap"
+  location                     = "${var.location}"
+  resource_group_name          = "${azurerm_resource_group.bean.name}"
+  public_ip_address_allocation = "Static"
+  idle_timeout_in_minutes      = 30
+  tags {
+    environment = "${var.prefix}"
+  }
+}
+
 resource "azurerm_storage_account" "bean" {
     name                     = "${azurerm_resource_group.bean.name}"
     resource_group_name      = "${azurerm_resource_group.bean.name}"

--- a/plans/ldap.tf
+++ b/plans/ldap.tf
@@ -25,6 +25,6 @@ resource "azurerm_storage_share" "ldap" {
     name = "ldap"
     resource_group_name     = "${azurerm_resource_group.ldap.name}"
     storage_account_name    = "${azurerm_storage_account.ldap.name}"
-    quota                   = 10
+    quota                   = 100
     depends_on              = ["azurerm_resource_group.ldap","azurerm_storage_account.ldap"]
 }

--- a/plans/ldap.tf
+++ b/plans/ldap.tf
@@ -1,0 +1,30 @@
+#
+# This terraform plan defines the resources necessary to host accounts.jenkins.io files
+#
+resource "azurerm_resource_group" "ldap" {
+    name     = "${var.prefix}ldap"
+    location = "${var.location}"
+    tags {
+        env = "${var.prefix}"
+    }
+}
+
+resource "azurerm_storage_account" "ldap" {
+    name                      = "${var.prefix}ldap"
+    resource_group_name       = "${azurerm_resource_group.ldap.name}"
+    location                  = "${var.location}"
+    account_tier              = "Standard"
+    account_replication_type  = "GRS"
+    depends_on                = ["azurerm_resource_group.ldap"]
+    tags {
+        env = "${var.prefix}"
+    }
+}
+
+resource "azurerm_storage_share" "ldap" {
+    name = "ldap"
+    resource_group_name     = "${azurerm_resource_group.ldap.name}"
+    storage_account_name    = "${azurerm_storage_account.ldap.name}"
+    quota                   = 10
+    depends_on              = ["azurerm_resource_group.ldap","azurerm_storage_account.ldap"]
+}


### PR DESCRIPTION
After reevaluation, this storage will only be used to store ldap backups