### PR TITLE
feat(public-pgsql) add a postgresql flexible server instance for the public applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .tf-remote-state-enabled
 .terraform
 backend-config
+terraform-plan-output.txt

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,58 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "2.99.0"
+  hashes = [
+    "h1:/ZY1j8YgB5GeqPnjT8avyRFjUcGH3rCk1xGLKcUCtWc=",
+    "zh:08d81e72e97351538ab4d15548942217bf0c4d3b79ad3f4c95d8f07f902d2fa6",
+    "zh:11fdfa4f42d6b6f01371f336fea56f28a1db9e7b490c5ca0b352f6bbca5a27f1",
+    "zh:12376e2c4b56b76098d5d713d1a4e07e748a926c4d165f0bd6f52157b1f7a7e9",
+    "zh:31f1cb5b88ed1307625050e3ee7dd9948773f522a3f3bf179195d607de843ea3",
+    "zh:767971161405d38412662a73ea40a422125cdc214c72fbc569bcfbea6e66c366",
+    "zh:973c402c3728b68c980ea537319b703c009b902a981b0067fbc64e04a90e434c",
+    "zh:9ec62a4f82ec1e92bceeff80dd8783f61de0a94665c133f7c7a7a68bda9cdbd6",
+    "zh:bbb3b7e1229c531c4634338e4fc81b28bce58312eb843a931a4420abe42d5b7e",
+    "zh:cbbe02cd410d21476b3a081b5fa74b4f1b3d9d79b00214009028d60e859c19a3",
+    "zh:cc00ecc7617a55543b60a0da1196ea92df48c399bcadbedf04c783e3d47c6e08",
+    "zh:eecb9fd0e7509c7fd4763e546ef0933f125770cbab2b46152416e23d5ec9dd53",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.2"
+  hashes = [
+    "h1:SjDyZXIUHEQzZe10VjhlhZq2a9kgQB6tmqJcpq2BeWg=",
+    "zh:027e4873c69da214e2fed131666d5de92089732a11d096b68257da54d30b6f9d",
+    "zh:0ba2216e16cfb72538d76a4c4945b4567a76f7edbfef926b1c5a08d7bba2a043",
+    "zh:1fee8f6aae1833c27caa96e156cf99a681b6f085e476d7e1b77d285e21d182c1",
+    "zh:2e8a3e72e877003df1c390a231e0d8e827eba9f788606e643f8e061218750360",
+    "zh:719008f9e262aa1523a6f9132adbe9eee93c648c2981f8359ce41a40e6425433",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9a70fdbe6ef955c4919a4519caca116f34c19c7ddedd77990fbe4f80fe66dc84",
+    "zh:abc412423d670cbb6264827fa80e1ffdc4a74aff3f19ba6a239dd87b85b15bec",
+    "zh:ae953a62c94d2a2a0822e5717fafc54e454af57bd6ed02cd301b9786765c1dd3",
+    "zh:be0910bdf46698560f9e86f51a4ff795c62c02f8dc82b2b1dab77a0b3a93f61e",
+    "zh:e58f9083b7971919b95f553227adaa7abe864fce976f0166cf4d65fc17257ff2",
+    "zh:ff4f77cbdbb22cc98182821c7ef84dce16298ab0e997d5c7fae97247f7a4bcb0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.2"
+  hashes = [
+    "h1:9A6Ghjgad0KjJRxa6nPo8i8uFvwj3Vv0wnEgy49u+24=",
+    "zh:0daceba867b330d3f8e2c5dc895c4291845a78f31955ce1b91ab2c4d1cd1c10b",
+    "zh:104050099efd30a630741f788f9576b19998e7a09347decbec3da0b21d64ba2d",
+    "zh:173f4ef3fdf0c7e2564a3db0fac560e9f5afdf6afd0b75d6646af6576b122b16",
+    "zh:41d50f975e535f968b3f37170fb07937c15b76d85ba947d0ce5e5ff9530eda65",
+    "zh:51a5038867e5e60757ed7f513dd6a973068241190d158a81d1b69296efb9cb8d",
+    "zh:6432a568e97a5a36cc8aebca5a7e9c879a55d3bc71d0da1ab849ad905f41c0be",
+    "zh:6bac6501394b87138a5e17c9f3a41e46ff7833ad0ba2a96197bb7787e95b641c",
+    "zh:6c0a7f5faacda644b022e7718e53f5868187435be6d000786d1ca05aa6683a25",
+    "zh:74c89de3fa6ef3027efe08f8473c2baeb41b4c6cee250ba7aeb5b64e8c79800d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b29eabbf0a5298f0e95a1df214c7cfe06ea9bcf362c63b3ad2f72d85da7d4685",
+    "zh:e891458c7a61e5b964e09616f1a4f87d0471feae1ec04cc51776e7dec1a3abce",
+  ]
+}

--- a/pgsql.tf
+++ b/pgsql.tf
@@ -1,0 +1,23 @@
+################################################################################
+## Public Network
+################################################################################
+resource "random_password" "pgsql_admin_login" {
+  length  = 14
+  special = false
+  upper   = false
+}
+
+resource "random_password" "pgsql_admin_password" {
+  length = 24
+}
+
+resource "azurerm_postgresql_flexible_server" "public" {
+  name                   = "public"
+  resource_group_name    = data.azurerm_resource_group.public_prod.name
+  location               = var.location
+  administrator_login    = "psqladmin${random_password.pgsql_admin_login.result}"
+  administrator_password = random_password.pgsql_admin_password.result
+  sku_name               = "B_Standard_B1ms" # 1vCore / 2 Gb - https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable
+  storage_mb             = "32768"
+  version                = "13"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,4 @@
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,4 @@
+variable "location" {
+  type    = string
+  default = "East US 2"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 1.1, <1.2"
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}

--- a/vnets-nsg.tf
+++ b/vnets-nsg.tf
@@ -1,0 +1,8 @@
+################################################################################
+## Public Network
+################################################################################
+resource "azurerm_network_security_group" "public_pgsql_tier" {
+  name                = "public-network-pgsql-tier"
+  location            = var.location
+  resource_group_name = data.azurerm_resource_group.public_prod.name
+}

--- a/vnets.tf
+++ b/vnets.tf
@@ -1,0 +1,55 @@
+#
+# This terraform plan defines the resources necessary to provision the Virtual
+# Networks in Azure according to IEP-002:
+#   <https://github.com/jenkins-infra/iep/tree/master/iep-002>
+#
+#                        +---------------------+
+#                        |                     |
+#      +---------------> |  Public Production  <-------+
+#      |                 |                     |       |
+#      |                 +---------------------+     VNet Peering
+#      |                                               |
+#      |                                 +-------------v--------+
+#                        +-------------+ |                      |
+# The Internet --------> + VPN Gateway |-|  Private Production  |
+#                        +-------------+ |                      |
+#      |                                 +----------------------+
+#      |
+#      |                 +----------------+
+#      |                 |                |
+#      +---------------> |   Development  |
+#                        |                |
+#                        +----------------+
+#
+## RESOURCE GROUPS
+################################################################################
+data "azurerm_resource_group" "public_prod" {
+  name = "prod-jenkins-public-prod"
+}
+
+################################################################################
+## VIRTUAL NETWORKS
+################################################################################
+data "azurerm_virtual_network" "public_prod" {
+  name                = "prod-jenkins-public-prod"
+  resource_group_name = data.azurerm_resource_group.public_prod.name
+  # address_space       = ["10.0.0.0/16"]
+}
+
+################################################################################
+## SUB NETWORKS
+################################################################################
+
+# "pgsql-tier" subnet is reserved as "delegated" for the pgsql server on the public network
+# Ref. https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking
+resource "azurerm_subnet" "pgsql_tier" {
+  name                 = "pgsql-tier"
+  resource_group_name  = data.azurerm_resource_group.public_prod.name
+  virtual_network_name = data.azurerm_virtual_network.public_prod.name
+  address_prefixes     = ["10.0.3.0/24"]
+}
+
+resource "azurerm_subnet_network_security_group_association" "public_pgsql" {
+  subnet_id                 = azurerm_subnet.pgsql_tier.id
+  network_security_group_id = azurerm_network_security_group.public_pgsql_tier.id
+}


### PR DESCRIPTION
Part of https://github.com/jenkins-infra/helpdesk/issues/1627 (migrating ratings.jenkins.io from AWS VM to Azure AKS).

This PR adds a postgresql flexible server for the public applications:

- with its own subnet since the azure documentation explains that it must be reserved ("delegated" subnet)
  - That subnet should not be reachable from the outside, and would only be allowed incoming connections from AKS subnet.
- Admin and password are generated by terraform (and stored in the encrypted backend state). Please note that the resources of kind `random_password` are considered as sensitive as per [its documentation](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) and their output hidden from the console log.
- For sizing, we took the default recommended burstable instance size with 1 vCPU and 2 Gb, with a data storage of 20 Gb
    - Current rating database in AWS is an RDS on a t2.micro (1vCPU/1Gb) with 5Gb of data, which is ~55% full
    - This postgres won't be only used for rating in the future, hence the instance size with more RAM and more storage.
    - Burstable serie to ensure that we can outperform the CPU when there is a peak without paying too much. That might need to grow based on metric on the future.
    - Please note that the most recent LTS version of postgres is used: v13.x
    - Choice of flexible (instead of single) to ensure we are using latest azure recommendations. HA is not enabled for now but it can be at any moment.


Please note the followings:
- This is a first iteration that we already tested successfully with @smerle33 and we destroyed it to ensure that it is created and maintained by the full infra-as-code process
- No database created yet for rating.jenkins.io (2nd iteration)
- The connectivity from AKS will be tested and eventually updated after the initial creation
- For now, the public network is only referenced as a "data". It will have to be imported and managed soon.