### PR TITLE
fix(trusted.ci) Ensure that "terraform-production" is the explicit owner of the azuread_application

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -106,7 +106,7 @@ resource "kubernetes_storage_class" "managed_csi_premium_retain_public" {
   parameters = {
     skuname = "Premium_LRS"
   }
-  provider = kubernetes.publick8s
+  provider               = kubernetes.publick8s
   allow_volume_expansion = true
 }
 

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -1,7 +1,9 @@
 resource "azuread_application" "trusted_ci_jenkins_io" {
   display_name = "trusted.ci.jenkins.io"
-  owners       = [data.azuread_client_config.current.object_id]
-  tags         = [for key, value in local.default_tags : "${key}:${value}"]
+  owners = [
+    "b847a030-25e1-4791-ad04-9e8484d87bce", # terraform-production Service Principal, used by the CI system
+  ]
+  tags = [for key, value in local.default_tags : "${key}:${value}"]
   required_resource_access {
     resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,9 @@ terraform {
     azurerm = {
       source = "hashicorp/azurerm"
     }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
@@ -16,6 +19,9 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
+    }
+    time = {
+      source = "hashicorp/time"
     }
   }
 }


### PR DESCRIPTION
This PR is assorted of the following changes:

- State was cleaned to remove `azuread_application.packer`
- The trusted.ci.jenkins.io SP was re-imported in the state