### PR TITLE
Properly enable storage encryption for tfstate

### DIFF
--- a/plans/remote-state.tf
+++ b/plans/remote-state.tf
@@ -14,6 +14,7 @@ resource "azurerm_storage_account" "tfstate" {
     location                 = "${var.location}"
     account_tier             = "Standard"
     account_replication_type = "GRS"
+    enable_blob_encryption   = true
 }
 
 resource "azurerm_storage_container" "tfstate" {


### PR DESCRIPTION
This is enabled by default for new storage accounts, which led to failures when
running terraform locally.

Splitting separately from my other work.