### PR TITLE
Add new dns record set to ci.j.io private ip

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -215,3 +215,11 @@ resource "azurerm_dns_a_record" "certci" {
   ttl                 = 3600
   records             = ["${azurerm_network_interface.certci_private.private_ip_address}"]
 }
+
+resource "azurerm_dns_a_record" "ciprivate" {
+  name                = "ci.private.jenkins.io"
+  zone_name           = "${azurerm_dns_zone.jenkinsio.name}"
+  resource_group_name = "${azurerm_resource_group.dns_jenkinsio.name}"
+  ttl                 = 3600
+  records             = ["${azurerm_network_interface.ci_public.private_ip_address}"]
+}


### PR DESCRIPTION
Now that we have a working VPN, it doesn't make sense anymore to allow ssh connection on public IPs
This change create a new dns record to get ci.j.io private IPs