### PR TITLE
fix(privatek8s) correct deprecated 'api_server_access_profile' directive

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -28,13 +28,16 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
   kubernetes_version                = var.kubernetes_version
   dns_prefix                        = "privatek8s-${random_pet.suffix_privatek8s.id}"
   role_based_access_control_enabled = true # default value, added to please tfsec
-  api_server_authorized_ip_ranges = setunion(
-    values(local.admin_allowed_ips),
-    data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
-    # temp-privatek8s nodes subnet
-    data.azurerm_subnet.default.address_prefixes,
-    [local.temp_privatek8s_pod_ip]
-  )
+  
+  api_server_access_profile {
+    authorized_ip_ranges = setunion(
+      values(local.admin_allowed_ips),
+      data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
+      # temp-privatek8s nodes subnet
+      data.azurerm_subnet.default.address_prefixes,
+      [local.temp_privatek8s_pod_ip]
+    )
+  }
 
   network_profile {
     network_plugin = "azure"


### PR DESCRIPTION
This PR fixes the following warning message:

```
Warning: Argument is deprecated

  with azurerm_kubernetes_cluster.privatek8s,
  on privatek8s.tf line 31, in resource "azurerm_kubernetes_cluster" "privatek8s":
  31:   api_server_authorized_ip_ranges = setunion(
  32:     values(local.admin_allowed_ips),
  33:     data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
  34:     # temp-privatek8s nodes subnet
  35:     data.azurerm_subnet.default.address_prefixes,
  36:     [local.temp_privatek8s_pod_ip]
  37:   )

This property has been renamed to `authorized_ip_ranges` within the
`api_server_access_profile` block and will be removed in v4.0 of the provider
```