### PR TITLE
fix(cert,packer) Fix the role assignement scopes to avoid re-creating on each apply

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -56,12 +56,12 @@ resource "azuread_application_password" "cert_ci_jenkins_io" {
 # Allow Service Principal to manage AzureRM resources inside the agents resource groups
 # "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/providers/Microsoft.Authorization/roleAssignments/3c9aca58-7582-4e39-a8f5-4e547eb93584"
 resource "azurerm_role_assignment" "cert_ci_jenkins_io_allow_azurerm" {
-  scope                = "subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.cert_ci_jenkins_io_agents.name}"
+  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.cert_ci_jenkins_io_agents.name}"
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.cert_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "cert_ci_jenkins_io_allow_packer" {
-  scope                = "subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/prod-packer-images"
+  scope                = "${data.azurerm_client_config.current.subscription_id}/resourceGroups/prod-packer-images"
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.cert_ci_jenkins_io.id
 }

--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -61,7 +61,7 @@ resource "azurerm_role_assignment" "cert_ci_jenkins_io_allow_azurerm" {
   principal_id         = azuread_service_principal.cert_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "cert_ci_jenkins_io_allow_packer" {
-  scope                = "${data.azurerm_client_config.current.subscription_id}/resourceGroups/prod-packer-images"
+  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/prod-packer-images"
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.cert_ci_jenkins_io.id
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,6 @@ data "azuread_service_principal" "terraform_production" {
   display_name = "terraform-production"
 }
 
-# Data source used to retrieve the subscription id and tenant id
-data "azurerm_client_config" "current" {
+# Data source used to retrieve the subscription id
+data "azurerm_subscription" "jenkins" {
 }

--- a/packer-resources.tf
+++ b/packer-resources.tf
@@ -109,7 +109,7 @@ resource "azurerm_shared_image" "jenkins_agent_images" {
 resource "azurerm_role_assignment" "packer_role_images_assignement" {
   for_each = azurerm_resource_group.packer_images
 
-  scope                = "subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${each.value.name}"
+  scope                = "${data.azurerm_client_config.current.subscription_id}/resourceGroups/${each.value.name}"
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.packer.id
 }
@@ -117,7 +117,7 @@ resource "azurerm_role_assignment" "packer_role_images_assignement" {
 resource "azurerm_role_assignment" "packer_role_builds_assignement" {
   for_each = azurerm_resource_group.packer_builds
 
-  scope                = "subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${each.value.name}"
+  scope                = "${data.azurerm_client_config.current.subscription_id}/resourceGroups/${each.value.name}"
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.packer.id
 }

--- a/packer-resources.tf
+++ b/packer-resources.tf
@@ -109,7 +109,7 @@ resource "azurerm_shared_image" "jenkins_agent_images" {
 resource "azurerm_role_assignment" "packer_role_images_assignement" {
   for_each = azurerm_resource_group.packer_images
 
-  scope                = "${data.azurerm_client_config.current.subscription_id}/resourceGroups/${each.value.name}"
+  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${each.value.name}"
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.packer.id
 }
@@ -117,7 +117,7 @@ resource "azurerm_role_assignment" "packer_role_images_assignement" {
 resource "azurerm_role_assignment" "packer_role_builds_assignement" {
   for_each = azurerm_resource_group.packer_builds
 
-  scope                = "${data.azurerm_client_config.current.subscription_id}/resourceGroups/${each.value.name}"
+  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${each.value.name}"
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.packer.id
 }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -1,6 +1,3 @@
-data "azurerm_subscription" "jenkins" {
-}
-
 resource "azurerm_resource_group" "privatek8s" {
   name     = "prod-privatek8s"
   location = var.location
@@ -178,7 +175,7 @@ resource "kubernetes_storage_class" "azurefile_csi_premium_retain" {
     skuname = "Premium_LRS"
   }
   mount_options = ["dir_mode=0777", "file_mode=0777", "uid=1000", "gid=1000", "mfsymlinks", "nobrl"]
-  provider = kubernetes.privatek8s
+  provider      = kubernetes.privatek8s
 }
 
 # Used later by the load balancer deployed on the cluster, see https://github.com/jenkins-infra/kubernetes-management/config/privatek8s.yaml


### PR DESCRIPTION
This PR reuses the work by @lemeurherve on the privatek8s resources to ensure that the correct scope syntax is used.