### PR TITLE
[INFRA-1797] Update various DNS record

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -35,12 +35,12 @@ locals {
     usage   = "52.204.62.78"
 
     # Azure
-    ldap              = "40.70.191.84"
-    azure.ci          = "104.208.238.39"
-    ci                = "104.208.238.39"
-    private.aks       = "10.0.2.5"
-    public.aks        = "52.147.174.4"
-    nginx.azure       = "40.79.70.97"
+    ldap        = "40.70.191.84"
+    azure.ci    = "104.208.238.39"
+    ci          = "104.208.238.39"
+    private.aks = "10.0.2.5"
+    public.aks  = "52.147.174.4"
+    nginx.azure = "40.79.70.97"
   }
 
   jenkinsio_aaaa_records = {

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -35,10 +35,9 @@ locals {
     usage   = "52.204.62.78"
 
     # Azure
-    ldap              = "52.232.180.203"
+    ldap              = "40.70.191.84"
     azure.ci          = "104.208.238.39"
     ci                = "104.208.238.39"
-    gateway.evergreen = "137.116.80.151"
     private.aks       = "10.0.2.5"
     public.aks        = "52.147.174.4"
     nginx.azure       = "40.79.70.97"
@@ -52,15 +51,14 @@ locals {
 
   jenkinsio_cname_records = {
     # Azure
-    accounts      = "nginx.azure.jenkins.io"
+    accounts      = "public.aks.jenkins.io"
     javadoc       = "public.aks.jenkins.io"
     plugins       = "public.aks.jenkins.io"
     repo.azure    = "nginx.azure.jenkins.io"
     updates.azure = "nginx.azure.jenkins.io"
     reports       = "public.aks.jenkins.io"
     www           = "jenkins.io"
-    evergreen     = "nginx.azure.jenkins.io"
-    uplink        = "nginx.azure.jenkins.io"
+    uplink        = "public.aks.jenkins.io"
 
     # AKS
     release.repo      = "private.aks.jenkins.io"


### PR DESCRIPTION
This pull request is related to different works
* Ldap migration [[INFRA-2364](https://issues.jenkins-ci.org/browse/INFRA-2364)]
* Account app migration [[INFRA-2360](https://issues.jenkins-ci.org/browse/INFRA-2360)]
* Uplink migration [[INFRA-2363](https://issues.jenkins-ci.org/browse/INFRA-2363)]
* Evergreen is deprecated [[INFRA-2362](https://issues.jenkins-ci.org/browse/INFRA-2362)]
* Release.mirrors is currently an experiment with https://github.com/etix/mirrorbits to replace mirrorbrain

! This Pr can only be merge on Monday the 20th of January at 8AM (UTC) as announced [here](http://lists.jenkins-ci.org/pipermail/jenkins-infra/2020-January/001900.html)