### PR TITLE
Set custom_domain for reports.jenkins.io only in production

### DIFF
--- a/plans/reports.tf
+++ b/plans/reports.tf
@@ -17,13 +17,9 @@ resource "azurerm_storage_account" "reports" {
     account_tier             = "Standard"
     account_replication_type = "GRS"
 
-
-    # Setup custom domain to "" in non production environment, lead azure to become crazy
-    # The storage account stay stuck in 'creating' mode
-    # https://git.io/vNuG2
-    # custom_domain {
-    #     name = "${var.prefix == "prod" ? "reports.jenkins.io" : ""}"
-    # }
+    custom_domain {
+        name = "${var.prefix == "prod" ? "reports.jenkins.io" : ""}"
+    }
 }
 
 resource "azurerm_storage_container" "reports" {


### PR DESCRIPTION
This doesn't seem to be an issue anymore