### PR TITLE
Azure network cleanup

### DIFF
--- a/plans/vnets-nsg.tf
+++ b/plans/vnets-nsg.tf
@@ -11,18 +11,20 @@ resource "azurerm_network_security_group" "development_dmz" {
   name                = "dev-network-dmz"
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.development.name}"
+}
 
-  security_rule {
-    name                       = "allow-all-inbound"
-    priority                   = 100
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "development-dmz-deny-internet-inbound" {
+  name                        = "deny-all-internet-inbound"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "INTERNET"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.development.name}"
+  network_security_group_name = "${azurerm_network_security_group.development_dmz.name}"
 }
 
 # Allow HTTP(s) by default to anything in the Public Production application
@@ -31,67 +33,94 @@ resource "azurerm_network_security_group" "public_app_tier" {
   name                = "public-network-apptier"
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.public_prod.name}"
+}
 
-  security_rule {
-    name                       = "allow-http-inbound"
-    priority                   = 100
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "tcp"
-    source_port_range          = "80"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "public-app-tier-allow-http-inbound" {
+  name                        = "allow-http-inbound"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "80"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_app_tier.name}"
+}
 
-  security_rule {
-    name                       = "allow-https-inbound"
-    priority                   = 101
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "tcp"
-    source_port_range          = "443"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
 
-  # Always allow SSH from machines in our Private Production network
-  security_rule {
-    name                       = "allow-private-ssh"
-    priority                   = 4000
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "tcp"
-    source_port_range          = "22"
-    destination_port_range     = "*"
-    source_address_prefix      = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "public-app-tier-allow-https-inbound" {
+  name                        = "allow-https-inbound"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "443"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_app_tier.name}"
+}
 
-  security_rule {
-    name                       = "allow-puppet-outbound"
-    priority                   = 2100
-    direction                  = "outbound"
-    access                     = "allow"
-    protocol                   = "tcp"
-    source_port_range          = "${var.puppet_master_port}"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
-  }
+resource "azurerm_network_security_rule" "public-app-tier-allow-ldaps-inbound" {
+  name                        = "allow-ldaps-inbound"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "636"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_app_tier.name}"
+}
 
-  security_rule {
-    name                       = "deny-all-else"
-    priority                   = 4096
-    direction                  = "inbound"
-    access                     = "deny"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+# Always allow SSH from machines in our Private Production network
+resource "azurerm_network_security_rule" "public-app-tier-allow-private-ssh" {
+  name                        = "allow-private-ssh"
+  priority                    = 4000
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
+  destination_address_prefix  = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_app_tier.name}"
+}
+
+resource "azurerm_network_security_rule" "public-app-tier-deny-all-else" {
+  name                        = "deny-all-else"
+  priority                    = 4096
+  direction                   = "inbound"
+  access                      = "deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_app_tier.name}"
+}
+
+# This rule is useless since don't block outbound connections by default.
+# Should we? 
+resource "azurerm_network_security_rule" "public-app-tier-allow-puppet-outbound" {
+  name                        = "allow-puppet-outbound"
+  priority                    = 2100
+  direction                   = "outbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "${var.puppet_master_port}"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_app_tier.name}"
 }
 
 # NOTE: Currently empty to enable us to add security rules to this NSG at a
@@ -100,44 +129,50 @@ resource "azurerm_network_security_group" "public_data_tier" {
   name                = "public-network-datatier"
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.public_prod.name}"
-
-  # Always allow SSH from machines in our Private Production network
-  security_rule {
-    name                       = "allow-private-ssh"
-    priority                   = 4000
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "tcp"
-    source_port_range          = "22"
-    destination_port_range     = "*"
-    source_address_prefix      = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
-    name                       = "allow-puppet-outbound"
-    priority                   = 2100
-    direction                  = "outbound"
-    access                     = "allow"
-    protocol                   = "tcp"
-    source_port_range          = "${var.puppet_master_port}"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
-  }
-
-  security_rule {
-    name                       = "deny-all-else"
-    priority                   = 4096
-    direction                  = "inbound"
-    access                     = "deny"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
 }
+
+resource "azurerm_network_security_rule" "public-data-tier-allow-private-ssh" {
+  name                        = "allow-private-ssh"
+  priority                    = 4000
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
+  destination_address_prefix  = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_data_tier.name}"
+}
+
+resource "azurerm_network_security_rule" "public-data-tier-deny-all-else" {
+  name                        = "deny-all-else"
+  priority                    = 4096
+  direction                   = "inbound"
+  access                      = "deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_data_tier.name}"
+}
+
+resource "azurerm_network_security_rule" "public-data-tier-allow-puppet-outbound" {
+  name                        = "allow-puppet-outbound"
+  priority                    = 2100
+  direction                   = "outbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "${var.puppet_master_port}"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "${element(azurerm_virtual_network.private_prod.address_space, 0)}"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_data_tier.name}"
+}
+
 
 # NOTE: Currently empty to enable us to add security rules to this NSG at a
 # later date.
@@ -145,77 +180,135 @@ resource "azurerm_network_security_group" "public_dmz_tier" {
   name                = "public-network-dmztier"
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.public_prod.name}"
+}
 
-  # Always allow SSH
-  security_rule {
-    name                       = "allow-private-ssh"
-    priority                   = 4000
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "tcp"
-    source_port_range          = "22"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "public-dmz-tier-allow-https-inbound" {
+  name                        = "allow-https-inbound"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "443"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_dmz_tier.name}"
+}
 
-  security_rule {
-    name                       = "deny-all-else"
-    priority                   = 4096
-    direction                  = "inbound"
-    access                     = "deny"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
+resource "azurerm_network_security_rule" "public-dmz-tier-allow-private-ssh" {
+  name                        = "allow-private-ssh"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_dmz_tier.name}"
+}
+
+resource "azurerm_network_security_rule" "public-dmz-tier-deny-all-else" {
+  name                        = "deny-all-else"
+  priority                    = 4096
+  direction                   = "inbound"
+  access                      = "deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.public_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.public_dmz_tier.name}"
 }
 
 resource "azurerm_network_security_group" "private_mgmt_tier" {
   name                = "private-network-mgmt-tier"
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.private_prod.name}"
-
-  security_rule {
-    name                       = "deny-all-internet"
-    priority                   = 100
-    direction                  = "inbound"
-    access                     = "deny"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "INTERNET"
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
-    name                       = "allow-https-inbound"
-    priority                   = 200
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "TCP"
-    source_port_range          = "443"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
-    name                       = "allow-puppet-inbound"
-    priority                   = 300
-    direction                  = "inbound"
-    access                     = "allow"
-    protocol                   = "TCP"
-    source_port_range          = "${var.puppet_master_port}"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
 }
+
+resource "azurerm_network_security_rule" "private-mgmt-tier-deny-all-internet" {
+  name                        = "deny-all-internet"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "INTERNET"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.private_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.private_mgmt_tier.name}"
+}
+
+resource "azurerm_network_security_rule" "private-mgmt-tier-allow-https-inbound" {
+  name                        = "allow-https-inbound"
+  priority                    = 200
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "TCP"
+  source_port_range           = "443"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.private_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.private_mgmt_tier.name}"
+}
+
+resource "azurerm_network_security_rule" "private-mgmt-tier-allow-puppet-inbound" {
+  name                        = "allow-puppet-inbound"
+  priority                    = 300
+  direction                   = "inbound"
+  access                      = "allow"
+  protocol                    = "TCP"
+  source_port_range           = "${var.puppet_master_port}"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.private_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.private_mgmt_tier.name}"
+}
+
+resource "azurerm_network_security_group" "private_data_tier" {
+  name                = "private-network-data-tier"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.private_prod.name}"
+}
+
+resource "azurerm_network_security_rule" "private-data-tier-deny-all-internet" {
+  name                        = "deny-all-internet"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "INTERNET"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.private_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.private_data_tier.name}"
+}
+
 resource "azurerm_network_security_group" "private_dmz_tier" {
   name                = "private-network-dmz-tier"
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.private_prod.name}"
+}
+
+resource "azurerm_network_security_rule" "private-dmz-tier-deny-all-internet" {
+  name                        = "deny-all-internet"
+  priority                    = 100
+  direction                   = "inbound"
+  access                      = "deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "INTERNET"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${azurerm_resource_group.private_prod.name}"
+  network_security_group_name = "${azurerm_network_security_group.private_dmz_tier.name}"
 }
 ################################################################################

--- a/plans/vnets-nsg.tf
+++ b/plans/vnets-nsg.tf
@@ -25,7 +25,7 @@ resource "azurerm_network_security_group" "development_dmz" {
 
 resource "azurerm_network_security_rule" "development-dmz-allow-ssh-inbound" {
   name                        = "allow-ssh-inbound"
-  priority                    = 100
+  priority                    = 101
   direction                   = "inbound"
   access                      = "allow"
   protocol                    = "*"

--- a/plans/vnets-nsg.tf
+++ b/plans/vnets-nsg.tf
@@ -61,7 +61,7 @@ resource "azurerm_network_security_rule" "public-app-tier-allow-http-inbound" {
 
 resource "azurerm_network_security_rule" "public-app-tier-allow-https-inbound" {
   name                        = "allow-https-inbound"
-  priority                    = 100
+  priority                    = 101
   direction                   = "inbound"
   access                      = "allow"
   protocol                    = "tcp"
@@ -75,7 +75,7 @@ resource "azurerm_network_security_rule" "public-app-tier-allow-https-inbound" {
 
 resource "azurerm_network_security_rule" "public-app-tier-allow-ldaps-inbound" {
   name                        = "allow-ldaps-inbound"
-  priority                    = 100
+  priority                    = 102
   direction                   = "inbound"
   access                      = "allow"
   protocol                    = "tcp"
@@ -148,7 +148,7 @@ resource "azurerm_network_security_rule" "public-dmz-tier-allow-https-inbound" {
 
 resource "azurerm_network_security_rule" "public-dmz-tier-allow-ssh-inbound" {
   name                        = "allow-ssh-inbound"
-  priority                    = 100
+  priority                    = 101
   direction                   = "inbound"
   access                      = "allow"
   protocol                    = "tcp"

--- a/plans/vnets.tf
+++ b/plans/vnets.tf
@@ -156,7 +156,7 @@ resource "azurerm_subnet" "development_dmz_tier" {
   name                      = "dmz-tier"
   resource_group_name       = "${azurerm_resource_group.development.name}"
   virtual_network_name      = "${azurerm_virtual_network.development.name}"
-  address_prefix            = "10.1.99.0/24"
+  address_prefix            = "10.2.99.0/24"
 }
 
 resource "azurerm_subnet_network_security_group_association" "development_dmz_tier" {

--- a/plans/vnets.tf
+++ b/plans/vnets.tf
@@ -107,7 +107,7 @@ resource "azurerm_virtual_network" "private_prod" {
 }
 
 resource "azurerm_subnet" "private_mgmt_tier" {
-  name                      = "private-mgmt-tier"
+  name                      = "management-tier"
   resource_group_name       = "${azurerm_resource_group.private_prod.name}"
   virtual_network_name      = "${azurerm_virtual_network.private_prod.name}"
   address_prefix            = "10.1.1.0/24"
@@ -120,7 +120,7 @@ resource "azurerm_subnet_network_security_group_association" "private_mgmt_tier"
 
 
 resource "azurerm_subnet" "private_data_tier" {
-  name                      = "private-data-tier"
+  name                      = "data-tier"
   resource_group_name       = "${azurerm_resource_group.private_prod.name}"
   virtual_network_name      = "${azurerm_virtual_network.private_prod.name}"
   address_prefix            = "10.1.2.0/24"
@@ -153,7 +153,7 @@ resource "azurerm_virtual_network" "development" {
 # Pretty much everything in the development VNet should be considered
 # untrusted and almost like the wild west
 resource "azurerm_subnet" "development_dmz_tier" {
-  name                      = "development-dmz-tier"
+  name                      = "dmz-tier"
   resource_group_name       = "${azurerm_resource_group.development.name}"
   virtual_network_name      = "${azurerm_virtual_network.development.name}"
   address_prefix            = "10.1.99.0/24"

--- a/plans/vnets.tf
+++ b/plans/vnets.tf
@@ -157,8 +157,6 @@ resource "azurerm_subnet" "development_dmz_tier" {
   resource_group_name       = "${azurerm_resource_group.development.name}"
   virtual_network_name      = "${azurerm_virtual_network.development.name}"
   address_prefix            = "10.1.99.0/24"
-  network_security_group_id = "${azurerm_network_security_group.development_dmz.id}"
-  depends_on                = ["azurerm_virtual_network.development"]
 }
 
 resource "azurerm_subnet_network_security_group_association" "development_dmz_tier" {


### PR DESCRIPTION
This PR introduce various changes on the network groups and security rules:
* Remove deprecrated resource 
> "network_security_group_id": [DEPRECATED] Use the `azurerm_subnet_network_security_group_association` resource instead.
* Inbound security rule should open destination port instead of source port.
* development environment should block everything coming from the internet excepted port 22 for ssh
* public_dmz need ssh port open from the wild in order to be the ssh entry point for all the machines.
* clean up redundant or useless rules 
     * deny-all-internet is redundant with default DenyAllInbound && AllowVNetInBound
     * allow-private-ssh is useless with AllowVNetInBound

