### PR TITLE
Update jenkins release environment dns record

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,17 @@ lock("azure_${tfPrefix}") {
               }
           }
       }
+      stage('Validate Format') {
+          node('docker') {
+              deleteDir()
+              checkout scm
+              sh "echo '{\"prefix\":\"${tfPrefix}\"}' > ${tfVarFile}"
+
+              tfsh {
+                  sh 'make test_fmt'
+              }
+          }
+      }
 
       stage('Plan') {
           node('docker') {

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ init: prepare generate
 		-force-copy \
 		plans
 
+test_fmt:
+	$(TERRAFORM) fmt --write=false --diff=true --check=true
+
 clean:
 	$(MAKE) -C arm_templates clean
 	rm -Rf ${TFSTATE_PREPARE_DIR}

--- a/plans/accountapp.tf
+++ b/plans/accountapp.tf
@@ -2,29 +2,31 @@
 # This terraform plan defines the resources necessary to host accounts.jenkins.io files
 #
 resource "azurerm_resource_group" "accountapp" {
-    name     = "${var.prefix}accountapp"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}accountapp"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "accountapp" {
-    name                      = "${var.prefix}accountapp"
-    resource_group_name       = "${azurerm_resource_group.accountapp.name}"
-    location                  = "${var.location}"
-    account_tier              = "Standard"
-    account_replication_type  = "GRS"
-    depends_on                = ["azurerm_resource_group.accountapp"]
-    tags {
-        env = "${var.prefix}"
-    }
+  name                     = "${var.prefix}accountapp"
+  resource_group_name      = "${azurerm_resource_group.accountapp.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.accountapp"]
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_share" "accountapp" {
-    name = "accountapp"
-    resource_group_name     = "${azurerm_resource_group.accountapp.name}"
-    storage_account_name    = "${azurerm_storage_account.accountapp.name}"
-    quota                   = 10
-    depends_on              = ["azurerm_resource_group.accountapp","azurerm_storage_account.accountapp"]
+  name                 = "accountapp"
+  resource_group_name  = "${azurerm_resource_group.accountapp.name}"
+  storage_account_name = "${azurerm_storage_account.accountapp.name}"
+  quota                = 10
+  depends_on           = ["azurerm_resource_group.accountapp", "azurerm_storage_account.accountapp"]
 }

--- a/plans/backups.tf
+++ b/plans/backups.tf
@@ -5,32 +5,32 @@
 # See: https://issues.jenkins-ci.org/browse/INFRA-1148
 
 resource "azurerm_resource_group" "backups" {
-    name     = "${var.prefix}-backups"
-    location = "${var.location}"
+  name     = "${var.prefix}-backups"
+  location = "${var.location}"
 }
 
 resource "azurerm_storage_account" "backups" {
-    name                     = "${var.prefix}jenkinsbackups"
-    resource_group_name      = "${azurerm_resource_group.backups.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
+  name                     = "${var.prefix}jenkinsbackups"
+  resource_group_name      = "${azurerm_resource_group.backups.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
 }
 
 # Private backups are those which are going to contain sensitive information or
 # user data. Most things will fit into this storage container
 resource "azurerm_storage_container" "private_backups" {
-    name                  = "privatebackups"
-    resource_group_name   = "${azurerm_resource_group.backups.name}"
-    storage_account_name  = "${azurerm_storage_account.backups.name}"
-    container_access_type = "private"
+  name                  = "privatebackups"
+  resource_group_name   = "${azurerm_resource_group.backups.name}"
+  storage_account_name  = "${azurerm_storage_account.backups.name}"
+  container_access_type = "private"
 }
 
 # Public backups are for those things which are generated data, or otherwise
 # already existing public data, such as meeting minutes, etc.
 resource "azurerm_storage_container" "public_backups" {
-    name                  = "publicbackups"
-    resource_group_name   = "${azurerm_resource_group.backups.name}"
-    storage_account_name  = "${azurerm_storage_account.backups.name}"
-    container_access_type = "container"
+  name                  = "publicbackups"
+  resource_group_name   = "${azurerm_resource_group.backups.name}"
+  storage_account_name  = "${azurerm_storage_account.backups.name}"
+  container_access_type = "container"
 }

--- a/plans/bean.tf
+++ b/plans/bean.tf
@@ -3,6 +3,7 @@
 resource "azurerm_resource_group" "bean" {
   name     = "${var.prefix}bean"
   location = "${var.location}"
+
   tags {
     env = "${var.prefix}"
   }
@@ -15,6 +16,7 @@ resource "azurerm_public_ip" "bean" {
   resource_group_name          = "${azurerm_resource_group.bean.name}"
   public_ip_address_allocation = "Static"
   idle_timeout_in_minutes      = 30
+
   tags {
     environment = "${var.prefix}"
   }
@@ -27,21 +29,23 @@ resource "azurerm_public_ip" "ldap" {
   resource_group_name          = "${azurerm_resource_group.bean.name}"
   public_ip_address_allocation = "Static"
   idle_timeout_in_minutes      = 30
+
   tags {
     environment = "${var.prefix}"
   }
 }
 
 resource "azurerm_storage_account" "bean" {
-    name                     = "${azurerm_resource_group.bean.name}"
-    resource_group_name      = "${azurerm_resource_group.bean.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    depends_on               = ["azurerm_resource_group.bean"]
-    tags {
-        env = "${var.prefix}"
-    }
+  name                     = "${azurerm_resource_group.bean.name}"
+  resource_group_name      = "${azurerm_resource_group.bean.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.bean"]
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_container_service" "bean" {

--- a/plans/ci.tf
+++ b/plans/ci.tf
@@ -2,109 +2,110 @@
 # Resources related to our CI infrastructure for ci.jenkins.io or trusted.ci
 #
 
-
 resource "azurerm_resource_group" "ci" {
-    name     = "${var.prefix}jenkinsci"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}jenkinsci"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "ci_storage" {
-    name                     = "${var.prefix}jenkinscistore"
-    resource_group_name      = "${azurerm_resource_group.ci.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "LRS"
+  name                     = "${var.prefix}jenkinscistore"
+  resource_group_name      = "${azurerm_resource_group.ci.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 
-    tags {
-        environment = "${var.prefix}"
-    }
+  tags {
+    environment = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_container" "ci_container" {
-    name                  = "vhds"
-    resource_group_name   = "${azurerm_resource_group.ci.name}"
-    storage_account_name  = "${azurerm_storage_account.ci_storage.name}"
-    container_access_type = "private"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.ci.name}"
+  storage_account_name  = "${azurerm_storage_account.ci_storage.name}"
+  container_access_type = "private"
 }
 
 resource "azurerm_public_ip" "ci_trusted_agent_2" {
-    name                         = "trusted-agent-2"
-    location                     = "${azurerm_resource_group.ci.location}"
-    resource_group_name          = "${azurerm_resource_group.ci.name}"
-    public_ip_address_allocation = "dynamic"
+  name                         = "trusted-agent-2"
+  location                     = "${azurerm_resource_group.ci.location}"
+  resource_group_name          = "${azurerm_resource_group.ci.name}"
+  public_ip_address_allocation = "dynamic"
 
-    tags {
-        environment = "${var.prefix}"
-    }
+  tags {
+    environment = "${var.prefix}"
+  }
 }
 
 resource "azurerm_network_interface" "ci_trusted_agent_2_nic" {
-    name                = "trusted-agent-2-nic"
-    location            = "${var.location}"
-    resource_group_name = "${azurerm_resource_group.ci.name}"
+  name                = "trusted-agent-2-nic"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.ci.name}"
 
-    ip_configuration {
-        name                          = "testconfiguration1"
-        subnet_id                     = "${azurerm_subnet.public_dmz.id}"
-        private_ip_address_allocation = "dynamic"
-        public_ip_address_id          = "${azurerm_public_ip.ci_trusted_agent_2.id}"
-    }
-    depends_on = ["azurerm_subnet.public_dmz" ]
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.public_dmz.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.ci_trusted_agent_2.id}"
+  }
+
+  depends_on = ["azurerm_subnet.public_dmz"]
 }
 
 resource "azurerm_virtual_machine" "ci_trusted_agent_1" {
-    name                  = "trusted-agent-1"
-    location              = "${var.location}"
-    resource_group_name   = "${azurerm_resource_group.ci.name}"
-    network_interface_ids = ["${azurerm_network_interface.ci_trusted_agent_2_nic.id}"]
-    vm_size               = "Standard_DS4_v2"
+  name                  = "trusted-agent-1"
+  location              = "${var.location}"
+  resource_group_name   = "${azurerm_resource_group.ci.name}"
+  network_interface_ids = ["${azurerm_network_interface.ci_trusted_agent_2_nic.id}"]
+  vm_size               = "Standard_DS4_v2"
 
-    delete_os_disk_on_termination = true
-    delete_data_disks_on_termination = true
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
 
-    storage_image_reference {
-        publisher = "Canonical"
-        offer     = "UbuntuServer"
-        sku       = "16.04-LTS"
-        version   = "latest"
-    }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
 
-    storage_os_disk {
-        name          = "trusted-agent-1-disk"
-        vhd_uri       = "${azurerm_storage_account.ci_storage.primary_blob_endpoint}${azurerm_storage_container.ci_container.name}/trustedagent1os.vhd"
-        caching       = "ReadWrite"
-        create_option = "FromImage"
-    }
+  storage_os_disk {
+    name          = "trusted-agent-1-disk"
+    vhd_uri       = "${azurerm_storage_account.ci_storage.primary_blob_endpoint}${azurerm_storage_container.ci_container.name}/trustedagent1os.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
 
+  os_profile {
+    computer_name  = "trusted-agent-1"
+    admin_username = "azureuser"
+    admin_password = "${random_id.prefix.hex}"
+  }
 
-    os_profile {
-        computer_name  = "trusted-agent-1"
-        admin_username = "azureuser"
-        admin_password = "${random_id.prefix.hex}"
-    }
+  os_profile_linux_config {
+    disable_password_authentication = true
 
-    os_profile_linux_config {
-        disable_password_authentication = true
-        ssh_keys = [
-            {
-                path = "/home/azureuser/.ssh/authorized_keys"
-                key_data = "${file("${var.ssh_pubkey_path}")}"
-            },
-        ]
-    }
+    ssh_keys = [
+      {
+        path     = "/home/azureuser/.ssh/authorized_keys"
+        key_data = "${file("${var.ssh_pubkey_path}")}"
+      },
+    ]
+  }
 
-    tags {
-        environment = "${var.prefix}"
-    }
+  tags {
+    environment = "${var.prefix}"
+  }
 }
 
-
 resource "random_id" "prefix" {
-    keepers {
-        prefix = "${var.prefix}"
-    }
-    byte_length = 16
+  keepers {
+    prefix = "${var.prefix}"
+  }
+
+  byte_length = 16
 }

--- a/plans/confluence.tf
+++ b/plans/confluence.tf
@@ -5,16 +5,18 @@ data "azurerm_client_config" "current" {}
 # cfr. https://www.terraform.io/docs/providers/random/index.html
 resource "random_string" "confluence_db_password" {
   length = 16
-    keepers {
-      id = "${var.confluence_db_password_id}"
-    }
+
+  keepers {
+    id = "${var.confluence_db_password_id}"
+  }
 }
 
 resource "azurerm_resource_group" "confluence" {
   name     = "${var.prefix}confluence"
   location = "${var.location}"
+
   tags {
-      env = "${var.prefix}"
+    env = "${var.prefix}"
   }
 }
 
@@ -24,25 +26,27 @@ resource "azurerm_mysql_server" "confluence" {
   resource_group_name = "${azurerm_resource_group.confluence.name}"
 
   sku {
-    name = "GP_Gen5_2"
+    name     = "GP_Gen5_2"
     capacity = 2
-    tier = "GeneralPurpose"
-    family = "Gen5"
+    tier     = "GeneralPurpose"
+    family   = "Gen5"
   }
 
   # Current Database backup use 5.51GB (2018/08/23)
   storage_profile {
-    storage_mb = 10240
+    storage_mb            = 10240
     backup_retention_days = 7
-    geo_redundant_backup = "Enabled"
+    geo_redundant_backup  = "Enabled"
   }
 
   administrator_login = "mysqladmin"
+
   # Currently terraform doesn't detect if the password was changed from a different place like portal.azure.com
   # but if any other setting is modified, terraform will re-apply the password from the terraform state
   # cfr https://github.com/terraform-providers/terraform-provider-azurerm/issues/1823
   administrator_login_password = "${random_string.confluence_db_password.result}"
-  version = "5.7"
+
+  version         = "5.7"
   ssl_enforcement = "Disabled"
 }
 

--- a/plans/dns_jenkinsci.tf
+++ b/plans/dns_jenkinsci.tf
@@ -12,83 +12,83 @@ locals {
 
     # VM at Rackspace
     celery = "162.242.234.101"
-    okra = "162.209.106.32"
+    okra   = "162.209.106.32"
 
     # cabbage has died of dysentery
     cabbage = "104.130.167.56"
-    kelp = "162.209.124.149"
+    kelp    = "162.209.124.149"
 
     # Hosts at OSUOSL
     lettuce = "140.211.9.32"
 
     # artichoke has died of dysentery
     artichoke = "140.211.9.22"
-    eggplant = "140.211.15.101"
-    edamame = "140.211.9.2"
+    eggplant  = "140.211.15.101"
+    edamame   = "140.211.9.2"
 
     # Others
     lists = "140.211.166.34"
-    ns1 = "140.211.9.2"
-    ns2 = "162.209.124.149"
-    ns3 = "162.209.106.32"
+    ns1   = "140.211.9.2"
+    ns2   = "162.209.124.149"
+    ns3   = "162.209.106.32"
   }
 
   jenkinsci_aaaa_records = {
     celery = "2001:4802:7801:103:be76:4eff:fe20:357c"
-    okra = "2001:4802:7800:2:be76:4eff:fe20:7a31"
-    kelp = "2001:4802:7801:101:be76:4eff:fe20:b252"
-    ns2 = "2001:4802:7801:101:be76:4eff:fe20:b252"
+    okra   = "2001:4802:7800:2:be76:4eff:fe20:7a31"
+    kelp   = "2001:4802:7801:101:be76:4eff:fe20:b252"
+    ns2    = "2001:4802:7801:101:be76:4eff:fe20:b252"
   }
 
   jenkinsci_cname_records = {
-    www = "jenkins-ci.org"
-    issues = "edamame.jenkins-ci.org"
-    wiki = "lettuce.jenkins-ci.org"
-    updates = "updates.jenkins.io"
-    javadoc = "javadoc.jenkins.io"
-    gherkin = "cucumber.jenkins-ci.org"
-    drupal = "cucumber.jenkins-ci.org"
-    downloads = "cucumber.jenkins-ci.org"
-    fisheye = "cucumber.jenkins-ci.org"
-    stacktrace = "cucumber.jenkins-ci.org"
-    sorcerer = "cucumber.jenkins-ci.org"
-    maven = "cucumber.jenkins-ci.org"
-    maven2 = "cucumber.jenkins-ci.org"
-    ci = "ci.jenkins.io"
-    svn = "cucumber.jenkins-ci.org"
-    javanet2 = "cucumber.jenkins-ci.org"
-    l10n = "l10n.jenkins.io"
-    mirrors = "mirrors.jenkins.io"
-    pkg = "pkg.jenkins.io"
-    usage = "usage.jenkins.io"
-    stats = "jenkins-infra.github.io"
-    meetings = "edamame.jenkins-ci.org"
-    jekyll = "jenkinsci.github.io"
-    mirrors2 = "lettuce.jenkins-ci.org"
-    ips = "lettuce.jenkins-ci.org"
-    nagios = "lettuce.jenkins-ci.org"
-    kale = "ec2-184-73-58-254.compute-1.amazonaws.com"
-    repo = "jenkinsci.jfrog.org"
-    links = "rhs.reddit.com"
-    plugin-generator = "jpi-create.jenkins.cloudbees.net"
-    goto = "goto.jenkins.cloudbees.net"
-    recipe = "recipe.jenkins.cloudbees.net"
-    puppet = "artichoke.jenkins-ci.org"
-    archives = "okra.jenkins-ci.org"
-    demo = "kelp.jenkins-ci.org"
-    accounts = "accounts.jenkins.io"
+    www                                 = "jenkins-ci.org"
+    issues                              = "edamame.jenkins-ci.org"
+    wiki                                = "lettuce.jenkins-ci.org"
+    updates                             = "updates.jenkins.io"
+    javadoc                             = "javadoc.jenkins.io"
+    gherkin                             = "cucumber.jenkins-ci.org"
+    drupal                              = "cucumber.jenkins-ci.org"
+    downloads                           = "cucumber.jenkins-ci.org"
+    fisheye                             = "cucumber.jenkins-ci.org"
+    stacktrace                          = "cucumber.jenkins-ci.org"
+    sorcerer                            = "cucumber.jenkins-ci.org"
+    maven                               = "cucumber.jenkins-ci.org"
+    maven2                              = "cucumber.jenkins-ci.org"
+    ci                                  = "ci.jenkins.io"
+    svn                                 = "cucumber.jenkins-ci.org"
+    javanet2                            = "cucumber.jenkins-ci.org"
+    l10n                                = "l10n.jenkins.io"
+    mirrors                             = "mirrors.jenkins.io"
+    pkg                                 = "pkg.jenkins.io"
+    usage                               = "usage.jenkins.io"
+    stats                               = "jenkins-infra.github.io"
+    meetings                            = "edamame.jenkins-ci.org"
+    jekyll                              = "jenkinsci.github.io"
+    mirrors2                            = "lettuce.jenkins-ci.org"
+    ips                                 = "lettuce.jenkins-ci.org"
+    nagios                              = "lettuce.jenkins-ci.org"
+    kale                                = "ec2-184-73-58-254.compute-1.amazonaws.com"
+    repo                                = "jenkinsci.jfrog.org"
+    links                               = "rhs.reddit.com"
+    plugin-generator                    = "jpi-create.jenkins.cloudbees.net"
+    goto                                = "goto.jenkins.cloudbees.net"
+    recipe                              = "recipe.jenkins.cloudbees.net"
+    puppet                              = "artichoke.jenkins-ci.org"
+    archives                            = "okra.jenkins-ci.org"
+    demo                                = "kelp.jenkins-ci.org"
+    accounts                            = "accounts.jenkins.io"
     "_9EDE1B274D351E6D534FDC94833DF749" = "A52BB2524DAF896F76544BA7067F72E7.EADA96B92AE1DBD4BE6A9DB208FD8EED.5c60846ea259f.comodoca.com"
     "_9EDE1B274D351E6D534FDC94833DF749" = "A52BB2524DAF896F76544BA7067F72E7.EADA96B92AE1DBD4BE6A9DB208FD8EED.5c60846ea259f.comodoca.com"
     "_9EDE1B274D351E6D534FDC94833DF749" = "A52BB2524DAF896F76544BA7067F72E7.EADA96B92AE1DBD4BE6A9DB208FD8EED.5c60846ea259f.comodoca.com"
-
   }
 }
 
 resource "azurerm_resource_group" "dns_jenkinsci" {
   name     = "${var.prefix}dns_jenkinsci"
   location = "${var.location}"
+
   tags {
-      env = "${var.prefix}"
+    env = "${var.prefix}"
   }
 }
 
@@ -121,15 +121,15 @@ resource "azurerm_dns_cname_record" "jenkinsci_cname_entries" {
   zone_name           = "${azurerm_dns_zone.jenkinsci.name}"
   resource_group_name = "${azurerm_resource_group.dns_jenkinsci.name}"
   ttl                 = 3600
-  record             = "${local.jenkinsci_cname_records[element(keys(local.jenkinsci_cname_records), count.index)]}"
+  record              = "${local.jenkinsci_cname_records[element(keys(local.jenkinsci_cname_records), count.index)]}"
 }
-
 
 resource "azurerm_dns_txt_record" "jenkinsci_root_txt_entries" {
   name                = "@"
   zone_name           = "${azurerm_dns_zone.jenkinsci.name}"
   resource_group_name = "${azurerm_resource_group.dns_jenkinsci.name}"
   ttl                 = 3600
+
   record {
     value = "v=spf1 mx ip4:199.193.196.24 ip4:140.211.15.0/24 ip4:140.211.8.0/23 ip4:173.203.60.151 ip4:140.211.166.128/25 -all"
   }

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -12,76 +12,76 @@ locals {
 
     # VM at Rackspace
     celery = "162.242.234.101"
-    okra = "162.209.106.32"
+    okra   = "162.209.106.32"
 
     # cabbage has died of dysentery
     cabbage = "104.130.167.56"
-    kelp = "162.209.124.149"
+    kelp    = "162.209.124.149"
 
     # Hosts at OSUOSL
     lettuce = "140.211.9.32"
 
     # artichoke has died of dysentery
     artichoke = "140.211.9.22"
-    eggplant = "140.211.15.101"
-    edamame = "140.211.9.2"
-    radish = "140.211.9.94"
+    eggplant  = "140.211.15.101"
+    edamame   = "140.211.9.2"
+    radish    = "140.211.9.94"
 
     # EC2
-    rating = "52.23.130.110"
+    rating  = "52.23.130.110"
     mirrors = "52.202.51.185"
-    l10n = "52.71.7.244"
-    census = "52.202.38.86"
-    usage = "52.204.62.78"
+    l10n    = "52.71.7.244"
+    census  = "52.202.38.86"
+    usage   = "52.204.62.78"
 
     # Azure
-    ldap = "52.232.180.203"
-    cn = "159.138.4.250" # Chinese jenkins.io hosted Huawei China
-    azure.ci = "104.208.238.39"
-    ci = "104.208.238.39"
+    ldap              = "52.232.180.203"
+    cn                = "159.138.4.250"  # Chinese jenkins.io hosted Huawei China
+    azure.ci          = "104.208.238.39"
+    ci                = "104.208.238.39"
     gateway.evergreen = "137.116.80.151"
-    private.aks = "10.0.2.5"
-    public.aks = "40.70.215.138"
+    private.aks       = "10.0.2.5"
+    public.aks        = "40.70.215.138"
   }
 
   jenkinsio_aaaa_records = {
     # VM at Rackspace
     celery = "2001:4802:7801:103:be76:4eff:fe20:357c"
-    okra = "2001:4802:7800:2:be76:4eff:fe20:7a31"
+    okra   = "2001:4802:7800:2:be76:4eff:fe20:7a31"
   }
-  
+
   jenkinsio_cname_records = {
     # Azure
-    accounts = "nginx.azure.jenkins.io"
-    nginx.azure = "jenkins.io"
-    javadoc = "nginx.azure.jenkins.io"
-    plugins = "nginx.azure.jenkins.io"
-    repo.azure = "nginx.azure.jenkins.io"
+    accounts      = "nginx.azure.jenkins.io"
+    nginx.azure   = "jenkins.io"
+    javadoc       = "nginx.azure.jenkins.io"
+    plugins       = "nginx.azure.jenkins.io"
+    repo.azure    = "nginx.azure.jenkins.io"
     updates.azure = "nginx.azure.jenkins.io"
-    reports = "nginx.azure.jenkins.io"
-    www = "nginx.azure.jenkins.io"
-    evergreen = "nginx.azure.jenkins.io"
-    uplink = "nginx.azure.jenkins.io"
+    reports       = "nginx.azure.jenkins.io"
+    www           = "nginx.azure.jenkins.io"
+    evergreen     = "nginx.azure.jenkins.io"
+    uplink        = "nginx.azure.jenkins.io"
 
     # AKS
     repo.release = "private.aks.jenkins.io"
-    ci.release = "private.aks.jenkins.io"
+    ci.release   = "private.aks.jenkins.io"
 
     # CNAME Records
-    pkg = "mirrors.jenkins.io"
-    puppet = "radish.jenkins.io"
-    updates = "mirrors.jenkins.io"
+    pkg      = "mirrors.jenkins.io"
+    puppet   = "radish.jenkins.io"
+    updates  = "mirrors.jenkins.io"
     archives = "okra.jenkins.io"
-    stats = "jenkins-infra.github.io"
-    patron = "jenkins-infra.github.io"
-    wiki = "lettuce.jenkins.io"
-    issues = "edamame.jenkins.io"
+    stats    = "jenkins-infra.github.io"
+    patron   = "jenkins-infra.github.io"
+    wiki     = "lettuce.jenkins.io"
+    issues   = "edamame.jenkins.io"
 
     # Magical CNAME for certificate validation
     "D07F852F584FA592123140354D366066.ldap" = "75E741181A7ACDBE2996804B2813E09B65970718.comodoca.com"
 
     # Amazon SES configuration to send out email from noreply@jenkins.io
-    pbssnl2yyudgfdl3flznotnarnamz5su._domainkey = "pbssnl2yyudgfdl3flznotnarnamz5su.dkim.amazonses.com"
+    pbssnl2yyudgfdl3flznotnarnamz5su._domainkey   = "pbssnl2yyudgfdl3flznotnarnamz5su.dkim.amazonses.com"
     "6ch6fw67efpfgoqyhdhs2cy2fpkwrvsk._domainkey" = "6ch6fw67efpfgoqyhdhs2cy2fpkwrvsk.dkim.amazonses.com"
     "37qo4cqmkxeocwr2iicjop77fq52m6yh._domainkey" = "37qo4cqmkxeocwr2iicjop77fq52m6yh.dkim.amazonses.com"
 
@@ -92,8 +92,9 @@ locals {
   jenkinsio_txt_records = {
     # Amazon SES configuration to send out email from noreply@jenkins.io    
     _amazonses = "kYNeW+b+9GnKO/LzqP/t0TzLyN86jQ9didoBAJSjezE="
+
     # mailgun configuration
-    "@" = "v=spf1 include:mailgun.org ~all"
+    "@"              = "v=spf1 include:mailgun.org ~all"
     mailo._domainkey = "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCpS+8K+bVvFlfTqbVbuvM9SoX0BqjW3zK7BJeCZ4GnaJTeRaurKx81hUX1wz3wKt+Qt9xI+X6mAlar2Co+B13GsNZIlYVdO/zBVtZG+R5KvMQUynNyie05oRyaTFWtNEiQVgGYgM4xkwlIWSA9EXmBMaKg7ze3kKNKUOnzKDIxMQIDAQAB"
   }
 }
@@ -101,8 +102,9 @@ locals {
 resource "azurerm_resource_group" "dns_jenkinsio" {
   name     = "${var.prefix}dns_jenkinsio"
   location = "${var.location}"
+
   tags {
-      env = "${var.prefix}"
+    env = "${var.prefix}"
   }
 }
 
@@ -135,7 +137,7 @@ resource "azurerm_dns_cname_record" "jenkinsio_cname_entries" {
   zone_name           = "${azurerm_dns_zone.jenkinsio.name}"
   resource_group_name = "${azurerm_resource_group.dns_jenkinsio.name}"
   ttl                 = 3600
-  record             = "${local.jenkinsio_cname_records[element(keys(local.jenkinsio_cname_records), count.index)]}"
+  record              = "${local.jenkinsio_cname_records[element(keys(local.jenkinsio_cname_records), count.index)]}"
 }
 
 resource "azurerm_dns_txt_record" "jenkinsio_txt_entries" {
@@ -144,6 +146,7 @@ resource "azurerm_dns_txt_record" "jenkinsio_txt_entries" {
   zone_name           = "${azurerm_dns_zone.jenkinsio.name}"
   resource_group_name = "${azurerm_resource_group.dns_jenkinsio.name}"
   ttl                 = 3600
+
   record {
     value = "${local.jenkinsio_txt_records[element(keys(local.jenkinsio_txt_records), count.index)]}"
   }

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -63,6 +63,10 @@ locals {
     evergreen = "nginx.azure.jenkins.io"
     uplink = "nginx.azure.jenkins.io"
 
+    # AKS
+    repo.release = "private.aks.jenkins.io"
+    ci.release = "private.aks.jenkins.io"
+
     # CNAME Records
     pkg = "mirrors.jenkins.io"
     puppet = "radish.jenkins.io"
@@ -72,8 +76,6 @@ locals {
     patron = "jenkins-infra.github.io"
     wiki = "lettuce.jenkins.io"
     issues = "edamame.jenkins.io"
-
-    "*.jx.release.alpha" = "private.aks.jenkins.io"
 
     # Magical CNAME for certificate validation
     "D07F852F584FA592123140354D366066.ldap" = "75E741181A7ACDBE2996804B2813E09B65970718.comodoca.com"

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -64,8 +64,8 @@ locals {
     uplink        = "nginx.azure.jenkins.io"
 
     # AKS
-    repo.release = "private.aks.jenkins.io"
-    ci.release   = "private.aks.jenkins.io"
+    release.repo = "private.aks.jenkins.io"
+    release.ci   = "private.aks.jenkins.io"
 
     # CNAME Records
     pkg      = "mirrors.jenkins.io"

--- a/plans/dockerregistry.tf
+++ b/plans/dockerregistry.tf
@@ -1,34 +1,39 @@
 resource "azurerm_resource_group" "dockerregistry" {
   name     = "${var.prefix}dockerregistry"
   location = "${var.dockerregistrylocation}"
+
   tags {
     "env" = "${var.prefix}"
   }
 }
 
 resource "azurerm_storage_account" "dockerregistry" {
-    name                     = "${var.prefix}dockerregistry"
-    resource_group_name      = "${azurerm_resource_group.dockerregistry.name}"
-    location                 = "${var.dockerregistrylocation}"
-    depends_on               = ["azurerm_resource_group.dockerregistry"]
-    account_tier              = "Standard"
-    account_replication_type = "GRS"
-    tags {
-        "env" = "${var.prefix}"
-    }
+  name                     = "${var.prefix}dockerregistry"
+  resource_group_name      = "${azurerm_resource_group.dockerregistry.name}"
+  location                 = "${var.dockerregistrylocation}"
+  depends_on               = ["azurerm_resource_group.dockerregistry"]
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+
+  tags {
+    "env" = "${var.prefix}"
+  }
 }
 
-resource "azurerm_template_deployment" "dockerregistry"{
+resource "azurerm_template_deployment" "dockerregistry" {
   name                = "${var.prefix}dockerregistry"
   resource_group_name = "${ azurerm_resource_group.dockerregistry.name }"
   depends_on          = ["azurerm_resource_group.dockerregistry"]
-  parameters          = {
-	registryName       = "${var.prefix}registry"
+
+  parameters = {
+    registryName       = "${var.prefix}registry"
     registryLocation   = "${var.dockerregistrylocation}"
-	registryApiVersion = "2016-06-27-preview"
-	storageAccountName = "${ azurerm_storage_account.dockerregistry.name }"
-	#adminUserEnabled  = true
+    registryApiVersion = "2016-06-27-preview"
+    storageAccountName = "${ azurerm_storage_account.dockerregistry.name }"
+
+    #adminUserEnabled  = true
   }
-  deployment_mode     = "Incremental"
-  template_body       = "${file("./arm_templates/dockerregistry.json")}"
+
+  deployment_mode = "Incremental"
+  template_body   = "${file("./arm_templates/dockerregistry.json")}"
 }

--- a/plans/evergreen.tf
+++ b/plans/evergreen.tf
@@ -14,23 +14,25 @@ resource "azurerm_postgresql_server" "evergreen" {
   resource_group_name = "${azurerm_resource_group.evergreen.name}"
 
   sku {
-    name = "B_Gen5_2"
+    name     = "B_Gen5_2"
     capacity = 2
-    tier = "Basic"
-    family = "Gen5"
+    tier     = "Basic"
+    family   = "Gen5"
   }
 
   storage_profile {
-    storage_mb = 5120
+    storage_mb            = 5120
     backup_retention_days = 7
-    geo_redundant_backup = "Disabled"
+    geo_redundant_backup  = "Disabled"
   }
 
   administrator_login = "evergreen_admin"
+
   # Once the infrastructure has been deployed, the password should be manually
   # reset such that it can be utilized in Kubernetes/Puppet/etc
   administrator_login_password = "${random_id.prefix.hex}A1!"
-  version = "10.0"
+
+  version         = "10.0"
   ssl_enforcement = "Disabled"
 }
 
@@ -41,4 +43,3 @@ resource "azurerm_postgresql_database" "evergreen_prod" {
   charset             = "UTF8"
   collation           = "English_United States.1252"
 }
-

--- a/plans/javadoc.tf
+++ b/plans/javadoc.tf
@@ -3,28 +3,30 @@
 #
 
 resource "azurerm_resource_group" "javadoc" {
-    name     = "${var.prefix}javadoc"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}javadoc"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "javadoc" {
-    name                     = "${var.prefix}javadoc"
-    resource_group_name      = "${azurerm_resource_group.javadoc.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    depends_on               = ["azurerm_resource_group.javadoc"]
-    tags {
-        env = "${var.prefix}"
-    }
+  name                     = "${var.prefix}javadoc"
+  resource_group_name      = "${azurerm_resource_group.javadoc.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.javadoc"]
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_share" "javadoc" {
-    name = "javadoc"
-    resource_group_name     = "${azurerm_resource_group.javadoc.name}"
-    storage_account_name    = "${azurerm_storage_account.javadoc.name}"
-    depends_on              = ["azurerm_resource_group.javadoc","azurerm_storage_account.javadoc"]
+  name                 = "javadoc"
+  resource_group_name  = "${azurerm_resource_group.javadoc.name}"
+  storage_account_name = "${azurerm_storage_account.javadoc.name}"
+  depends_on           = ["azurerm_resource_group.javadoc", "azurerm_storage_account.javadoc"]
 }

--- a/plans/jenkinsio.tf
+++ b/plans/jenkinsio.tf
@@ -3,45 +3,47 @@
 #
 
 resource "azurerm_resource_group" "jenkinsio" {
-    name     = "${var.prefix}jenkinsio"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}jenkinsio"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "jenkinsio" {
-    name                     = "${var.prefix}jenkinsio"
-    resource_group_name      = "${azurerm_resource_group.jenkinsio.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    depends_on               = ["azurerm_resource_group.jenkinsio"]
-    tags {
-        env = "${var.prefix}"
-    }
+  name                     = "${var.prefix}jenkinsio"
+  resource_group_name      = "${azurerm_resource_group.jenkinsio.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.jenkinsio"]
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_share" "jenkinsio" {
-    name                    = "jenkinsio"
-    resource_group_name     = "${azurerm_resource_group.jenkinsio.name}"
-    storage_account_name    = "${azurerm_storage_account.jenkinsio.name}"
-    quota                   = 10
-    depends_on              = ["azurerm_resource_group.jenkinsio","azurerm_storage_account.jenkinsio"]
+  name                 = "jenkinsio"
+  resource_group_name  = "${azurerm_resource_group.jenkinsio.name}"
+  storage_account_name = "${azurerm_storage_account.jenkinsio.name}"
+  quota                = 10
+  depends_on           = ["azurerm_resource_group.jenkinsio", "azurerm_storage_account.jenkinsio"]
 }
 
 resource "azurerm_storage_share" "cnjenkinsio" {
-    name                    = "cnjenkinsio"
-    resource_group_name     = "${azurerm_resource_group.jenkinsio.name}"
-    storage_account_name    = "${azurerm_storage_account.jenkinsio.name}"
-    quota                   = 10
-    depends_on              = ["azurerm_resource_group.jenkinsio","azurerm_storage_account.jenkinsio"]
+  name                 = "cnjenkinsio"
+  resource_group_name  = "${azurerm_resource_group.jenkinsio.name}"
+  storage_account_name = "${azurerm_storage_account.jenkinsio.name}"
+  quota                = 10
+  depends_on           = ["azurerm_resource_group.jenkinsio", "azurerm_storage_account.jenkinsio"]
 }
 
 resource "azurerm_storage_share" "zhjenkinsio" {
-    name                    = "zhjenkinsio"
-    resource_group_name     = "${azurerm_resource_group.jenkinsio.name}"
-    storage_account_name    = "${azurerm_storage_account.jenkinsio.name}"
-    quota                   = 10
-    depends_on              = ["azurerm_resource_group.jenkinsio","azurerm_storage_account.jenkinsio"]
+  name                 = "zhjenkinsio"
+  resource_group_name  = "${azurerm_resource_group.jenkinsio.name}"
+  storage_account_name = "${azurerm_storage_account.jenkinsio.name}"
+  quota                = 10
+  depends_on           = ["azurerm_resource_group.jenkinsio", "azurerm_storage_account.jenkinsio"]
 }

--- a/plans/ldap.tf
+++ b/plans/ldap.tf
@@ -2,29 +2,31 @@
 # This terraform plan defines the resources necessary to host accounts.jenkins.io files
 #
 resource "azurerm_resource_group" "ldap" {
-    name     = "${var.prefix}ldap"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}ldap"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "ldap" {
-    name                      = "${var.prefix}ldap"
-    resource_group_name       = "${azurerm_resource_group.ldap.name}"
-    location                  = "${var.location}"
-    account_tier              = "Standard"
-    account_replication_type  = "GRS"
-    depends_on                = ["azurerm_resource_group.ldap"]
-    tags {
-        env = "${var.prefix}"
-    }
+  name                     = "${var.prefix}ldap"
+  resource_group_name      = "${azurerm_resource_group.ldap.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.ldap"]
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_share" "ldap" {
-    name = "ldap"
-    resource_group_name     = "${azurerm_resource_group.ldap.name}"
-    storage_account_name    = "${azurerm_storage_account.ldap.name}"
-    quota                   = 100
-    depends_on              = ["azurerm_resource_group.ldap","azurerm_storage_account.ldap"]
+  name                 = "ldap"
+  resource_group_name  = "${azurerm_resource_group.ldap.name}"
+  storage_account_name = "${azurerm_storage_account.ldap.name}"
+  quota                = 100
+  depends_on           = ["azurerm_resource_group.ldap", "azurerm_storage_account.ldap"]
 }

--- a/plans/logs.tf
+++ b/plans/logs.tf
@@ -1,43 +1,46 @@
 resource "azurerm_resource_group" "logs" {
-    name     = "${var.prefix}logs"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}logs"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "logs" {
-    name                     = "${var.prefix}jenkinslogs"
-    resource_group_name      = "${azurerm_resource_group.logs.name}"
-    location                 = "${var.location}"
-    depends_on               = ["azurerm_resource_group.logs"]
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    tags {
-        env = "${var.prefix}"
-    }
-}
+  name                     = "${var.prefix}jenkinslogs"
+  resource_group_name      = "${azurerm_resource_group.logs.name}"
+  location                 = "${var.location}"
+  depends_on               = ["azurerm_resource_group.logs"]
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
 
+  tags {
+    env = "${var.prefix}"
+  }
+}
 
 resource "azurerm_storage_share" "logs" {
-    name = "logs"
-    resource_group_name     = "${azurerm_resource_group.logs.name}"
-    storage_account_name    = "${azurerm_storage_account.logs.name}"
-    quota                   = 200
-    depends_on              = ["azurerm_resource_group.logs","azurerm_storage_account.logs"]
+  name                 = "logs"
+  resource_group_name  = "${azurerm_resource_group.logs.name}"
+  storage_account_name = "${azurerm_storage_account.logs.name}"
+  quota                = 200
+  depends_on           = ["azurerm_resource_group.logs", "azurerm_storage_account.logs"]
 }
 
-resource "azurerm_template_deployment" "logs"{
-    name                = "${var.prefix}logs"
-    resource_group_name = "${ azurerm_resource_group.logs.name }"
-    depends_on          = ["azurerm_resource_group.logs"]
-    parameters          = {
-        omsWorkspaceName                        = "${var.prefix}logs"
-        omsRegion                               = "${var.logslocation}"
-        existingStorageAccountName              = "${azurerm_storage_account.logs.name}"
-        existingStorageAccountResourceGroupName = "${azurerm_resource_group.logs.name}"
-        table                                   = "WADWindowsEventLogsTable"
-    }
-    deployment_mode     = "Incremental"
-    template_body       = "${file("./arm_templates/logs.json")}"
+resource "azurerm_template_deployment" "logs" {
+  name                = "${var.prefix}logs"
+  resource_group_name = "${ azurerm_resource_group.logs.name }"
+  depends_on          = ["azurerm_resource_group.logs"]
+
+  parameters = {
+    omsWorkspaceName                        = "${var.prefix}logs"
+    omsRegion                               = "${var.logslocation}"
+    existingStorageAccountName              = "${azurerm_storage_account.logs.name}"
+    existingStorageAccountResourceGroupName = "${azurerm_resource_group.logs.name}"
+    table                                   = "WADWindowsEventLogsTable"
+  }
+
+  deployment_mode = "Incremental"
+  template_body   = "${file("./arm_templates/logs.json")}"
 }

--- a/plans/machine_certci.tf
+++ b/plans/machine_certci.tf
@@ -4,6 +4,7 @@
 resource "azurerm_resource_group" "certci" {
   name     = "${var.prefix}certci"
   location = "${var.location}"
+
   tags {
     env = "${var.prefix}"
   }
@@ -17,6 +18,7 @@ resource "azurerm_public_ip" "certci" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.certci.name}"
   public_ip_address_allocation = "static"
+
   tags {
     env = "${var.prefix}"
   }
@@ -29,6 +31,7 @@ resource "azurerm_network_interface" "certci_private" {
   resource_group_name     = "${azurerm_resource_group.certci.name}"
   enable_ip_forwarding    = false
   internal_dns_name_label = "certci"
+
   ip_configuration {
     name                          = "${var.prefix}-private"
     subnet_id                     = "${azurerm_subnet.public_data.id}"
@@ -36,22 +39,25 @@ resource "azurerm_network_interface" "certci_private" {
     private_ip_address            = "10.0.2.252"
     public_ip_address_id          = "${azurerm_public_ip.certci.id}"
   }
+
   tags {
     env = "${var.prefix}"
   }
 }
 
 resource "azurerm_virtual_machine" "certci" {
-  name                  = "${var.prefix}-certci"
-  location              = "${azurerm_resource_group.certci.location}"
-  resource_group_name   = "${azurerm_resource_group.certci.name}"
-  network_interface_ids = [
-    "${azurerm_network_interface.certci_private.id}"
-  ]
-  primary_network_interface_id = "${azurerm_network_interface.certci_private.id}"
-  vm_size               = "Standard_D2s_v3"
+  name                = "${var.prefix}-certci"
+  location            = "${azurerm_resource_group.certci.location}"
+  resource_group_name = "${azurerm_resource_group.certci.name}"
 
-  delete_os_disk_on_termination = true
+  network_interface_ids = [
+    "${azurerm_network_interface.certci_private.id}",
+  ]
+
+  primary_network_interface_id = "${azurerm_network_interface.certci_private.id}"
+  vm_size                      = "Standard_D2s_v3"
+
+  delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
 
   storage_image_reference {
@@ -78,11 +84,13 @@ resource "azurerm_virtual_machine" "certci" {
 
   os_profile_linux_config {
     disable_password_authentication = true
+
     ssh_keys {
       key_data = "${file("${var.ssh_pubkey_path}")}"
-      path = "/home/azureadmin/.ssh/authorized_keys"
+      path     = "/home/azureadmin/.ssh/authorized_keys"
     }
   }
+
   tags {
     env = "${var.prefix}"
   }
@@ -96,6 +104,7 @@ resource "azurerm_managed_disk" "certci_data" {
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
   disk_size_gb         = "300"
+
   tags {
     env = "${var.prefix}"
   }

--- a/plans/machine_ci.tf
+++ b/plans/machine_ci.tf
@@ -5,6 +5,7 @@ resource "azurerm_public_ip" "ci" {
   location                     = "${var.location}"
   resource_group_name          = "${azurerm_resource_group.ci.name}"
   public_ip_address_allocation = "static"
+
   tags {
     env = "${var.prefix}"
   }
@@ -16,28 +17,32 @@ resource "azurerm_network_interface" "ci_public" {
   resource_group_name     = "${azurerm_resource_group.ci.name}"
   enable_ip_forwarding    = false
   internal_dns_name_label = "ci"
+
   ip_configuration {
     name                          = "${var.prefix}-public"
     subnet_id                     = "${azurerm_subnet.public_data.id}"
     private_ip_address_allocation = "dynamic"
     public_ip_address_id          = "${azurerm_public_ip.ci.id}"
   }
+
   tags {
     env = "${var.prefix}"
   }
 }
 
 resource "azurerm_virtual_machine" "ci" {
-  name                  = "${var.prefix}-ci"
-  location              = "${azurerm_resource_group.ci.location}"
-  resource_group_name   = "${azurerm_resource_group.ci.name}"
-  network_interface_ids = [
-    "${azurerm_network_interface.ci_public.id}"
-  ]
-  primary_network_interface_id = "${azurerm_network_interface.ci_public.id}"
-  vm_size               = "Standard_D4s_v3"
+  name                = "${var.prefix}-ci"
+  location            = "${azurerm_resource_group.ci.location}"
+  resource_group_name = "${azurerm_resource_group.ci.name}"
 
-  delete_os_disk_on_termination = true
+  network_interface_ids = [
+    "${azurerm_network_interface.ci_public.id}",
+  ]
+
+  primary_network_interface_id = "${azurerm_network_interface.ci_public.id}"
+  vm_size                      = "Standard_D4s_v3"
+
+  delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
 
   storage_image_reference {
@@ -64,11 +69,13 @@ resource "azurerm_virtual_machine" "ci" {
 
   os_profile_linux_config {
     disable_password_authentication = true
+
     ssh_keys {
       key_data = "${file("${var.ssh_pubkey_path}")}"
-      path = "/home/azureadmin/.ssh/authorized_keys"
+      path     = "/home/azureadmin/.ssh/authorized_keys"
     }
   }
+
   tags {
     env = "${var.prefix}"
   }
@@ -82,6 +89,7 @@ resource "azurerm_managed_disk" "ci_data" {
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
   disk_size_gb         = "300"
+
   tags {
     env = "${var.prefix}"
   }

--- a/plans/provider.tf
+++ b/plans/provider.tf
@@ -2,7 +2,7 @@
 # https://releases.hashicorp.com/terraform-provider-azurerm/
 
 provider "azurerm" {
-  version         = "~> 1.25.0"
+  version         = "~> 1.28.0"
   subscription_id = "${var.subscription_id}"
   client_id       = "${var.client_id}"
   client_secret   = "${var.client_secret}"

--- a/plans/provider.tf
+++ b/plans/provider.tf
@@ -2,9 +2,9 @@
 # https://releases.hashicorp.com/terraform-provider-azurerm/
 
 provider "azurerm" {
-    version         = "~> 1.25.0"
-    subscription_id = "${var.subscription_id}"
-    client_id       = "${var.client_id}"
-    client_secret   = "${var.client_secret}"
-    tenant_id       = "${var.tenant_id}"
+  version         = "~> 1.25.0"
+  subscription_id = "${var.subscription_id}"
+  client_id       = "${var.client_id}"
+  client_secret   = "${var.client_secret}"
+  tenant_id       = "${var.tenant_id}"
 }

--- a/plans/publick8s.tf
+++ b/plans/publick8s.tf
@@ -35,7 +35,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   location            = "${azurerm_resource_group.publick8s.location}"
   dns_prefix          = "${var.prefix}"
   resource_group_name = "${azurerm_resource_group.publick8s.name}"
-  kubernetes_version  = "1.12.6"                                       #az aks get-versions --location eastus --output table
+  kubernetes_version  = "1.12.8"                                       #az aks get-versions --location eastus --output table
 
   role_based_access_control {
     enabled = true

--- a/plans/publick8s.tf
+++ b/plans/publick8s.tf
@@ -1,6 +1,7 @@
 resource "azurerm_resource_group" "publick8s" {
   name     = "${var.prefix}publick8s"
   location = "${var.location}"
+
   tags {
     environment = "${var.prefix}"
   }
@@ -16,35 +17,37 @@ resource "azurerm_log_analytics_workspace" "publick8s" {
 }
 
 resource "azurerm_storage_account" "publick8s" {
-    name                     = "${azurerm_resource_group.publick8s.name}"
-    resource_group_name      = "${azurerm_resource_group.publick8s.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    depends_on               = ["azurerm_resource_group.publick8s"]
-    tags {
-        environment = "${var.prefix}"
-    }
+  name                     = "${azurerm_resource_group.publick8s.name}"
+  resource_group_name      = "${azurerm_resource_group.publick8s.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.publick8s"]
+
+  tags {
+    environment = "${var.prefix}"
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "publick8s" {
-  depends_on             = ["azurerm_subnet.publick8s"]
-  name                   = "${azurerm_resource_group.publick8s.name}"
-  location               = "${azurerm_resource_group.publick8s.location}"
-  dns_prefix             = "${var.prefix}"
-  resource_group_name    = "${azurerm_resource_group.publick8s.name}"
-  kubernetes_version     = "1.12.6" #az aks get-versions --location eastus --output table
+  depends_on          = ["azurerm_subnet.publick8s"]
+  name                = "${azurerm_resource_group.publick8s.name}"
+  location            = "${azurerm_resource_group.publick8s.location}"
+  dns_prefix          = "${var.prefix}"
+  resource_group_name = "${azurerm_resource_group.publick8s.name}"
+  kubernetes_version  = "1.12.6"                                       #az aks get-versions --location eastus --output table
+
   role_based_access_control {
     enabled = true
   }
 
   agent_pool_profile {
-    name    = "publick8s"
-    count   = "1"
-    vm_size = "Standard_D4s_v3"
-    os_type = "Linux"
-    vnet_subnet_id = "${azurerm_subnet.publick8s.id}" # ! Only one AKS per subnet
-    os_disk_size_gb = 30 # It seems that terraform force a resource re-creation if size is not defined
+    name            = "publick8s"
+    count           = "1"
+    vm_size         = "Standard_D4s_v3"
+    os_type         = "Linux"
+    vnet_subnet_id  = "${azurerm_subnet.publick8s.id}" # ! Only one AKS per subnet
+    os_disk_size_gb = 30                               # It seems that terraform force a resource re-creation if size is not defined
   }
 
   linux_profile {
@@ -58,13 +61,13 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   network_profile {
     network_plugin     = "kubenet"
     service_cidr       = "10.128.0.0/16" # Number of IPs needed  = (number of nodes) + (number of nodes * pods per node)
-    dns_service_ip     = "10.128.0.10" # Must be in service_cidr range
+    dns_service_ip     = "10.128.0.10"   # Must be in service_cidr range
     docker_bridge_cidr = "172.17.0.1/16"
   }
 
   addon_profile {
     oms_agent {
-      enabled = "true"
+      enabled                    = "true"
       log_analytics_workspace_id = "${ azurerm_log_analytics_workspace.publick8s.id }"
     }
   }
@@ -88,8 +91,8 @@ resource "azurerm_public_ip" "publick8s" {
   resource_group_name          = "MC_${azurerm_resource_group.publick8s.name}_${azurerm_kubernetes_cluster.publick8s.name}_${azurerm_kubernetes_cluster.publick8s.location}"
   public_ip_address_allocation = "Static"
   idle_timeout_in_minutes      = 30
+
   tags {
     environment = "${var.prefix}"
   }
 }
-

--- a/plans/release-core.tf
+++ b/plans/release-core.tf
@@ -21,7 +21,7 @@ resource "azurerm_key_vault" "release-core" {
 
 # https://docs.microsoft.com/en-us/rest/api/keyvault/certificates-and-policies
 resource "azurerm_key_vault_certificate" "release-core" {
-  name     = "${var.prefix}releasecore"
+  name         = "${var.prefix}releasecore"
   key_vault_id = "${azurerm_key_vault.release-core.id}"
 
   certificate_policy {
@@ -68,20 +68,19 @@ resource "azurerm_key_vault_certificate" "release-core" {
   }
 }
 
-
 ### GPG key stored on a storage account 
 
 resource "azurerm_storage_account" "release-core" {
-    name                     = "${var.prefix}releasecore"
-    resource_group_name      = "${azurerm_resource_group.release-core.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
+  name                     = "${var.prefix}releasecore"
+  resource_group_name      = "${azurerm_resource_group.release-core.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
 }
 
 resource "azurerm_storage_container" "release-core-gpg" {
-    name                  = "gpg"
-    resource_group_name   = "${azurerm_resource_group.release-core.name}"
-    storage_account_name  = "${azurerm_storage_account.release-core.name}"
-    container_access_type = "container"
+  name                  = "gpg"
+  resource_group_name   = "${azurerm_resource_group.release-core.name}"
+  storage_account_name  = "${azurerm_storage_account.release-core.name}"
+  container_access_type = "container"
 }

--- a/plans/releases-storage.tf
+++ b/plans/releases-storage.tf
@@ -6,18 +6,17 @@
 # this plan represents the enforcement of those resources.
 
 resource "azurerm_resource_group" "releases" {
-    name     = "${var.prefix}-core-releases"
-    location = "${var.location}"
+  name     = "${var.prefix}-core-releases"
+  location = "${var.location}"
 }
 
 resource "azurerm_storage_account" "releases" {
-    name                     = "${var.prefix}jenkinsreleases"
-    resource_group_name      = "${azurerm_resource_group.releases.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
+  name                     = "${var.prefix}jenkinsreleases"
+  resource_group_name      = "${azurerm_resource_group.releases.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
 }
-
 
 ##
 ## Defining containers for the various types of Jenkisn releases. This could
@@ -29,170 +28,192 @@ resource "azurerm_storage_account" "releases" {
 # Containers for the .war file releases:
 ########################################
 resource "azurerm_storage_container" "war" {
-    name                  = "war"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "war"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "war-stable" {
-    name                  = "war-stable"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "war-stable"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "war-stable-rc" {
-    name                  = "war-stable-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "war-stable-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "war-rc" {
-    name                  = "war-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "war-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 ########################################
 
 # Containers for Red Hat rpm releases:
 ######################################
 resource "azurerm_storage_container" "redhat" {
-    name                  = "redhat"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "redhat"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "redhat-stable" {
-    name                  = "redhat-stable"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "redhat-stable"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "redhat-stable-rc" {
-    name                  = "redhat-stable-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "redhat-stable-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "redhat-rc" {
-    name                  = "redhat-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "redhat-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 ######################################
 
 # Containers for openSUSE rpm releases:
 #######################################
 resource "azurerm_storage_container" "opensuse" {
-    name                  = "opensuse"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "opensuse"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
-resource "azurerm_storage_container" "opensuse-stable" {
-    name                  = "opensuse-stable"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-resource "azurerm_storage_container" "opensuse-stable-rc" {
-    name                  = "opensuse-stable-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-resource "azurerm_storage_container" "opensuse-rc" {
-    name                  = "opensuse-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-#######################################
 
+resource "azurerm_storage_container" "opensuse-stable" {
+  name                  = "opensuse-stable"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+resource "azurerm_storage_container" "opensuse-stable-rc" {
+  name                  = "opensuse-stable-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+resource "azurerm_storage_container" "opensuse-rc" {
+  name                  = "opensuse-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+#######################################
 
 # Container for Debian (.dpkg) releases:
 ########################################
 resource "azurerm_storage_container" "debian" {
-    name                  = "debian"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "debian"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
-resource "azurerm_storage_container" "debian-stable" {
-    name                  = "debian-stable"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-resource "azurerm_storage_container" "debian-stable-rc" {
-    name                  = "debian-stable-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-resource "azurerm_storage_container" "debian-rc" {
-    name                  = "debian-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-########################################
 
+resource "azurerm_storage_container" "debian-stable" {
+  name                  = "debian-stable"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+resource "azurerm_storage_container" "debian-stable-rc" {
+  name                  = "debian-stable-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+resource "azurerm_storage_container" "debian-rc" {
+  name                  = "debian-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+########################################
 
 # Container for Windows (.zip) releases:
 ########################################
 resource "azurerm_storage_container" "windows" {
-    name                  = "windows"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "windows"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
-resource "azurerm_storage_container" "windows-stable" {
-    name                  = "windows-stable"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-resource "azurerm_storage_container" "windows-stable-rc" {
-    name                  = "windows-stable-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-resource "azurerm_storage_container" "windows-rc" {
-    name                  = "windows-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
-}
-########################################
 
+resource "azurerm_storage_container" "windows-stable" {
+  name                  = "windows-stable"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+resource "azurerm_storage_container" "windows-stable-rc" {
+  name                  = "windows-stable-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+resource "azurerm_storage_container" "windows-rc" {
+  name                  = "windows-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
+}
+
+########################################
 
 # Container for Mac OS X (.pkg) releases:
 #########################################
 resource "azurerm_storage_container" "osx" {
-    name                  = "osx"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "osx"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "osx-stable" {
-    name                  = "osx-stable"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "osx-stable"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "osx-stable-rc" {
-    name                  = "osx-stable-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "osx-stable-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 resource "azurerm_storage_container" "osx-rc" {
-    name                  = "osx-rc"
-    resource_group_name   = "${azurerm_resource_group.releases.name}"
-    storage_account_name  = "${azurerm_storage_account.releases.name}"
-    container_access_type = "container"
+  name                  = "osx-rc"
+  resource_group_name   = "${azurerm_resource_group.releases.name}"
+  storage_account_name  = "${azurerm_storage_account.releases.name}"
+  container_access_type = "container"
 }
+
 #########################################
+

--- a/plans/remote-state.tf
+++ b/plans/remote-state.tf
@@ -4,40 +4,40 @@
 # <https://www.terraform.io/docs/state/remote/azure.html>
 
 resource "azurerm_resource_group" "tfstate" {
-    name     = "${var.prefix}tfstate"
-    location = "${var.location}"
+  name     = "${var.prefix}tfstate"
+  location = "${var.location}"
 }
 
 resource "azurerm_storage_account" "tfstate" {
-    name                     = "${var.prefix}tfstate"
-    resource_group_name      = "${azurerm_resource_group.tfstate.name}"
-    location                 = "${var.location}"
-    account_kind             = "StorageV2"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    enable_blob_encryption   = true
+  name                     = "${var.prefix}tfstate"
+  resource_group_name      = "${azurerm_resource_group.tfstate.name}"
+  location                 = "${var.location}"
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  enable_blob_encryption   = true
 }
 
 resource "azurerm_storage_container" "tfstate" {
-    name                  = "tfstate"
-    resource_group_name   = "${azurerm_resource_group.tfstate.name}"
-    storage_account_name  = "${azurerm_storage_account.tfstate.name}"
-    container_access_type = "private"
+  name                  = "tfstate"
+  resource_group_name   = "${azurerm_resource_group.tfstate.name}"
+  storage_account_name  = "${azurerm_storage_account.tfstate.name}"
+  container_access_type = "private"
 }
 
 resource "azurerm_storage_account" "tfstate_datadog" {
-    name                     = "${var.prefix}tfstatedatadog"
-    resource_group_name      = "${azurerm_resource_group.tfstate.name}"
-    location                 = "${var.location}"
-    account_kind             = "StorageV2"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    enable_blob_encryption   = true
+  name                     = "${var.prefix}tfstatedatadog"
+  resource_group_name      = "${azurerm_resource_group.tfstate.name}"
+  location                 = "${var.location}"
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  enable_blob_encryption   = true
 }
 
 resource "azurerm_storage_container" "tfstate_datadog" {
-    name                  = "tfstatedatadog"
-    resource_group_name   = "${azurerm_resource_group.tfstate.name}"
-    storage_account_name  = "${azurerm_storage_account.tfstate_datadog.name}"
-    container_access_type = "private"
+  name                  = "tfstatedatadog"
+  resource_group_name   = "${azurerm_resource_group.tfstate.name}"
+  storage_account_name  = "${azurerm_storage_account.tfstate_datadog.name}"
+  container_access_type = "private"
 }

--- a/plans/repo_proxy.tf
+++ b/plans/repo_proxy.tf
@@ -4,29 +4,31 @@
 # See: https://issues.jenkins-ci.org/browse/INFRA-1176
 
 resource "azurerm_resource_group" "repo-proxy" {
-    name     = "${var.prefix}repo-proxy"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}repo-proxy"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "repo-proxy" {
-    name                     = "${var.prefix}repoproxy"
-    resource_group_name      = "${azurerm_resource_group.repo-proxy.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    depends_on               = ["azurerm_resource_group.repo-proxy"]
-    tags {
-        env = "${var.prefix}"
-    }
+  name                     = "${var.prefix}repoproxy"
+  resource_group_name      = "${azurerm_resource_group.repo-proxy.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.repo-proxy"]
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_share" "repo-proxy" {
-    name = "repo-proxy"
-    resource_group_name     = "${azurerm_resource_group.repo-proxy.name}"
-    storage_account_name    = "${azurerm_storage_account.repo-proxy.name}"
-    quota                   = 200
-    depends_on              = ["azurerm_resource_group.repo-proxy","azurerm_storage_account.repo-proxy"]
+  name                 = "repo-proxy"
+  resource_group_name  = "${azurerm_resource_group.repo-proxy.name}"
+  storage_account_name = "${azurerm_storage_account.repo-proxy.name}"
+  quota                = 200
+  depends_on           = ["azurerm_resource_group.repo-proxy", "azurerm_storage_account.repo-proxy"]
 }

--- a/plans/reports.tf
+++ b/plans/reports.tf
@@ -5,34 +5,33 @@
 # See: https://issues.jenkins-ci.org/browse/INFRA-947
 
 resource "azurerm_resource_group" "reports" {
-    name     = "${var.prefix}-reports"
-    location = "${var.location}"
+  name     = "${var.prefix}-reports"
+  location = "${var.location}"
 }
 
 resource "azurerm_storage_account" "reports" {
-    name                     = "${var.prefix}jenkinsreports"
-    resource_group_name      = "${azurerm_resource_group.reports.name}"
+  name                = "${var.prefix}jenkinsreports"
+  resource_group_name = "${azurerm_resource_group.reports.name}"
 
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
 
-    custom_domain {
-        name = "${var.prefix == "prod" ? "reports.jenkins.io" : ""}"
-    }
+  custom_domain {
+    name = "${var.prefix == "prod" ? "reports.jenkins.io" : ""}"
+  }
 }
 
 resource "azurerm_storage_container" "reports" {
-    name                  = "reports"
-    resource_group_name   = "${azurerm_resource_group.reports.name}"
-    storage_account_name  = "${azurerm_storage_account.reports.name}"
-    container_access_type = "container"
+  name                  = "reports"
+  resource_group_name   = "${azurerm_resource_group.reports.name}"
+  storage_account_name  = "${azurerm_storage_account.reports.name}"
+  container_access_type = "container"
 }
 
 resource "azurerm_storage_share" "reports" {
-    name                  = "reports"
-    resource_group_name   = "${azurerm_resource_group.reports.name}"
-    storage_account_name  = "${azurerm_storage_account.reports.name}"
-    depends_on            = ["azurerm_resource_group.reports","azurerm_storage_account.reports"]
+  name                 = "reports"
+  resource_group_name  = "${azurerm_resource_group.reports.name}"
+  storage_account_name = "${azurerm_storage_account.reports.name}"
+  depends_on           = ["azurerm_resource_group.reports", "azurerm_storage_account.reports"]
 }
-

--- a/plans/updates_proxy.tf
+++ b/plans/updates_proxy.tf
@@ -5,28 +5,30 @@
 #
 
 resource "azurerm_resource_group" "updates-proxy" {
-    name     = "${var.prefix}updates-proxy"
-    location = "${var.location}"
-    tags {
-        env = "${var.prefix}"
-    }
+  name     = "${var.prefix}updates-proxy"
+  location = "${var.location}"
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_account" "updates-proxy" {
-    name                     = "${var.prefix}updatesproxy"
-    resource_group_name      = "${azurerm_resource_group.updates-proxy.name}"
-    location                 = "${var.location}"
-    account_tier             = "Standard"
-    account_replication_type = "GRS"
-    depends_on               = ["azurerm_resource_group.updates-proxy"]
-    tags {
-        env = "${var.prefix}"
-    }
+  name                     = "${var.prefix}updatesproxy"
+  resource_group_name      = "${azurerm_resource_group.updates-proxy.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  depends_on               = ["azurerm_resource_group.updates-proxy"]
+
+  tags {
+    env = "${var.prefix}"
+  }
 }
 
 resource "azurerm_storage_share" "updates-proxy" {
-    name = "updates-proxy"
-    resource_group_name     = "${azurerm_resource_group.updates-proxy.name}"
-    storage_account_name    = "${azurerm_storage_account.updates-proxy.name}"
-    depends_on              = ["azurerm_resource_group.updates-proxy","azurerm_storage_account.updates-proxy"]
+  name                 = "updates-proxy"
+  resource_group_name  = "${azurerm_resource_group.updates-proxy.name}"
+  storage_account_name = "${azurerm_storage_account.updates-proxy.name}"
+  depends_on           = ["azurerm_resource_group.updates-proxy", "azurerm_storage_account.updates-proxy"]
 }

--- a/plans/uplink.tf
+++ b/plans/uplink.tf
@@ -7,16 +7,18 @@
 # cfr. https://www.terraform.io/docs/providers/random/index.html
 resource "random_string" "uplink_db_password" {
   length = 16
-    keepers {
-      id = "${var.uplink_db_password_id}"
-    }
+
+  keepers {
+    id = "${var.uplink_db_password_id}"
+  }
 }
 
 resource "azurerm_resource_group" "uplink" {
   name     = "${var.prefix}uplink"
   location = "${var.location}"
+
   tags {
-      env = "${var.prefix}"
+    env = "${var.prefix}"
   }
 }
 
@@ -26,22 +28,22 @@ resource "azurerm_postgresql_server" "uplink" {
   resource_group_name = "${azurerm_resource_group.uplink.name}"
 
   sku {
-    name = "B_Gen5_2"
+    name     = "B_Gen5_2"
     capacity = 2
-    tier = "Basic"
-    family = "Gen5"
+    tier     = "Basic"
+    family   = "Gen5"
   }
 
   storage_profile {
-    storage_mb = 46080
+    storage_mb            = 46080
     backup_retention_days = 7
-    geo_redundant_backup = "Disabled"
+    geo_redundant_backup  = "Disabled"
   }
 
-  administrator_login = "uplinkadmin"
+  administrator_login          = "uplinkadmin"
   administrator_login_password = "${random_string.uplink_db_password.result}"
-  version = "10.0"
-  ssl_enforcement = "Disabled"
+  version                      = "10.0"
+  ssl_enforcement              = "Disabled"
 }
 
 resource "azurerm_postgresql_database" "uplink" {
@@ -51,4 +53,3 @@ resource "azurerm_postgresql_database" "uplink" {
   charset             = "UTF8"
   collation           = "English_United States.1252"
 }
-

--- a/plans/variables.tf
+++ b/plans/variables.tf
@@ -3,42 +3,47 @@ variable "client_id" {}
 variable "client_secret" {}
 variable "tenant_id" {}
 variable "prefix" {}
+
 variable "dockerregistrylocation" {
-    type    = "string"
-    default = "East US"
+  type    = "string"
+  default = "East US"
 }
+
 variable "location" {
-    type    = "string"
-    default = "East US 2"
+  type    = "string"
+  default = "East US 2"
 }
+
 # Port used for Puppet agents to connect to a Puppet master
 variable "puppet_master_port" {
-    default = 8140
+  default = 8140
 }
+
 # Define kubernetes agent instance size
 variable "k8s_agent_size" {
-    type = "string"
-    default = "Standard_D2_v2"
+  type    = "string"
+  default = "Standard_D2_v2"
 }
+
 # Define default ssh public key path used to provision new kubernetes agent
-variable "ssh_pubkey_path"{
-    type = "string"
-    default = "./ssh_key/id_rsa.pub"
+variable "ssh_pubkey_path" {
+  type    = "string"
+  default = "./ssh_key/id_rsa.pub"
 }
 
 variable "logslocation" {
-    type    = "string"
-    default = "East US"
+  type    = "string"
+  default = "East US"
 }
 
 # This variable is only use to trigger a new confluence database password
-variable "confluence_db_password_id"{
-    type = "string"
-    default = "2018082402"
+variable "confluence_db_password_id" {
+  type    = "string"
+  default = "2018082402"
 }
 
 # This variable is used to trigger a new uplink database password
-variable "uplink_db_password_id"{
-    type = "string"
-    default = "2018091501"
+variable "uplink_db_password_id" {
+  type    = "string"
+  default = "2018091501"
 }

--- a/plans/vnets-nsg.tf
+++ b/plans/vnets-nsg.tf
@@ -11,7 +11,6 @@
 #   65500       DenyAllInBound                  Any   Any       Any                 Any             Deny
 # https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#security-rules
 
-
 ## NETWORK SECURITY GROUPS
 ################################################################################
 # Allow pretty much any and all traffic into the development DMZ. Wild west!
@@ -123,7 +122,6 @@ resource "azurerm_network_security_rule" "public-data-tier-allow-puppet-outbound
   network_security_group_name = "${azurerm_network_security_group.public_data_tier.name}"
 }
 
-
 # NOTE: Currently empty to enable us to add security rules to this NSG at a
 # later date.
 resource "azurerm_network_security_group" "public_dmz_tier" {
@@ -191,4 +189,6 @@ resource "azurerm_network_security_group" "private_dmz_tier" {
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.private_prod.name}"
 }
+
 ################################################################################
+

--- a/plans/vnets.tf
+++ b/plans/vnets.tf
@@ -22,23 +22,24 @@
 #                        +----------------+
 #
 
-
 ## RESOURCE GROUPS
 ################################################################################
 resource "azurerm_resource_group" "public_prod" {
-    name     = "${var.prefix}-jenkins-public-prod"
-    location = "${var.location}"
+  name     = "${var.prefix}-jenkins-public-prod"
+  location = "${var.location}"
 }
-resource "azurerm_resource_group" "private_prod" {
-    name     = "${var.prefix}-jenkins-private-prod"
-    location = "${var.location}"
-}
-resource "azurerm_resource_group" "development" {
-    name     = "${var.prefix}-jenkins-development"
-    location = "${var.location}"
-}
-################################################################################
 
+resource "azurerm_resource_group" "private_prod" {
+  name     = "${var.prefix}-jenkins-private-prod"
+  location = "${var.location}"
+}
+
+resource "azurerm_resource_group" "development" {
+  name     = "${var.prefix}-jenkins-development"
+  location = "${var.location}"
+}
+
+################################################################################
 
 ## VIRTUAL NETWORKS
 ################################################################################
@@ -56,7 +57,7 @@ resource "azurerm_virtual_network" "public_prod" {
 # Jenkins masters, or other untrusted workloads which should be in the Public
 # Production VNet
 
-resource "azurerm_subnet" "public_dmz"{
+resource "azurerm_subnet" "public_dmz" {
   name                      = "dmz-tier"
   resource_group_name       = "${azurerm_resource_group.public_prod.name}"
   virtual_network_name      = "${azurerm_virtual_network.public_prod.name}"
@@ -72,7 +73,7 @@ resource "azurerm_subnet_network_security_group_association" "public_dmz" {
 # The "data-tier" subnet is for data services which we might choose to run
 # ourselves that shouldn't have public IP addresses but accessible from within
 # the Public Production network
-resource "azurerm_subnet" "public_data"{
+resource "azurerm_subnet" "public_data" {
   name                      = "data-tier"
   resource_group_name       = "${azurerm_resource_group.public_prod.name}"
   virtual_network_name      = "${azurerm_virtual_network.public_prod.name}"
@@ -86,7 +87,7 @@ resource "azurerm_subnet_network_security_group_association" "public_data" {
 }
 
 # "app-tier" hosts should expect to be accessible from the public internet
-resource "azurerm_subnet" "public_app"{
+resource "azurerm_subnet" "public_app" {
   name                      = "app-tier"
   resource_group_name       = "${azurerm_resource_group.public_prod.name}"
   virtual_network_name      = "${azurerm_virtual_network.public_prod.name}"
@@ -99,7 +100,7 @@ resource "azurerm_subnet_network_security_group_association" "public_app" {
   network_security_group_id = "${azurerm_network_security_group.public_app_tier.id}"
 }
 
-resource "azurerm_subnet" "publick8s"{
+resource "azurerm_subnet" "publick8s" {
   name                      = "publick8s"
   resource_group_name       = "${azurerm_resource_group.public_prod.name}"
   virtual_network_name      = "${azurerm_virtual_network.public_prod.name}"
@@ -111,7 +112,6 @@ resource "azurerm_subnet_network_security_group_association" "publick8s" {
   subnet_id                 = "${azurerm_subnet.publick8s.id}"
   network_security_group_id = "${azurerm_network_security_group.public_data_tier.id}"
 }
-
 
 # The Private Production VNet is where all management and highly classified
 # resources should be provisioned. It should never have its resources exposed
@@ -136,7 +136,6 @@ resource "azurerm_subnet_network_security_group_association" "private_mgmt_tier"
   network_security_group_id = "${azurerm_network_security_group.private_mgmt_tier.id}"
 }
 
-
 resource "azurerm_subnet" "private_data_tier" {
   name                      = "data-tier"
   resource_group_name       = "${azurerm_resource_group.private_prod.name}"
@@ -153,10 +152,10 @@ resource "azurerm_subnet_network_security_group_association" "private_data_tier"
 # Peer the Public and Private Production networks, using the Private Production
 # resource group for holding the VNet Peer
 resource "azurerm_virtual_network_peering" "pub_to_priv_peer" {
-    name                      = "${var.prefix}-public-to-private-peer"
-    resource_group_name       = "${azurerm_resource_group.private_prod.name}"
-    virtual_network_name      = "${azurerm_virtual_network.private_prod.name}"
-    remote_virtual_network_id = "${azurerm_virtual_network.public_prod.id}"
+  name                      = "${var.prefix}-public-to-private-peer"
+  resource_group_name       = "${azurerm_resource_group.private_prod.name}"
+  virtual_network_name      = "${azurerm_virtual_network.private_prod.name}"
+  remote_virtual_network_id = "${azurerm_virtual_network.public_prod.id}"
 }
 
 # The development VNet should be largely considered entirely on its own and
@@ -185,3 +184,4 @@ resource "azurerm_subnet_network_security_group_association" "development_dmz_ti
 }
 
 ################################################################################
+


### PR DESCRIPTION
This PR removed the wildcard DNS record '*.jx.release.alpha.jenkins.io' and replace it with two new records, `[release.repo.jenkins.io](https://release.repo.jenkins.io)` and `[release.ci.jenkins.io](https://release.repo.jenkins.io)`.
Those two records follow the same pattern than the other endpoint like ci.jenkins.io, cert.ci, trusted.ci,...

While initially I wanted to be able to use dynamic dns records for short lived environments, I am now convinced that  for long lived environments, we must use well defined DNS records and the release environment will be a long lived environment. 

Just keep in mind that in the current state, this environment is reachable to everybody who has access to the vpn network and will be move in a more secure place.


PS: Starting from now, this pr also test if terraform plans follow the same format than `terraform fmt`