### PR TITLE
Add two share storages: mirrors & archives 

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -44,6 +44,7 @@ locals {
   jenkinsio_cname_records = {
     # Azure
     accounts = "public.aks.jenkins.io"
+    get      = "public.aks.jenkins.io"
     javadoc  = "public.aks.jenkins.io"
     plugins  = "public.aks.jenkins.io"
     reports  = "public.aks.jenkins.io"

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -43,13 +43,14 @@ locals {
 
   jenkinsio_cname_records = {
     # Azure
-    accounts = "public.aks.jenkins.io"
-    get      = "public.aks.jenkins.io"
-    javadoc  = "public.aks.jenkins.io"
-    plugins  = "public.aks.jenkins.io"
-    reports  = "public.aks.jenkins.io"
-    www      = "jenkins.io"
-    uplink   = "public.aks.jenkins.io"
+    accounts       = "public.aks.jenkins.io"
+    archives.azure = "public.aks.jenkins.io"
+    get            = "public.aks.jenkins.io"
+    javadoc        = "public.aks.jenkins.io"
+    plugins        = "public.aks.jenkins.io"
+    reports        = "public.aks.jenkins.io"
+    www            = "jenkins.io"
+    uplink         = "public.aks.jenkins.io"
 
     # AKS
     "release.repo"      = "private.aks.jenkins.io"

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -43,14 +43,14 @@ locals {
 
   jenkinsio_cname_records = {
     # Azure
-    accounts       = "public.aks.jenkins.io"
-    archives.azure = "public.aks.jenkins.io"
-    get            = "public.aks.jenkins.io"
-    javadoc        = "public.aks.jenkins.io"
-    plugins        = "public.aks.jenkins.io"
-    reports        = "public.aks.jenkins.io"
-    www            = "jenkins.io"
-    uplink         = "public.aks.jenkins.io"
+    accounts         = "public.aks.jenkins.io"
+    "archives.azure" = "public.aks.jenkins.io"
+    get              = "public.aks.jenkins.io"
+    javadoc          = "public.aks.jenkins.io"
+    plugins          = "public.aks.jenkins.io"
+    reports          = "public.aks.jenkins.io"
+    www              = "jenkins.io"
+    uplink           = "public.aks.jenkins.io"
 
     # AKS
     "release.repo"      = "private.aks.jenkins.io"

--- a/plans/releases-storage.tf
+++ b/plans/releases-storage.tf
@@ -192,3 +192,8 @@ resource "azurerm_storage_container" "osx-rc" {
 }
 
 #########################################
+
+resource "azurerm_storage_share" "mirrorbits" {
+  name                 = "mirrorbits"
+  storage_account_name = "${azurerm_storage_account.releases.name}"
+}

--- a/plans/releases-storage.tf
+++ b/plans/releases-storage.tf
@@ -197,3 +197,9 @@ resource "azurerm_storage_share" "mirrorbits" {
   name                 = "mirrorbits"
   storage_account_name = "${azurerm_storage_account.releases.name}"
 }
+
+resource "azurerm_storage_share" "archives" {
+  name                 = "archives"
+  storage_account_name = "${azurerm_storage_account.releases.name}"
+}
+


### PR DESCRIPTION
This pull request defined two DNS records and share storages needed by services running on Kubernetes

* Dns record `get.jenkins.io`  and azure file storage needed for [PR#122](https://github.com/jenkins-infra/charts/pull/122) 

* Dns record `archives.azure.jenkins.io` and azure file storage needed for [PR#130](https://github.com/jenkins-infra/charts/pull/130)

In both cases the data need to be pushed from [here](https://github.com/jenkins-infra/jenkins-infra/blob/8ecc23a590eacddb50e784aeb503f7b9af63d866/dist/profile/files/mirrorbrain/sync.sh#L49)
using **blobxfer**