### PR TITLE
breaking(privatek8s) apply Azure Best Practises on node pools (ephemeral system disks and avoid multi-AZ due to PVs)

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -38,6 +38,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
   default_node_pool {
     name           = "systempool"
     vm_size        = "Standard_D2as_v4"
+    os_disk_type   = "Ephemeral"
     node_count     = 1
     vnet_subnet_id = azurerm_subnet.privatek8s_tier.id
     tags           = local.default_tags
@@ -53,6 +54,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
 resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
   name                  = "linuxpool"
   vm_size               = "Standard_D4s_v3"
+  os_disk_type          = "Ephemeral"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s.id
   enable_auto_scaling   = true
   min_count             = 0
@@ -65,6 +67,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
 resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
   name                  = "infracipool"
   vm_size               = "Standard_D4s_v3"
+  os_disk_type          = "Ephemeral"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s.id
   enable_auto_scaling   = true
   min_count             = 0

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -42,6 +42,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
     node_count     = 1
     vnet_subnet_id = azurerm_subnet.privatek8s_tier.id
     tags           = local.default_tags
+    zones          = [3]
   }
 
   identity {
@@ -59,7 +60,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
   enable_auto_scaling   = true
   min_count             = 0
   max_count             = 3
-  zones                 = [1, 2, 3]
+  zones                 = [3]
   vnet_subnet_id        = azurerm_subnet.privatek8s_tier.id
   tags                  = local.default_tags
 }
@@ -72,7 +73,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
   enable_auto_scaling   = true
   min_count             = 0
   max_count             = 2
-  zones                 = [1, 2, 3]
+  zones                 = [3]
   vnet_subnet_id        = azurerm_subnet.privatek8s_tier.id
 
   # Spot instances


### PR DESCRIPTION
(edit) 💥 this PR destroyes and create a new cluster + IP address (ref. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#os_disk_type => `Changing this forces a new resource to be created`)

As per @lemeurherve diagnostics on the newly created cluster (`privatek8s`), the node pools should use ephemeral system disks as indicated by Azure Best Practises:

![image](https://user-images.githubusercontent.com/1522731/202508758-42b51aea-72ee-4766-ad2a-e74a5b9c60f3.png)

This PR sets the system disk type to Ephemeral instead of the default "Managed" as per https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool#os_disk_type.


(edit 2)
Since this PR will re-create the cluster, I've also added another change: we only deploy the node pools to the same zone `3`:

![image](https://user-images.githubusercontent.com/1522731/202513880-c5ef1c23-6011-4b90-acec-866c405dcbe9.png)

- We do not need "multi-zone" for the private k8s (infra.ci/releasE.ci). In case of a zone being  we accept this cluster to be inoperative until fixed (unless we create ZRS PVC as per https://learn.microsoft.com/en-us/azure/aks/availability-zones#azure-disk-availability-zone-support)

