### PR TITLE
chore: temporary disable the terraform part

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,35 +1,35 @@
 parallel(
   failFast: false,
-  'terraform': {
-    terraform(
-      stagingCredentials: [
-        azureServicePrincipal(
-          credentialsId: 'staging-terraform-azure-serviceprincipal',
-          subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
-          clientIdVariable: 'ARM_CLIENT_ID',
-          clientSecretVariable: 'ARM_CLIENT_SECRET',
-          tenantIdVariable: 'ARM_TENANT_ID',
-        ),
-        file(
-          credentialsId: 'staging-terraform-azure-backend-config',
-          variable: 'BACKEND_CONFIG_FILE',
-        ),
-      ],
-      productionCredentials: [
-        azureServicePrincipal(
-          credentialsId: 'production-terraform-azure-serviceprincipal',
-          subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
-          clientIdVariable: 'ARM_CLIENT_ID',
-          clientSecretVariable: 'ARM_CLIENT_SECRET',
-          tenantIdVariable: 'ARM_TENANT_ID',
-        ),
-        file(
-          credentialsId: 'production-terraform-azure-backend-config',
-          variable: 'BACKEND_CONFIG_FILE',
-        ),
-      ],
-    )
-  },
+  // 'terraform': {
+  //   terraform(
+  //     stagingCredentials: [
+  //       azureServicePrincipal(
+  //         credentialsId: 'staging-terraform-azure-serviceprincipal',
+  //         subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
+  //         clientIdVariable: 'ARM_CLIENT_ID',
+  //         clientSecretVariable: 'ARM_CLIENT_SECRET',
+  //         tenantIdVariable: 'ARM_TENANT_ID',
+  //       ),
+  //       file(
+  //         credentialsId: 'staging-terraform-azure-backend-config',
+  //         variable: 'BACKEND_CONFIG_FILE',
+  //       ),
+  //     ],
+  //     productionCredentials: [
+  //       azureServicePrincipal(
+  //         credentialsId: 'production-terraform-azure-serviceprincipal',
+  //         subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
+  //         clientIdVariable: 'ARM_CLIENT_ID',
+  //         clientSecretVariable: 'ARM_CLIENT_SECRET',
+  //         tenantIdVariable: 'ARM_TENANT_ID',
+  //       ),
+  //       file(
+  //         credentialsId: 'production-terraform-azure-backend-config',
+  //         variable: 'BACKEND_CONFIG_FILE',
+  //       ),
+  //     ],
+  //   )
+  // },
   'updatecli': {
     def updatecliImage = 'jenkinsciinfra/hashicorp-tools:latest'
     updatecli(action: 'diff', updatecliDockerImage: updatecliImage)


### PR DESCRIPTION
Easier for me to work locally without having my cluster erased if/when infra is redeployed (resetting the suspended state of the corresponding job)