### PR TITLE
hotfix(updatecli) use latest jenkinsciinfra/hashicorp-tools

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -31,9 +31,10 @@ parallel(
     )
   },
   'updatecli': {
-    updatecli(action: 'diff')
+    def updatecliImage = 'jenkinsciinfra/hashicorp-tools:latest'
+    updatecli(action: 'diff', updatecliDockerImage: updatecliImage)
     if (env.BRANCH_IS_PRIMARY) {
-      updatecli(action: 'apply', cronTriggerExpression: '@daily')
+      updatecli(action: 'apply', cronTriggerExpression: '@daily', updatecliDockerImage: updatecliImage)
     }
   },
 )


### PR DESCRIPTION
- We need terraform for updatecli
- Using `latest` for now;: it will always work (and won't be too noisy)
- Long term: we should parse the project to get the latest version. Should be a reusable script from shared tools (so we can do the same trick on all terraform projects)