### PR TITLE
feat(privatek8s): enable KeyVault service endpoint

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -35,9 +35,9 @@ locals {
   }
 
   admin_allowed_ips = {
-    dduportal        = "109.88.253.125"
-    lemeurherve      = "176.185.227.180"
-    smerle33         = "82.64.5.129"
+    dduportal   = "109.88.253.125"
+    lemeurherve = "176.185.227.180"
+    smerle33    = "82.64.5.129"
   }
 
   # TODO: remove when switching infra.ci.jenkins.io from temp-privatek8s to privatek8s

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -18,6 +18,8 @@ data "azurerm_subnet" "privatek8s_tier" {
   name                 = "privatek8s-tier"
   resource_group_name  = data.azurerm_resource_group.private.name
   virtual_network_name = data.azurerm_virtual_network.private.name
+  # Enable KeyVault service endpoint so the cluster can access secrets to update other clusters
+  service_endpoints = ["Microsoft.KeyVault"]
 }
 
 #tfsec:ignore:azure-container-logging #tfsec:ignore:azure-container-limit-authorized-ips


### PR DESCRIPTION
Enabling this endpoint so the privatek8s subnet can be added to the prodjenkinsinfra keys vault allowed networks, in order for infra.ci.jenkins.io to access secrets to control and admin other clusters.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2844