### PR TITLE
hotfix(`privatek8s`): fix `WindowsAgentPoolNameTooLong` error (#284

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -121,7 +121,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "highmempool" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "windows2019pool" {
-  name                  = "windows2019"
+  name                  = "w2019"
   vm_size               = "Standard_D4s_v3"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 100


### PR DESCRIPTION
Fixup of #271 

> Windows agent pool name can not be longer than 6 characters.