### PR TITLE
azurerm_kubernetes_cluster.publick8s: agent_pool_profile.1.node_taint…

### DIFF
--- a/plans/publick8s.tf
+++ b/plans/publick8s.tf
@@ -78,7 +78,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     min_count           = 1
     max_count           = 3
     max_pods            = 200
-    node_taints         = "os=windows:NoSchedule"
+    node_taints         = ["os=windows:NoSchedule"]
   }
 
   windows_profile {


### PR DESCRIPTION
…s: must be a list