### PR TITLE
Disable hns

### DIFF
--- a/plans/remote-state.tf
+++ b/plans/remote-state.tf
@@ -33,6 +33,7 @@ resource "azurerm_storage_account" "tfstate_datadog" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   enable_blob_encryption   = true
+  is_hns_enabled           = false
 }
 
 resource "azurerm_storage_container" "tfstate_datadog" {

--- a/plans/remote-state.tf
+++ b/plans/remote-state.tf
@@ -16,6 +16,7 @@ resource "azurerm_storage_account" "tfstate" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
   enable_blob_encryption   = true
+  is_hns_enabled           = false
 }
 
 resource "azurerm_storage_container" "tfstate" {


### PR DESCRIPTION
build is failing due to trying to update a property that can't be updated

[2019-12-11T16:04:30.828Z] * azurerm_storage_account.tfstate_datadog: Error creating Azure Storage Account "infracitfstatedatadog": storage.AccountsClient#Create: Failure sending request: StatusCode=400 -- Original Error: Code="AccountPropertyCannotBeUpdated" Message="The property 'isHnsEnabled' was specified in the input, but it cannot be updated."