### PR TITLE
feat(privatek8s): add `azurefile-csi-premium-retain` storage class

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -168,6 +168,19 @@ resource "kubernetes_storage_class" "managed_csi_premium_retain" {
   provider = kubernetes.privatek8s
 }
 
+resource "kubernetes_storage_class" "azurefile_csi_premium_retain" {
+  metadata {
+    name = "azurefile-csi-premium-retain"
+  }
+  storage_provisioner = "file.csi.azure.com"
+  reclaim_policy      = "Retain"
+  parameters = {
+    skuname = "Premium_LRS"
+  }
+  mount_options = ["dir_mode=0777", "file_mode=0777", "uid=1000", "gid=1000", "mfsymlinks", "nobrl"]
+  provider = kubernetes.privatek8s
+}
+
 # Used later by the load balancer deployed on the cluster, see https://github.com/jenkins-infra/kubernetes-management/config/privatek8s.yaml
 resource "azurerm_public_ip" "public_privatek8s" {
   name                = "public-privatek8s"


### PR DESCRIPTION
Same mount options as https://github.com/jenkins-infra/helm-charts/blob/a491e7356a304fc2545b175dc90b880a50b727fc/charts/env-jenkins-release/templates/core-packages.yaml#L29-L35, will be used to set storage class in this chart for `release` volumes.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2844