### PR TITLE
[Infra-1467] Fix Azure

### DIFF
--- a/plans/ci.tf
+++ b/plans/ci.tf
@@ -30,8 +30,8 @@ resource "azurerm_storage_container" "ci_container" {
     container_access_type = "private"
 }
 
-resource "azurerm_public_ip" "ci_trusted_agent_1" {
-    name                         = "trusted-agent-1"
+resource "azurerm_public_ip" "ci_trusted_agent_2" {
+    name                         = "trusted-agent-2"
     location                     = "${azurerm_resource_group.ci.location}"
     resource_group_name          = "${azurerm_resource_group.ci.name}"
     public_ip_address_allocation = "dynamic"
@@ -41,24 +41,25 @@ resource "azurerm_public_ip" "ci_trusted_agent_1" {
     }
 }
 
-resource "azurerm_network_interface" "ci_trusted_agent_1_nic" {
-    name                = "trusted-agent-1-nic"
+resource "azurerm_network_interface" "ci_trusted_agent_2_nic" {
+    name                = "trusted-agent-2-nic"
     location            = "${var.location}"
     resource_group_name = "${azurerm_resource_group.ci.name}"
 
     ip_configuration {
         name                          = "testconfiguration1"
-        subnet_id                     = "${azurerm_virtual_network.public_prod.subnet.public_dmz.id}"
+        subnet_id                     = "${azurerm_subnet.public_dmz.id}"
         private_ip_address_allocation = "dynamic"
-        public_ip_address_id          = "${azurerm_public_ip.ci_trusted_agent_1.id}"
+        public_ip_address_id          = "${azurerm_public_ip.ci_trusted_agent_2.id}"
     }
+    depends_on = ["azurerm_subnet.public_dmz" ]
 }
 
 resource "azurerm_virtual_machine" "ci_trusted_agent_1" {
     name                  = "trusted-agent-1"
     location              = "${var.location}"
     resource_group_name   = "${azurerm_resource_group.ci.name}"
-    network_interface_ids = ["${azurerm_network_interface.ci_trusted_agent_1_nic.id}"]
+    network_interface_ids = ["${azurerm_network_interface.ci_trusted_agent_2_nic.id}"]
     vm_size               = "Standard_DS4_v2"
 
     delete_os_disk_on_termination = true

--- a/plans/provider.tf
+++ b/plans/provider.tf
@@ -2,7 +2,7 @@
 # https://releases.hashicorp.com/terraform-provider-azurerm/
 
 provider "azurerm" {
-    version         = "0.3.2"
+    version         = "1.0.1"
     subscription_id = "${var.subscription_id}"
     client_id       = "${var.client_id}"
     client_secret   = "${var.client_secret}"

--- a/plans/reports.tf
+++ b/plans/reports.tf
@@ -17,9 +17,13 @@ resource "azurerm_storage_account" "reports" {
     account_tier             = "Standard"
     account_replication_type = "GRS"
 
-    custom_domain {
-        name = "${var.prefix == "prod" ? "reports.jenkins.io" : ""}"
-    }
+
+    # Setup custom domain to "" in non production environment, lead azure to become crazy
+    # The storage account stay stuck in 'creating' mode
+    # https://git.io/vNuG2
+    # custom_domain {
+    #     name = "${var.prefix == "prod" ? "reports.jenkins.io" : ""}"
+    # }
 }
 
 resource "azurerm_storage_container" "reports" {

--- a/plans/vnets.tf
+++ b/plans/vnets.tf
@@ -42,38 +42,55 @@ resource "azurerm_resource_group" "development" {
 
 ## VIRTUAL NETWORKS
 ################################################################################
+# The "dmz-tier" subnet is intended for resources which need to be
+# provisioned in the Public Production network but don't need to be
+# accessible from the public internet. Such as dynamically provisioned VMs for
+# Jenkins masters, or other untrusted workloads which should be in the Public
+# Production VNet
+resource "azurerm_subnet" "public_dmz"{
+  name                      = "dmz-tier"
+  resource_group_name       = "${azurerm_resource_group.public_prod.name}"
+  virtual_network_name      = "${var.prefix}-jenkins-public-prod"
+  address_prefix            = "10.0.99.0/24"
+  network_security_group_id = "${azurerm_network_security_group.public_dmz_tier.id}"
+}
+
+# The "data-tier" subnet is for data services which we might choose to run
+# ourselves that shouldn't have public IP addresses but accessible from within
+# the Public Production network
+resource "azurerm_subnet" "public_data"{
+  name                      = "data-tier"
+  resource_group_name       = "${azurerm_resource_group.public_prod.name}"
+  virtual_network_name      = "${var.prefix}-jenkins-public-prod"
+  address_prefix            = "10.0.2.0/24"
+  network_security_group_id = "${azurerm_network_security_group.public_data_tier.id}"
+}
+
+# "app-tier" hosts should expect to be accessible from the public internet
+resource "azurerm_subnet" "public_app"{
+  name                      = "app-tier"
+  resource_group_name       = "${azurerm_resource_group.public_prod.name}"
+  virtual_network_name      = "${var.prefix}-jenkins-public-prod"
+  address_prefix            = "10.0.1.0/24"
+  network_security_group_id = "${azurerm_network_security_group.public_app_tier.id}"
+}
+
+# As we can't retrieve a subnet id if declared in a virtual network resource (https://git.io/vNa4F), we split them into separated subnet resources.
+# And because one of subnet (defined in the virtual network resouce'public_prod') was already referenced from trusted_ci_agent_1, we must follow this order in order to unblock the situation.
+# 
+# 1 Create subnet resources
+# 2 Recreate ci_trusted_agent network interface with a reference to the new subnet resource
+# 3 Remove subnet definition from azurerm_virtual_network resource.
+# Once applied in
+
+# This resource is volontary put after all public subnet, 
+
 resource "azurerm_virtual_network" "public_prod" {
   name                = "${var.prefix}-jenkins-public-prod"
   resource_group_name = "${azurerm_resource_group.public_prod.name}"
   address_space       = ["10.0.0.0/16"]
   location            = "${var.location}"
-
-  # "app-tier" hosts should expect to be accessible from the public internet
-  subnet {
-    name           = "app-tier"
-    address_prefix = "10.0.1.0/24"
-    security_group = "${azurerm_network_security_group.public_app_tier.id}"
-  }
-
-  # The "data-tier" subnet is for data services which we might choose to run
-  # ourselves that shouldn't have public IP addresses but accessible from within
-  # the Public Production network
-  subnet {
-    name           = "data-tier"
-    address_prefix = "10.0.2.0/24"
-    security_group = "${azurerm_network_security_group.public_data_tier.id}"
-  }
-
-  # The "dmz-tier" subnet is intended for resources which need to be
-  # provisioned in the Public Production network but don't need to be
-  # accessible from the public internet. Such as dynamically provisioned VMs for
-  # Jenkins masters, or other untrusted workloads which should be in the Public
-  # Production VNet
-  subnet {
-    name           = "dmz-tier"
-    address_prefix = "10.0.99.0/24"
-    security_group = "${azurerm_network_security_group.public_dmz_tier.id}"
-  }
+  depends_on          = ["azurerm_network_interface.ci_trusted_agent_2_nic"]
 }
 
 

--- a/scripts/terraform
+++ b/scripts/terraform
@@ -3,7 +3,7 @@
 # This script is meant to be added to the PATH so the latest terraform
 # container is always in use
 
-CONTAINER_NAME=hashicorp/terraform:0.11.0
+CONTAINER_NAME=hashicorp/terraform:0.11.2
 
 set -x
 


### PR DESCRIPTION
* Remove custom_domain configuration for reports
* Redefine subnet definition for virtual network public_prod

As we can't retrieve a subnet id if declared in a virtual network resource (https://git.io/vNa4F), we split them into separated subnet resources.
And because one of subnet (defined in the virtual network resouce'public_prod') was already referenced from trusted_ci_agent_1, we must follow this order in order to unblock the situation.
 
1. Create subnet resources
2. Recreate ci_trusted_agent network interface with a reference to the new subnet resource
3. Remove subnet definition from azurerm_virtual_network resource.

Once the state is modified in production, we can redefined the order of resource definition
1. Create virtua_network resource 'public_prod'
2. Create subnet 'data-tier, app-tier, dmz-tier'
3. Create Network Interface trusted_agent_nic_2 
