### PR TITLE
[INFRA-1955] Define an openvpn virtual machine and its dns record

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -175,3 +175,11 @@ resource "azurerm_dns_mx_record" "spamtrap_jenkinsio_mx_entries" {
     exchange   = "mxb.mailgun.org"
   }
 }
+
+resource "azurerm_dns_a_record" "vpn" {
+  name                = "${azurerm_public_ip.vpn.name}"
+  zone_name           = "${azurerm_dns_zone.jenkinsio.name}"
+  resource_group_name = "${azurerm_resource_group.dns_jenkinsio.name}"
+  ttl                 = 3600
+  records             = ["${azurerm_public_ip.vpn.ip_address}"]
+}

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -177,7 +177,7 @@ resource "azurerm_dns_mx_record" "spamtrap_jenkinsio_mx_entries" {
 }
 
 resource "azurerm_dns_a_record" "vpn" {
-  name                = "${azurerm_public_ip.vpn.name}"
+  name                = "vpn"
   zone_name           = "${azurerm_dns_zone.jenkinsio.name}"
   resource_group_name = "${azurerm_resource_group.dns_jenkinsio.name}"
   ttl                 = 3600

--- a/plans/machine_vpn.tf
+++ b/plans/machine_vpn.tf
@@ -52,7 +52,7 @@ resource "azurerm_virtual_machine" "vpn" {
   location              = "${azurerm_resource_group.vpn.location}"
   resource_group_name   = "${azurerm_resource_group.vpn.name}"
   network_interface_ids = ["${azurerm_network_interface.public_app_vpn.id}"]
-  vm_size               = "Standard_DS2_v3"
+  vm_size               = "Standard_D2s_v3"
 
   delete_os_disk_on_termination = false
   delete_data_disks_on_termination = false

--- a/plans/machine_vpn.tf
+++ b/plans/machine_vpn.tf
@@ -20,14 +20,14 @@ resource "azurerm_public_ip" "vpn" {
 
 # Interface within a network with ports 80,443 opened to the internet
 resource "azurerm_network_interface" "public_app_vpn" {
-  name                = "${var.prefix}-public-app-nic"
+  name                = "${var.prefix}-public-dmz-nic"
   location            = "${azurerm_resource_group.vpn.location}"
   resource_group_name = "${azurerm_resource_group.vpn.name}"
   enable_ip_forwarding          = true
 
   ip_configuration {
     name                          = "${var.prefix}-public-app"
-    subnet_id                     = "${azurerm_subnet.public_app.id}"
+    subnet_id                     = "${azurerm_subnet.public_dmz.id}"
     private_ip_address_allocation = "dynamic" # nope
     primary                       = true
     public_ip_address_id          = "${azurerm_public_ip.vpn.id}"

--- a/plans/machine_vpn.tf
+++ b/plans/machine_vpn.tf
@@ -1,0 +1,91 @@
+# This terraform plan describe the virtual machine needed to run an openvpn service
+
+resource "azurerm_resource_group" "vpn" {
+  name     = "${var.prefix}vpn"
+  location = "${var.location}"
+  tags {
+    env = "${var.prefix}"
+  }
+}
+
+resource "azurerm_public_ip" "vpn" {
+  name                         = "${var.prefix}vpn"
+  location                     = "${var.location}"
+  resource_group_name          = "${azurerm_resource_group.vpn.name}"
+  public_ip_address_allocation = "static"
+  tags {
+    environment = "${var.prefix}"
+  }
+}
+
+# Interface within a network with ports 80,443 opened to the internet
+resource "azurerm_network_interface" "public_app_vpn" {
+  name                = "${var.prefix}-public-app-nic"
+  location            = "${azurerm_resource_group.vpn.location}"
+  resource_group_name = "${azurerm_resource_group.vpn.name}"
+  enable_ip_forwarding          = true
+
+  ip_configuration {
+    name                          = "${var.prefix}-public-app"
+    subnet_id                     = "${azurerm_subnet.public_app.id}"
+    private_ip_address_allocation = "dynamic" # nope
+    primary                       = true
+    public_ip_address_id          = "${azurerm_public_ip.vpn.id}"
+  }
+}
+
+# Interface within a network without access from internet
+resource "azurerm_network_interface" "public_data_vpn" {
+  name                = "${var.prefix}-public-data-nic"
+  location            = "${azurerm_resource_group.vpn.location}"
+  resource_group_name = "${azurerm_resource_group.vpn.name}"
+  enable_ip_forwarding          = true
+  ip_configuration {
+    name                          = "${var.prefix}-public-data"
+    subnet_id                     = "${azurerm_subnet.public_data.id}"
+    private_ip_address_allocation = "dynamic" # nope
+  }
+}
+
+resource "azurerm_virtual_machine" "vpn" {
+  name                  = "${var.prefix}-vpn"
+  location              = "${azurerm_resource_group.vpn.location}"
+  resource_group_name   = "${azurerm_resource_group.vpn.name}"
+  network_interface_ids = ["${azurerm_network_interface.public_app_vpn.id}"]
+  vm_size               = "Standard_DS2_v3"
+
+  delete_os_disk_on_termination = false
+  delete_data_disks_on_termination = false
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "${var.prefix}vpn"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+    disk_size_gb      = "50"
+    os_type           = "Linux"
+  }
+
+  os_profile {
+    computer_name  = "vpn.jenkins.io"
+    admin_username = "azureadmin"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+    ssh_keys {
+      key_data = "${file("${var.ssh_pubkey_path}")}"
+      path = "/home/butler/.ssh/authorized_keys"
+    }
+  }
+  tags {
+    env = "${var.prefix}"
+  }
+}

--- a/plans/machine_vpn.tf
+++ b/plans/machine_vpn.tf
@@ -28,7 +28,7 @@ resource "azurerm_network_interface" "vpn_public_dmz" {
   ip_configuration {
     name                          = "${var.prefix}-public-app"
     subnet_id                     = "${azurerm_subnet.public_dmz.id}"
-    private_ip_address_allocation = "dynamic" # nope
+    private_ip_address_allocation = "dynamic"
     primary                       = true
     public_ip_address_id          = "${azurerm_public_ip.vpn.id}"
   }
@@ -43,7 +43,7 @@ resource "azurerm_network_interface" "vpn_public_data" {
   ip_configuration {
     name                          = "${var.prefix}-public-data"
     subnet_id                     = "${azurerm_subnet.public_data.id}"
-    private_ip_address_allocation = "dynamic" # nope
+    private_ip_address_allocation = "dynamic"
   }
 }
 

--- a/plans/machine_vpn.tf
+++ b/plans/machine_vpn.tf
@@ -58,8 +58,8 @@ resource "azurerm_virtual_machine" "vpn" {
   primary_network_interface_id = "${azurerm_network_interface.vpn_public_dmz.id}"
   vm_size               = "Standard_D2s_v3"
 
-  delete_os_disk_on_termination = false
-  delete_data_disks_on_termination = false
+  delete_os_disk_on_termination = true
+  delete_data_disks_on_termination = true
 
   storage_image_reference {
     publisher = "Canonical"
@@ -80,6 +80,7 @@ resource "azurerm_virtual_machine" "vpn" {
   os_profile {
     computer_name  = "vpn.jenkins.io"
     admin_username = "azureadmin"
+    custom_data    = "${ var.prefix == "prod"? file("scripts/init-puppet.sh"): "#cloud-config" }"
   }
 
   os_profile_linux_config {

--- a/plans/machine_vpn.tf
+++ b/plans/machine_vpn.tf
@@ -18,9 +18,9 @@ resource "azurerm_public_ip" "vpn" {
   }
 }
 
-# Interface within a network with ports 80,443 opened to the internet
-resource "azurerm_network_interface" "public_app_vpn" {
-  name                = "${var.prefix}-public-dmz-nic"
+# Interface within a network with ports 443 opened to the internet
+resource "azurerm_network_interface" "vpn_public_dmz" {
+  name                = "${var.prefix}-vpn-public-dmz"
   location            = "${azurerm_resource_group.vpn.location}"
   resource_group_name = "${azurerm_resource_group.vpn.name}"
   enable_ip_forwarding          = true
@@ -35,8 +35,8 @@ resource "azurerm_network_interface" "public_app_vpn" {
 }
 
 # Interface within a network without access from internet
-resource "azurerm_network_interface" "public_data_vpn" {
-  name                = "${var.prefix}-public-data-nic"
+resource "azurerm_network_interface" "vpn_public_data" {
+  name                = "${var.prefix}-vpn-public-data"
   location            = "${azurerm_resource_group.vpn.location}"
   resource_group_name = "${azurerm_resource_group.vpn.name}"
   enable_ip_forwarding          = true
@@ -51,7 +51,11 @@ resource "azurerm_virtual_machine" "vpn" {
   name                  = "${var.prefix}-vpn"
   location              = "${azurerm_resource_group.vpn.location}"
   resource_group_name   = "${azurerm_resource_group.vpn.name}"
-  network_interface_ids = ["${azurerm_network_interface.public_app_vpn.id}"]
+  network_interface_ids = [
+    "${azurerm_network_interface.vpn_public_dmz.id}",
+    "${azurerm_network_interface.vpn_public_data.id}"
+  ]
+  primary_network_interface_id = "${azurerm_network_interface.vpn_public_dmz.id}"
   vm_size               = "Standard_D2s_v3"
 
   delete_os_disk_on_termination = false

--- a/plans/machine_vpn.tf
+++ b/plans/machine_vpn.tf
@@ -82,7 +82,7 @@ resource "azurerm_virtual_machine" "vpn" {
     disable_password_authentication = true
     ssh_keys {
       key_data = "${file("${var.ssh_pubkey_path}")}"
-      path = "/home/butler/.ssh/authorized_keys"
+      path = "/home/azureadmin/.ssh/authorized_keys"
     }
   }
   tags {

--- a/scripts/init-puppet.sh
+++ b/scripts/init-puppet.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -k https://puppet.jenkins.io:8140/packages/current/install.bash | sudo bash
+curl -k https://puppet.jenkins.io:8140/packages/current/install.bash

--- a/scripts/init-puppet.sh
+++ b/scripts/init-puppet.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -k https://puppet.jenkins.io:8140/packages/current/install.bash | sudo bash


### PR DESCRIPTION
This PR describe a vpn machine seated on two subnetworks, one open to  the internet "public_app", and a second closed to the internet.
It also introduce a new dns record "vpn.jenkins.io" in order to reach its public endpoint with a more convenient name.

The purpose of this machine is to deploy an vpn in order to reach hidden service.
This machine is designed to be used with [jenkins-infra/openvpn](https://github.com/jenkins-infra/openvpn) and managed by [jenkins-infra/jenkins-infra](https://github.com/jenkins-infra/jenkins-infra/pull/1204)