### PR TITLE
Add TXT record to validate Fastly certificate

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -48,7 +48,7 @@ locals {
     "mirror.azure"   = "public.aks.jenkins.io"
     get              = "public.aks.jenkins.io"
     javadoc          = "public.aks.jenkins.io"
-    plugins          = "public.aks.jenkins.io"
+    plugins          = "d.sni.global.fastly.net"
     reports          = "public.aks.jenkins.io"
     www              = "jenkins.io"
     uplink           = "public.aks.jenkins.io"
@@ -62,6 +62,11 @@ locals {
     "admin.polls"       = "private.aks.jenkins.io"
     "private.dex "      = "private.aks.jenkins.io"
     polls               = "public.aks.jenkins.io"
+
+    # Fastly
+    "_acme-challenge.plugins" = "tr8qxfomlsxfq1grha.fastly-validations.com"
+    "_acme-challenge" = "ohh97689e0dknl1rqp.fastly-validations.com"
+
     # CNAME Records
     pkg      = "mirrors.jenkins.io"
     puppet   = "radish.jenkins.io"

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -157,6 +157,10 @@ resource "azurerm_dns_txt_record" "jenkinsio_txt_root_entries" {
   record {
     value = "v=spf1 include:mailgun.org ~all"
   }
+
+  record {
+    value = "_globalsign-domain-verification=b1pmSjP4FyG8hkZunkD3Aoz8tK0FWCje80-YwtLeDU" # Fastly
+  }
 }
 
 resource "azurerm_dns_txt_record" "jenkinsio_txt_azure_entries" {

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -159,6 +159,18 @@ resource "azurerm_dns_txt_record" "jenkinsio_txt_root_entries" {
   }
 }
 
+resource "azurerm_dns_txt_record" "jenkinsio_txt_azure_entries" {
+  name                = "azure"
+  zone_name           = azurerm_dns_zone.jenkinsio.name
+  resource_group_name = azurerm_resource_group.dns_jenkinsio.name
+  ttl                 = 3600
+
+  record {
+    value = "MS=ms77162642"
+  }
+
+}
+
 resource "azurerm_dns_mx_record" "jenkinsio_mx_entries" {
   name                = "@"
   zone_name           = azurerm_dns_zone.jenkinsio.name


### PR DESCRIPTION
Align with manual modification done on portal.azure.com

Second txt record was to validate the azure active directory domain "azure.jenkins.io"