### PR TITLE
feat(privatek8s) update the `infracipool` configuration (bigger VMs and additional taint)

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -72,13 +72,13 @@ resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
 
 resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
   name                  = "infracipool"
-  vm_size               = "Standard_D4s_v3"
+  vm_size               = "Standard_D8s_v3"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 30
   kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s.id
   enable_auto_scaling   = true
   min_count             = 0
-  max_count             = 2
+  max_count             = 20
   zones                 = [3]
   vnet_subnet_id        = azurerm_subnet.privatek8s_tier.id
 
@@ -91,7 +91,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
     "kubernetes.azure.com/scalesetpriority" = "spot"
   }
   node_taints = [
-    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
+    "jenkins=infra.ci.jenkins.io:NoSchedule",
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule",
   ]
 
   tags = local.default_tags


### PR DESCRIPTION
Follow up of https://github.com/jenkins-infra/kubernetes-management/pull/3258 to ensure that the manual operation on `temp-privatek8s` is reported in the automation for the future `privatek8s` cluster.

For the record, command was:

```
az aks nodepool add \
    --resource-group prod-jenkins-private-prod \
    --cluster-name temp-privatek8s \
    --name infracipool \
    --priority Spot \
    --eviction-policy Delete \
    --spot-max-price -1 \
    --enable-cluster-autoscaler \
    --min-count 0 \
    --max-count 20 \
    --no-wait \
    --node-vm-size Standard_D8s_v3 \
    --node-taints jenkins=infra.ci.jenkins.io:NoSchedule
```