### PR TITLE
Add CNAME record charts.jenkins.io

### DIFF
--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -77,6 +77,7 @@ locals {
     patron   = "jenkins-infra.github.io"
     wiki     = "lettuce.jenkins.io"
     issues   = "edamame.jenkins.io"
+    charts   = "jenkinsci.github.io"
     # Magical CNAME for certificate validation
     "D07F852F584FA592123140354D366066.ldap" = "75E741181A7ACDBE2996804B2813E09B65970718.comodoca.com"
     # Amazon SES configuration to send out email from noreply@jenkins.io

--- a/plans/dns_jenkinsio.tf
+++ b/plans/dns_jenkinsio.tf
@@ -66,7 +66,7 @@ locals {
 
     # Fastly
     "_acme-challenge.plugins" = "tr8qxfomlsxfq1grha.fastly-validations.com"
-    "_acme-challenge" = "ohh97689e0dknl1rqp.fastly-validations.com"
+    "_acme-challenge"         = "ohh97689e0dknl1rqp.fastly-validations.com"
 
     # CNAME Records
     pkg      = "dualstack.d.sni.global.fastly.net"


### PR DESCRIPTION
As suggested by @timja in https://github.com/jenkinsci/helm-charts/pull/1#discussion_r477222318
this adds a CNAME record which points to helm charts

Part-of: jenkinsci/helm-charts#14