### PR TITLE
Add GSoC 2020 Custom distribution service dns

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -43,15 +43,16 @@ locals {
 
   jenkinsio_cname_records = {
     # Azure
-    accounts         = "public.aks.jenkins.io"
-    "archives.azure" = "public.aks.jenkins.io"
-    "mirror.azure"   = "public.aks.jenkins.io"
-    get              = "public.aks.jenkins.io"
-    javadoc          = "public.aks.jenkins.io"
-    plugins          = "dualstack.d.sni.global.fastly.net"
-    reports          = "public.aks.jenkins.io"
-    www              = "dualstack.d.sni.global.fastly.net"
-    uplink           = "public.aks.jenkins.io"
+    accounts              = "public.aks.jenkins.io"
+    "archives.azure"      = "public.aks.jenkins.io"
+    "mirror.azure"        = "public.aks.jenkins.io"
+    get                   = "public.aks.jenkins.io"
+    javadoc               = "public.aks.jenkins.io"
+    plugins               = "dualstack.d.sni.global.fastly.net"
+    reports               = "public.aks.jenkins.io"
+    www                   = "dualstack.d.sni.global.fastly.net"
+    uplink                = "public.aks.jenkins.io"
+    distribution_service
 
     # AKS
     "release.repo"      = "private.aks.jenkins.io"


### PR DESCRIPTION
This PR aims to add the new custom domain name for the [custom distribution service project](https://www.jenkins.io/projects/gsoc/2020/projects/custom-jenkins-distribution-build-service/) as per the discussion in [this google group](https://groups.google.com/g/jenkins-infra/c/v3UJfiFte8w/m/f-akpW0iAwAJ)
Gitter Chat: https://gitter.im/jenkinsci/jenkins-custom-distribution-service