### PR TITLE
chore: update `publick8s` cluster to Kubernetes 1.24

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -28,7 +28,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   name                              = "publick8s-${random_pet.suffix_publick8s.id}"
   location                          = azurerm_resource_group.publick8s.location
   resource_group_name               = azurerm_resource_group.publick8s.name
-  kubernetes_version                = "1.23.12"
+  kubernetes_version                = "1.24.9"
   dns_prefix                        = "publick8s-${random_pet.suffix_publick8s.id}"
   role_based_access_control_enabled = true # default value, added to please tfsec
   api_server_access_profile {


### PR DESCRIPTION
Version retrieved with `az aks get-upgrades --resource-group prod-privatek8s --name privatek8s-emerging-ram --output table`

Ref: https://github.com/jenkins-infra/helpdesk/issues/3387