### PR TITLE
Cleanup: migrate privatek8s subnet to jenkins-infra/azure-net

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -30,7 +30,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
   role_based_access_control_enabled = true # default value, added to please tfsec
   api_server_authorized_ip_ranges = setunion(
     values(local.admin_allowed_ips),
-    data.azurerm_subnet.data_tier.address_prefixes,
+    data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
     # temp-privatek8s nodes subnet
     data.azurerm_subnet.default.address_prefixes,
     [local.temp_privatek8s_pod_ip]

--- a/vnets.tf
+++ b/vnets.tf
@@ -56,8 +56,8 @@ data "azurerm_subnet" "default" {
 }
 
 # Defined in https://github.com/jenkins-infra/azure-net/blob/main/vpn.tf
-data "azurerm_subnet" "vpn" {
-  name                 = "${data.azurerm_virtual_network.private.name}-vpn"
+data "azurerm_subnet" "data_tier" {
+  name                 = "${data.azurerm_virtual_network.private.name}-data-tier"
   virtual_network_name = data.azurerm_virtual_network.private.name
   resource_group_name  = data.azurerm_resource_group.private.name
 }

--- a/vnets.tf
+++ b/vnets.tf
@@ -56,7 +56,7 @@ data "azurerm_subnet" "default" {
 }
 
 # Defined in https://github.com/jenkins-infra/azure-net/blob/main/vpn.tf
-data "azurerm_subnet" "data_tier" {
+data "azurerm_subnet" "private_vnet_data_tier" {
   name                 = "${data.azurerm_virtual_network.private.name}-data-tier"
   virtual_network_name = data.azurerm_virtual_network.private.name
   resource_group_name  = data.azurerm_resource_group.private.name


### PR DESCRIPTION
Twin of https://github.com/jenkins-infra/azure-net/pull/27

This PR should NOT change anything: the command

```console
terraform state rm 'azurerm_subnet.privatek8s_tier'
```

was run to avoid managing the network in state anymore.