### PR TITLE
fix(privatek8s) allow cluster identity to manage LBs in the data-tier subnet

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -35,10 +35,10 @@ locals {
   }
 
   admin_allowed_ips = {
-    dduportal          = "109.88.253.68"
-    dduportal-travel   = "86.194.33.212"
-    lemeurherve        = "176.185.227.180"
-    smerle33           = "82.64.5.129"
+    dduportal        = "109.88.253.68"
+    dduportal-travel = "86.194.33.212"
+    lemeurherve      = "176.185.227.180"
+    smerle33         = "82.64.5.129"
   }
 
   # TODO: remove when switching infra.ci.jenkins.io from temp-privatek8s to privatek8s

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -101,8 +101,17 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
   tags = local.default_tags
 }
 
+# Allow cluster to manage LBs in the privatek8s-tier subnet (Public LB)
 resource "azurerm_role_assignment" "privatek8s_networkcontributor" {
-  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.privatek8s_tier.name}" # azurerm_subnet.privatek8s_tier.name
+  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.privatek8s_tier.name}"
+  role_definition_name             = "Network Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}
+
+# Allow cluster to manage LBs in the data-tier subnet (internal LBs)
+resource "azurerm_role_assignment" "privatek8s_networkcontributor" {
+  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.private_vnet_data_tier.name}"
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
   skip_service_principal_aad_check = true

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -110,7 +110,7 @@ resource "azurerm_role_assignment" "privatek8s_networkcontributor" {
 }
 
 # Allow cluster to manage LBs in the data-tier subnet (internal LBs)
-resource "azurerm_role_assignment" "privatek8s_networkcontributor" {
+resource "azurerm_role_assignment" "datatier_networkcontributor" {
   scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.private_vnet_data_tier.name}"
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id


### PR DESCRIPTION
This PR ensures that the private-nginx-ingress is allowed to create an internal LB in the private-vnet-data-tier subnet.

Follow up of https://github.com/jenkins-infra/kubernetes-management/pull/3379

Avoid the following error (in the events of the Kubernetes Service of type LoadBalancer for the private-nginx-ingress):

```console
Error syncing load balancer: failed to ensure load balancer: Retriable: false,
  RetryAfter: 0s, HTTPStatusCode: 403, RawError:
  {"error":{"code":"AuthorizationFailed","message":"The client
  '<redacted>' with object id
  '<redacted>' does not have authorization to perform
  action 'Microsoft.Network/virtualNetworks/subnets/read' over scope
  '/subscriptions/<redacted>/resourceGroups/private/providers/Microsoft.Network/virtualNetworks/private-vnet/subnets/private-vnet-data-tier'
  or the scope is invalid. If access was recently granted, please refresh your
  credentials."}}
```