### PR TITLE
chore: factorize the terraform-production SP id to allow reusability

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,2 +1,5 @@
-# This data source allows referencing the identity used by Terraform to connect to the Azure API
-data "azuread_client_config" "current" {}
+# Service Principal ID used by the CI to authenticate terraform against the Azure API
+# Defined in the (private) repository jenkins-infra/terraform-states (in ./azure/main.tf)
+data "azuread_service_principal" "terraform_production" {
+  display_name = "terraform-production"
+}

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -1,7 +1,7 @@
 resource "azuread_application" "trusted_ci_jenkins_io" {
   display_name = "trusted.ci.jenkins.io"
   owners = [
-    data.azuread_service_principal.terraform_production,
+    data.azuread_service_principal.terraform_production.id,
   ]
   tags = [for key, value in local.default_tags : "${key}:${value}"]
   required_resource_access {
@@ -22,7 +22,7 @@ resource "azuread_service_principal" "trusted_ci_jenkins_io" {
   application_id               = azuread_application.trusted_ci_jenkins_io.application_id
   app_role_assignment_required = false
   owners = [
-    data.azuread_service_principal.terraform_production,
+    data.azuread_service_principal.terraform_production.id,
   ]
 }
 

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -1,7 +1,7 @@
 resource "azuread_application" "trusted_ci_jenkins_io" {
   display_name = "trusted.ci.jenkins.io"
   owners = [
-    "b847a030-25e1-4791-ad04-9e8484d87bce", # terraform-production Service Principal, used by the CI system
+    data.azuread_service_principal.terraform_production,
   ]
   tags = [for key, value in local.default_tags : "${key}:${value}"]
   required_resource_access {
@@ -22,7 +22,7 @@ resource "azuread_service_principal" "trusted_ci_jenkins_io" {
   application_id               = azuread_application.trusted_ci_jenkins_io.application_id
   app_role_assignment_required = false
   owners = [
-    "b847a030-25e1-4791-ad04-9e8484d87bce", # terraform-production Service Principal, used by the CI system
+    data.azuread_service_principal.terraform_production,
   ]
 }
 


### PR DESCRIPTION
Follow up of #285 and #286  (ref. https://github.com/jenkins-infra/helpdesk/issues/3416#issuecomment-1460801641) .

This PR factorizes the id of the `terraform-production` Service principal to allow reusability