### PR TITLE
Adds a dynamic lock to prevent multiple plans/applies at the same time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,96 +39,99 @@ else {
     tfPrefix = 'infraci'
 }
 
-try {
-    stage('Prepare') {
-        /* When planning and applying changes for a pull request, the Pipeline
-         * should first use the master branch which will create a remote state
-         * that can be continued from later, more accurately simulating an
-         * execution of terraform plans on an existing production
-         * infrastructure
-         */
-        if (env.CHANGE_ID) {
-            node('docker') {
-                deleteDir()
-                git 'https://github.com/jenkins-infra/azure.git'
-                /* Create an empty terraform variables file so that everything can
-                 * be overridden in the environment
-                 */
-                sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
+// dynamic lock to prevent multiple PR/branches trying to plan/apply things at the same time to the same environment
+lock("azure_${tfPrefix}") {
 
-                tfsh {
-                    sh 'make deploy'
-                }
-            }
-        }
-    }
+  try {
+      stage('Prepare') {
+          /* When planning and applying changes for a pull request, the Pipeline
+           * should first use the master branch which will create a remote state
+           * that can be continued from later, more accurately simulating an
+           * execution of terraform plans on an existing production
+           * infrastructure
+           */
+          if (env.CHANGE_ID) {
+              node('docker') {
+                  deleteDir()
+                  git 'https://github.com/jenkins-infra/azure.git'
+                  /* Create an empty terraform variables file so that everything can
+                   * be overridden in the environment
+                   */
+                  sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
 
-    stage('Plan') {
-        node('docker') {
-            deleteDir()
-            checkout scm
-            sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
+                  tfsh {
+                      sh 'make deploy'
+                  }
+              }
+          }
+      }
 
-            tfsh {
-                sh 'make terraform'
-            }
-        }
-    }
+      stage('Plan') {
+          node('docker') {
+              deleteDir()
+              checkout scm
+              sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
 
-    stage('Review') {
-        /* Inside of a pull request or if executing a Multibranch Pipeline it
-         * is acceptable to proceed without any review of the planned
-         * infrastructure. Inside our trusted.ci infrastructure the production
-         * Pipeline will be using a non-Multibranch Pipeline
-         */
-        if (infra.isTrusted()) {
-            timeout(30) {
-                input message: "Apply the planned updates to ${tfPrefix}?", ok: 'Apply'
-            }
-        }
-    }
+              tfsh {
+                  sh 'make terraform'
+              }
+          }
+      }
 
-    stage('Apply') {
-        node('docker') {
-            deleteDir()
-            checkout scm
-            sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
-            tfsh {
-                sh 'make deploy'
-            }
-        }
-    }
+      stage('Review') {
+          /* Inside of a pull request or if executing a Multibranch Pipeline it
+           * is acceptable to proceed without any review of the planned
+           * infrastructure. Inside our trusted.ci infrastructure the production
+           * Pipeline will be using a non-Multibranch Pipeline
+           */
+          if (infra.isTrusted()) {
+              timeout(30) {
+                  input message: "Apply the planned updates to ${tfPrefix}?", ok: 'Apply'
+              }
+          }
+      }
+
+      stage('Apply') {
+          node('docker') {
+              deleteDir()
+              checkout scm
+              sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
+              tfsh {
+                  sh 'make deploy'
+              }
+          }
+      }
+  }
+  finally {
+      /* If Pipeline is executing with a pull request, the infrastructure should
+       * be destroyed at the end
+       */
+      if (env.CHANGE_ID) {
+          stage('Destroy') {
+              node('docker') {
+                  deleteDir()
+                  checkout scm
+                  sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
+
+                  tfsh {
+                      /* `make init` ensures we have synced state from the remote
+                       * state before doing anything
+                       */
+                      sh 'make init'
+                      sh 'make refresh'
+                      /*
+                       * Remove backend configuration in order to use the default local backend
+                       * instead of azure
+                       */
+                      sh "sed -i 's/azurerm/local/g' backend.tf plans/backend.tf"
+                      sh "./scripts/terraform init -force-copy"
+                      sh "./scripts/terraform destroy -force -var-file=${tfVarFile} plans"
+                  }
+              }
+          }
+      }
+  }
 }
-finally {
-    /* If Pipeline is executing with a pull request, the infrastructure should
-     * be destroyed at the end
-     */
-    if (env.CHANGE_ID) {
-        stage('Destroy') {
-            node('docker') {
-                deleteDir()
-                checkout scm
-                sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
-
-                tfsh {
-                    /* `make init` ensures we have synced state from the remote
-                     * state before doing anything
-                     */
-                    sh 'make init'
-                    sh 'make refresh'
-                    /*
-                     * Remove backend configuration in order to use the default local backend
-                     * instead of azure
-                     */
-                    sh "sed -i 's/azurerm/local/g' backend.tf plans/backend.tf"
-                    sh "./scripts/terraform init -force-copy"
-                    sh "./scripts/terraform destroy -force -var-file=${tfVarFile} plans"
-                }
-            }
-        }
-    }
-}
-
 
 /**
  * tfsh is a simple function which will wrap whatever block is passed in with


### PR DESCRIPTION
To prevent multiple infrastructure changes at the same time on the
same environment, this change adds a lock on Jenkins' side.
All builds targeting the same environment/resource type will be applied
in sequential order.

NOTE: This change *requires* Lockable Resources Plugin to be installed.

cc @rtyler @olblak 