### PR TITLE
chore(publick8s): comment out storage class for now

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -11,13 +11,13 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.privatek8s.kube_config.0.cluster_ca_certificate)
 }
 
-provider "kubernetes" {
-  alias                  = "publick8s"
-  host                   = azurerm_kubernetes_cluster.publick8s.kube_config.0.host
-  client_certificate     = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.client_certificate)
-  client_key             = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.client_key)
-  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate)
-}
+# provider "kubernetes" {
+#   alias                  = "publick8s"
+#   host                   = azurerm_kubernetes_cluster.publick8s.kube_config.0.host
+#   client_certificate     = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.client_certificate)
+#   client_key             = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.client_key)
+#   cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate)
+# }
 
 # provider "postgresql" {
 #   /**

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -82,17 +82,17 @@ resource "azurerm_role_assignment" "publick8s_networkcontributor" {
   skip_service_principal_aad_check = true
 }
 
-resource "kubernetes_storage_class" "managed_csi_premium_retain_public" {
-  metadata {
-    name = "managed-csi-premium-retain"
-  }
-  storage_provisioner = "disk.csi.azure.com"
-  reclaim_policy      = "Retain"
-  parameters = {
-    skuname = "Premium_LRS"
-  }
-  provider = kubernetes.publick8s
-}
+# resource "kubernetes_storage_class" "managed_csi_premium_retain_public" {
+#   metadata {
+#     name = "managed-csi-premium-retain"
+#   }
+#   storage_provisioner = "disk.csi.azure.com"
+#   reclaim_policy      = "Retain"
+#   parameters = {
+#     skuname = "Premium_LRS"
+#   }
+#   provider = kubernetes.publick8s
+# }
 
 # Used later by the load balancer deployed on the cluster, see https://github.com/jenkins-infra/kubernetes-management/config/publick8s.yaml
 resource "azurerm_public_ip" "publick8s_ipv4" {


### PR DESCRIPTION
Avoid following error for now:

> Error: Post "[https://publick8s-endless-ghoul-1616a256.hcp.eastus2.azmk8s.io:443/apis/storage.k8s.io/v1/storageclasses](https://publick8s-endless-ghoul-1616a256.hcp.eastus2.azmk8s.io/apis/storage.k8s.io/v1/storageclasses)": dial tcp 20.72.109.139:443: i/o timeout
> 00:10:48.147  │ 
> 00:10:48.147  │   with kubernetes_storage_class.managed_csi_premium_retain_public,
> 00:10:48.147  │   on publick8s.tf line 85, in resource "kubernetes_storage_class" "managed_csi_premium_retain_public":
> 00:10:48.147  │   85: resource "kubernetes_storage_class" "managed_csi_premium_retain_public"

Will restore it after checking this new cluster connectivity.