### PR TITLE
fix(public-pgsql) ensure that network links are created BEFORE dealing with pgsql resources and providers

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/cyrilgdn/postgresql" {
   version = "1.15.0"
   hashes = [
+    "h1:13MQju/jLYDpwIYjfClFA6X4nk7AouOdVFqzzEMGNC4=",
     "h1:TMVCi9Ju1gBeOm2N5Na+xOkEbePoPkY7RuktGOlRgBk=",
     "zh:047711b33daf269eb61e5ff572a78c3b28213fecfa7ebe85f2d30b2fd60dba4d",
     "zh:261a85f44d398833672232bded4ebc671222c28de8fc7bafb2ab68db299900a2",

--- a/pgsql.tf
+++ b/pgsql.tf
@@ -23,6 +23,15 @@ resource "azurerm_postgresql_flexible_server" "public" {
   zone                   = "1"
   private_dns_zone_id    = azurerm_private_dns_zone.public_pgsql.id
   delegated_subnet_id    = azurerm_subnet.pgsql_tier.id
+
+  depends_on = [
+    /**
+    The network link from private pod is required to allow the provider "postgresql"
+    to connect to this server from the private Jenkins agents where terraform runs
+    (or through VPN tunnelling)
+    **/
+    azurerm_private_dns_zone_virtual_network_link.privatevnet_to_publicpgsql,
+  ]
 }
 
 resource "azurerm_private_dns_zone" "public_pgsql" {

--- a/pgsql.tf
+++ b/pgsql.tf
@@ -38,3 +38,17 @@ resource "azurerm_private_dns_zone" "public_pgsql" {
   name                = "public-pgsql.jenkins-infra.postgres.database.azure.com"
   resource_group_name = data.azurerm_resource_group.public_prod.name
 }
+
+resource "azurerm_private_dns_zone_virtual_network_link" "publicvnet_to_publicpgsql" {
+  name                  = "publicvnet-to-publicpgsql"
+  resource_group_name   = data.azurerm_resource_group.public_prod.name
+  private_dns_zone_name = azurerm_private_dns_zone.public_pgsql.name
+  virtual_network_id    = data.azurerm_virtual_network.public_prod.id
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "privatevnet_to_publicpgsql" {
+  name                  = "privatevnet-to-publicpgsql"
+  resource_group_name   = data.azurerm_resource_group.public_prod.name
+  private_dns_zone_name = azurerm_private_dns_zone.public_pgsql.name
+  virtual_network_id    = data.azurerm_virtual_network.private_prod.id
+}

--- a/providers.tf
+++ b/providers.tf
@@ -4,10 +4,16 @@ provider "azurerm" {
 }
 
 provider "postgresql" {
-  # Configuration options
+  /**
+  Important: terraform must be allowed to reach this instance through the network. Check the followings:
+  - If running in Jenkins, ensure that the subnet of the agents is peered to the subnet of this pgsql instance
+    * Don't forget to also check the network security group rules
+  - If running locally, ensure that:
+    * your /etc/hosts defines an entry with <azurerm_postgresql_flexible_server.public.fqdn> to 127.0.0.1
+    * you've opened an SSH tunnel such as `-L 5432:<azurerm_postgresql_flexible_server.public.fqdn>:5432` through a machine of the private network
+  **/
   host      = azurerm_postgresql_flexible_server.public.fqdn
   username  = local.public_pgsql_admin_login
   password  = random_password.pgsql_admin_password.result
   superuser = false
 }
-

--- a/vnets.tf
+++ b/vnets.tf
@@ -67,17 +67,3 @@ resource "azurerm_subnet_network_security_group_association" "public_pgsql" {
   subnet_id                 = azurerm_subnet.pgsql_tier.id
   network_security_group_id = azurerm_network_security_group.public_pgsql_tier.id
 }
-
-resource "azurerm_private_dns_zone_virtual_network_link" "publicvnet_to_publicpgsql" {
-  name                  = "publicvnet-to-publicpgsql"
-  resource_group_name   = data.azurerm_resource_group.public_prod.name
-  private_dns_zone_name = azurerm_private_dns_zone.public_pgsql.name
-  virtual_network_id    = data.azurerm_virtual_network.public_prod.id
-}
-
-resource "azurerm_private_dns_zone_virtual_network_link" "privatevnet_to_publicpgsql" {
-  name                  = "privatevnet-to-publicpgsql"
-  resource_group_name   = data.azurerm_resource_group.private_prod.name
-  private_dns_zone_name = azurerm_private_dns_zone.public_pgsql.name
-  virtual_network_id    = data.azurerm_virtual_network.private_prod.id
-}


### PR DESCRIPTION
This PR fixes the errors on the principal branches with the following changes:

- Add an explicit dependency to the postgresql server instance that must be created AFTER the DNS private zone link from private network, to avoid egg and chicken problem when running terraform on jenkins agents of the private network
  - Fixes the error message `Host not found with X.X.X.X:53` on Jenkins
- Document (as a comment in the provider `postgres`) how to run terraform locally (with a SSH tunnel)
  - Fixes the error message `Host not found with X.X.X.X:53` locally
- Correct the DNS<->vnet link from private network: its resource group must be the same as the DNS private zone
  - Fix the error message `creating/updating Virtual Network Link "privatevnet-to-publicpgsql" (Private DNS Zone "public-pgsql.jenkins-infra.postgres.database.azure.com" / Resource Group "prod-jenkins-private-prod"): privatedns.VirtualNetworkLinksClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code="ParentResourceNotFound" Message="Can not perform requested operation on nested resource. Parent resource 'public-pgsql.jenkins-infra.postgres.database.azure.com' not found."`