### PR TITLE
fix(public-pgsql) specify explicitly the zone as there are no HA (yet)

### DIFF
--- a/pgsql.tf
+++ b/pgsql.tf
@@ -20,4 +20,5 @@ resource "azurerm_postgresql_flexible_server" "public" {
   sku_name               = "B_Standard_B1ms" # 1vCore / 2 Gb - https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable
   storage_mb             = "32768"
   version                = "13"
+  zone                   = "1"
 }


### PR DESCRIPTION
Ref. https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/postgresql_flexible_server#zone

> Azure will automatically assign an Availability Zone if one is not specified. If the PostgreSQL Flexible Server fails-over to the Standby Availability Zone, the zone will be updated to reflect the current Primary Availability Zone. You can use [Terraform's ignore_changes functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the zone and high_availability.0.standby_availability_zone fields should you wish for Terraform to not migrate the PostgreSQL Flexible Server back to it's primary Availability Zone after a fail-over.