### PR TITLE
Upgrade provider, use node pool resource

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -36,12 +36,11 @@ locals {
 
     # Azure
     ldap              = "52.232.180.203"
-    cn                = "159.138.4.250"  # Chinese jenkins.io hosted Huawei China
     azure.ci          = "104.208.238.39"
     ci                = "104.208.238.39"
     gateway.evergreen = "137.116.80.151"
     private.aks       = "10.0.2.5"
-    public.aks        = "40.70.215.138"
+    public.aks        = "52.147.174.4"
   }
 
   jenkinsio_aaaa_records = {
@@ -55,7 +54,7 @@ locals {
     accounts      = "nginx.azure.jenkins.io"
     nginx.azure   = "jenkins.io"
     javadoc       = "nginx.azure.jenkins.io"
-    plugins       = "nginx.azure.jenkins.io"
+    plugins       = "public.aks.jenkins.io"
     repo.azure    = "nginx.azure.jenkins.io"
     updates.azure = "nginx.azure.jenkins.io"
     reports       = "nginx.azure.jenkins.io"
@@ -64,8 +63,13 @@ locals {
     uplink        = "nginx.azure.jenkins.io"
 
     # AKS
-    release.repo = "private.aks.jenkins.io"
-    release.ci   = "private.aks.jenkins.io"
+    release.repo    = "private.aks.jenkins.io"
+    release.ci      = "private.aks.jenkins.io"
+    release.pkg     = "private.aks.jenkins.io"
+    release.grafana = "private.aks.jenkins.io"
+    admin.polls     = "private.aks.jenkins.io"
+    private.dex     = "private.aks.jenkins.io"
+    polls           = "public.aks.jenkins.io"
 
     # CNAME Records
     pkg      = "mirrors.jenkins.io"

--- a/plans/provider.tf
+++ b/plans/provider.tf
@@ -2,7 +2,7 @@
 # https://releases.hashicorp.com/terraform-provider-azurerm/
 
 provider "azurerm" {
-  version         = "~> 1.33.0"
+  version         = "=1.37.0"
   subscription_id = "${var.subscription_id}"
   client_id       = "${var.client_id}"
   client_secret   = "${var.client_secret}"

--- a/plans/publick8s.tf
+++ b/plans/publick8s.tf
@@ -48,16 +48,15 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   location            = "${azurerm_resource_group.publick8s.location}"
   dns_prefix          = "${var.prefix}"
   resource_group_name = "${azurerm_resource_group.publick8s.name}"
-  kubernetes_version  = "1.14.6"                                       #az aks get-versions --location eastus --output table
+  kubernetes_version  = "1.14.8"                                       #az aks get-versions --location eastus --output table
 
   role_based_access_control {
     enabled = true
   }
 
-  agent_pool_profile {
+  default_node_pool {
     name                = "linux"
     vm_size             = "Standard_D4s_v3"
-    os_type             = "Linux"
     vnet_subnet_id      = "${azurerm_subnet.publick8s.id}" # ! Only one AKS per subnet
     os_disk_size_gb     = 100                              # It seems that terraform force a resource re-creation if size is not defined
     type                = "VirtualMachineScaleSets"
@@ -65,20 +64,6 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     min_count           = 1
     max_count           = 5
     max_pods            = 200                              # Private IPs pool for a node will be reserved at node creation
-  }
-
-  agent_pool_profile {
-    name                = "win"
-    vm_size             = "Standard_D4s_v3"
-    os_type             = "Windows"
-    vnet_subnet_id      = "${azurerm_subnet.publick8s.id}"
-    os_disk_size_gb     = 200
-    type                = "VirtualMachineScaleSets"
-    enable_auto_scaling = true
-    min_count           = 1
-    max_count           = 3
-    max_pods            = 200
-    node_taints         = ["os=windows:NoSchedule"]
   }
 
   windows_profile {
@@ -119,6 +104,43 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   }
 }
 
+resource "azurerm_kubernetes_cluster_node_pool" "highmem" {
+  name                  = "highmemlinux"
+  kubernetes_cluster_id = "${azurerm_kubernetes_cluster.publick8s.id}"
+  vm_size               = "Standard_D8s_v3"
+  enable_auto_scaling   = true
+  node_count            = 1
+  max_pods              = 200
+
+  node_taints = [
+    "os=linux:NoSchedule",
+    "profile=highmem:NoSchedule",
+  ]
+
+  os_disk_size_gb = 100
+  os_type         = "Linux"
+  vnet_subnet_id  = "${azurerm_subnet.publick8s.id}"
+
+  min_count = 1
+  max_count = 5
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "windows" {
+  name                  = "win"
+  kubernetes_cluster_id = "${azurerm_kubernetes_cluster.publick8s.id}"
+  vm_size               = "Standard_D4s_v3"
+  enable_auto_scaling   = true
+  node_count            = 1
+  max_pods              = 200
+  node_taints           = ["os=windows:NoSchedule"]
+  os_disk_size_gb       = 200
+  os_type               = "Windows"
+  vnet_subnet_id        = "${azurerm_subnet.publick8s.id}"
+
+  min_count = 1
+  max_count = 3
+}
+
 resource "azurerm_role_assignment" "publick8s" {
   scope                = "/subscriptions/${var.subscription_id}/resourceGroups/${azurerm_resource_group.publick8s.name}"
   role_definition_name = "Network Contributor"
@@ -127,12 +149,12 @@ resource "azurerm_role_assignment" "publick8s" {
 
 # Public IP used by the loadbalancer gw
 resource "azurerm_public_ip" "publick8s" {
-  depends_on                   = ["azurerm_kubernetes_cluster.publick8s"]
-  name                         = "${var.prefix}gw-publick8s"
-  location                     = "${var.location}"
-  resource_group_name          = "${azurerm_resource_group.publick8s.name}"
-  public_ip_address_allocation = "Static"
-  idle_timeout_in_minutes      = 30
+  depends_on              = ["azurerm_kubernetes_cluster.publick8s"]
+  name                    = "${var.prefix}gw-publick8s"
+  location                = "${var.location}"
+  resource_group_name     = "${azurerm_resource_group.publick8s.name}"
+  allocation_method       = "Static"
+  idle_timeout_in_minutes = 30
 
   tags {
     environment = "${var.prefix}"


### PR DESCRIPTION
I've taken a look at https://github.com/jenkins-infra/azure/pull/121 as discussed here:
https://issues.jenkins-ci.org/browse/INFRA-2357?focusedCommentId=380742&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-380742

The specific error appears to be:
https://github.com/jenkins-infra/azure/pull/121/files#r352280744

But it's probably worth upgrading to the node pool resource 
See the release notes on  why agent_pool_profile is deprecated and  replaced with `azurerm_kubernetes_cluster_node_pool` and  `default_node_pool`
https://github.com/terraform-providers/terraform-provider-azurerm/releases/tag/v1.37.0
