### PR TITLE
Feat: track Azure VM Galleries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .terraform
 backend-config
 terraform-plan-output.txt
+tfplan

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,36 @@
 locals {
   public_pgsql_admin_login = "psqladmin${random_password.pgsql_admin_login.result}"
+
+  shared_galleries = {
+    "dev" = {
+      description = "Shared images built by pull requests in jenkins-infra/packer-images (consider it untrusted)."
+      rg_location = "eastus"
+      images_location = {
+        "ubuntu-20"    = "eastus"
+        "ubuntu-20.04" = "eastus"
+        "windows-2019" = "eastus"
+        "windows-2022" = "eastus"
+      }
+    }
+    "staging" = {
+      description = "Shared images built by the principal code branch in jenkins-infra/packer-images (ready to be tested)."
+      rg_location = "eastus"
+      images_location = {
+        "ubuntu-20"    = "eastus2"
+        "ubuntu-20.04" = "eastus"
+        "windows-2019" = "eastus2"
+        "windows-2022" = "eastus"
+      }
+    }
+    "prod" = {
+      description = "Shared images built by the releases in jenkins-infra/packer-images (⚠️ Used in production.)."
+      rg_location = "eastus2"
+      images_location = {
+        "ubuntu-20"    = "eastus2"
+        "ubuntu-20.04" = "eastus"
+        "windows-2019" = "eastus"
+        "windows-2022" = "eastus"
+      }
+    }
+  }
 }

--- a/packer-resources.tf
+++ b/packer-resources.tf
@@ -1,0 +1,58 @@
+# Azure Resources required or used by the repository jenkins-infra/packer-images
+
+## Dev Resources are used by the pull requests in jenkins-infra/packer-images
+resource "azurerm_resource_group" "packer_images" {
+  for_each = local.shared_galleries
+
+  name     = "${each.key}-packer-images"
+  location = each.value.rg_location
+}
+
+resource "azurerm_shared_image_gallery" "packer_images" {
+  for_each = local.shared_galleries
+
+  name                = "${each.key}_packer_images"
+  resource_group_name = azurerm_resource_group.packer_images[each.key].name
+  location            = "eastus" #azurerm_resource_group.packer_images[each.key].location
+  description         = each.value.description
+
+  tags = {
+    scope = "terraform-managed"
+  }
+}
+
+# Note that Terraform does NOT manage image versions (it's packer-based).
+resource "azurerm_shared_image" "jenkins_agent_images" {
+  # Generate a list of images in the form "<gallery name>_<image_name>"
+  for_each = toset(
+    distinct(
+      flatten([
+        for gallery_key, gallery_value in local.shared_galleries : [
+          for image_key, image_value in gallery_value.images_location : "${gallery_key}_${image_key}"
+        ]
+      ])
+    )
+  )
+
+  name                = format("jenkins-agent-%s", split("_", each.value)[1])
+  gallery_name        = azurerm_shared_image_gallery.packer_images[split("_", each.value)[0]].name
+  resource_group_name = azurerm_resource_group.packer_images[split("_", each.value)[0]].name
+  location            = local.shared_galleries[split("_", each.value)[0]].images_location[split("_", each.value)[1]]
+
+  hyper_v_generation     = "V2"
+  os_type                = length(regexall(".*windows.*", lower(split("_", each.value)[1]))) > 0 ? "Windows" : "Linux"
+  specialized            = false
+  trusted_launch_enabled = false
+
+  identifier {
+    publisher = format("jenkins-agent-%s", split("_", each.value)[1])
+    offer     = format("jenkins-agent-%s", split("_", each.value)[1])
+    sku       = format("jenkins-agent-%s", split("_", each.value)[1])
+  }
+
+  timeouts {}
+
+  tags = {
+    scope = "terraform-managed"
+  }
+}

--- a/vnets.tf
+++ b/vnets.tf
@@ -59,6 +59,9 @@ resource "azurerm_subnet" "pgsql_tier" {
     name = "pgsql"
     service_delegation {
       name = "Microsoft.DBforPostgreSQL/flexibleServers"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
     }
   }
 }


### PR DESCRIPTION
Follow up of https://github.com/jenkins-infra/packer-images/issues/232.

This PR adds tracking, by terraform, of the Azure VM Shared Library images.

- The 3 missing images will be  created once this PR is merged: `staging_ubuntu-20.04`, `staging_windows-2022`, `prod_windows-2022
- All the other shared library had been imported with `terraform import <...> <...>` commands in the production state
- Tags are added to all resource to help us tracking the terraform managed resources
- Please note that some elements are located in US East 2: it's a bit of a mess, because it's the production, and Azure refused to migrate these items to US East. As I did not want to break the production, I've used a local to map the regions per gallery and image: it adds a bit of complexity in the code alas


This PR also adds 2 "chore" changes:
- Updated the `gitignore` and `.shared-tools` to latest setttings
- Ensure that the pgsql's subnet is not updated on each terraform run, by fixing the changed setting