### PR TITLE
Add dns: gateway.evergreen

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -38,6 +38,7 @@ locals {
     # Azure
     ldap = "52.232.180.203"
     cn = "159.138.4.250" # Chinese jenkins.io hosted Huawei China
+    gateway.evergreen = "137.116.80.151"
   }
 
   jenkinsio_aaaa_records = {


### PR DESCRIPTION
The evergreen ssh gateway IP will more than probably change over time, so I suggest to define a dns record for it. 