### PR TITLE
fix(privatek8s): correct rg and vnet for privatek8s-tier scope

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -104,7 +104,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
 }
 
 resource "azurerm_role_assignment" "privatek8s_networkcontributor" {
-  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private_prod.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private_prod.name}/subnets/${azurerm_subnet.privatek8s_tier.name}" # azurerm_subnet.privatek8s_tier.name
+  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${azurerm_subnet.privatek8s_tier.name}" # azurerm_subnet.privatek8s_tier.name
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
   skip_service_principal_aad_check = true


### PR DESCRIPTION
🤦 

Fixes this error on https://github.com/jenkins-infra/kubernetes-management/pull/3247 merge build
```
Error syncing load balancer: failed to ensure load balancer: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 403, RawError: {"erro
r":{"code":"AuthorizationFailed","message":"The client '1980c7ad-fc64-4e39-a833-1656e5828c47' with object id '1980c7ad-fc64-4e39-a833-1656e5828c47' does not have authorization to perform action 'Microsoft.Ne
twork/virtualNetworks/subnets/read' over scope '/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/private/providers/Microsoft.Network/virtualNetworks/private-vnet/subnets/privatek8s-tier' or
 the scope is invalid. If access was recently granted, please refresh your credentials."}}
```