### PR TITLE
feat(reports.jenkins.io) Track the reports.jenkins.io bucket as per helpdesk 3087

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ This repository is meant to hold documentation, tooling and other resources
 related to the link:https://jenkins.io[Jenkins] project's migration to
 link:https://azure.com[Azure].
 
-= Requirements
+== Requirements
 
 In order to use this repository to provision the Jenkins infrastructure on azure, you need:
 
@@ -18,9 +18,9 @@ In order to use this repository to provision the Jenkins infrastructure on azure
 * `Docker` to run terraform defined in this repository
 * `Make` which simplify the different steps
 
-= HowTo
+== HowTo
 
-== Provision
+=== Provision
 
 IMPORTANT: Don't blindly execute the terraform code located in this repository on your own account as it may lead your account bill to significantly increase.
 
@@ -33,7 +33,7 @@ Once you fulfill the requirements, you can use the code located here to provisio
 . Run `make deploy`: to provision all resources on your account.
 
 
-== Test
+=== Test
 
 In order to test any modification on this repository, you need to
 
@@ -41,7 +41,7 @@ In order to test any modification on this repository, you need to
 * You may also run make validate, if you have an azure account configured but keep in minds that it implies deploying at least an azure storage to store a remote terraform state
 * Open a pull request on link:https://github.com/jenkins-infra/azure[jenkins-infra/azure], this will provision a temporary environment with your specific changes and then report provisionning logs on link:https://ci.jenkins.io/blue/organizations/jenkins/Infra%2Fazure/pr[ci.jenkins.io].
 
-= Links
+== Links
 
 * link:https://github.com/jenkins-infra/jenkins-infra[Puppet repository]
 * link:https://p.datadoghq.com/sb/0Igb9a-a5ff8c4199[Public Datadog Dashboard]

--- a/reports.jenkins.io.tf
+++ b/reports.jenkins.io.tf
@@ -1,7 +1,7 @@
 ## This file contains the resources associated to the buckets used to store private and public reports
 resource "azurerm_resource_group" "prod_reports" {
   name     = "prod-reports"
-  location = "East US 2"
+  location = var.location
 
   tags = {
     scope = "terraform-managed"

--- a/reports.jenkins.io.tf
+++ b/reports.jenkins.io.tf
@@ -1,0 +1,29 @@
+## This file contains the resources associated to the buckets used to store private and public reports
+resource "azurerm_resource_group" "prod_reports" {
+  name     = "prod-reports"
+  location = "East US 2"
+
+  tags = {
+    scope = "terraform-managed"
+  }
+}
+
+resource "azurerm_storage_account" "prodjenkinsreports" {
+  name                      = "prodjenkinsreports"
+  resource_group_name       = azurerm_resource_group.prod_reports.name
+  location                  = azurerm_resource_group.prod_reports.location
+  account_tier              = "Standard"
+  account_replication_type  = "GRS"
+  account_kind              = "Storage" # StorageV2
+  enable_https_traffic_only = true
+  min_tls_version           = "TLS1_2"
+
+  custom_domain {
+    name          = "reports.jenkins.io"
+    use_subdomain = false
+  }
+
+  tags = {
+    scope = "terraform-managed"
+  }
+}

--- a/reports.jenkins.io.tf
+++ b/reports.jenkins.io.tf
@@ -14,7 +14,7 @@ resource "azurerm_storage_account" "prodjenkinsreports" {
   location                  = azurerm_resource_group.prod_reports.location
   account_tier              = "Standard"
   account_replication_type  = "GRS"
-  account_kind              = "Storage" # StorageV2
+  account_kind              = "Storage"
   enable_https_traffic_only = true
   min_tls_version           = "TLS1_2"
 

--- a/updatecli/updatecli.d/terraform-providers.yaml
+++ b/updatecli/updatecli.d/terraform-providers.yaml
@@ -1,4 +1,4 @@
-title: "Bump Terraform plugins - not modules"
+name: "Bump Terraform plugins - not modules"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   getLatestLockFileContent:
     kind: shell
+    name: Generate an up-to-date terraform lock file
     spec:
       command: bash ./updatecli/scripts/terraform-get-upgraded-lockfile.sh ./
 
@@ -31,8 +32,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - upgradeActualLockFile
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/terraform-providers.yaml
+++ b/updatecli/updatecli.d/terraform-providers.yaml
@@ -1,4 +1,4 @@
-name: "Bump Terraform plugins - not modules"
+name: "Bump Terraform providers - not modules"
 
 scms:
   default:
@@ -35,3 +35,4 @@ pullrequests:
     spec:
       labels:
         - dependencies
+        - terraform-providers


### PR DESCRIPTION
The service reports.jenkins.io is an Azure Storage Bucket already used by https://github.com/jenkins-infra/infra-reports.

We want to use it for generating more public reports as per https://github.com/jenkins-infra/helpdesk/issues/3087.

This PR adds this bucket and its resource group in the terraform tracking.