### PR TITLE
Allways return true when initiating remote backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,6 @@ prepare:
 	for file in variables provider remote-state; do \
 		cp plans/$$file.tf $(TFSTATE_PREPARE_DIR); \
 	done;
-	cd $(TFSTATE_PREPARE_DIR) && ../$(TERRAFORM) init &&  ../$(TERRAFORM) apply -var-file=$(VARFILE) -auto-approve=true
+	cd $(TFSTATE_PREPARE_DIR) && ../$(TERRAFORM) init &&  ../$(TERRAFORM) apply -var-file=$(VARFILE) -auto-approve=true -refresh=true || true
 	sleep 90
 

--- a/plans/publick8s.tf
+++ b/plans/publick8s.tf
@@ -6,7 +6,7 @@ resource "random_string" "publick8s_windows_admin_password" {
   lenght = 16
 
   keepers {
-    id = "${var.publickk8s_windows_admin_password}"
+    id = "${var.publick8s_windows_admin_password}"
   }
 }
 


### PR DESCRIPTION
`make prepare` is currently broken because trying to create a storage account that already exist return an error as showned in the following snippet

```
containers.Client#Create: Failure sending request: StatusCode=409 -- Original Error: Error occurred unmarshalling JSON - Error = 'invalid character '<' looking for beginning of value' JSON = '<?xml version="1.0" encoding="utf-8"?><Error><Code>ContainerAlreadyExists</Code><Message>The specified container already exists.
``` 