### PR TITLE
feat: track ci.jenkins.io agent resources

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -54,7 +54,6 @@ resource "azuread_application_password" "cert_ci_jenkins_io" {
   end_date              = "2024-03-18T00:00:00Z"
 }
 # Allow Service Principal to manage AzureRM resources inside the agents resource groups
-# "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/providers/Microsoft.Authorization/roleAssignments/3c9aca58-7582-4e39-a8f5-4e547eb93584"
 resource "azurerm_role_assignment" "cert_ci_jenkins_io_allow_azurerm" {
   scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.cert_ci_jenkins_io_agents.name}"
   role_definition_name = "Contributor"

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -1,0 +1,87 @@
+/** Two resources groups: one for the controller, the second for the agents **/
+# resource "azurerm_resource_group" "ci_jenkins_io_controller" {
+#   name     = "prodjenkinsci"
+#   location = "East US 2"
+# }
+
+resource "azurerm_resource_group" "ci_jenkins_io_agents" {
+  name     = "eastus-cijenkinsio"
+  location = "East US"
+}
+
+/** Controller Resources **/
+
+// TODO: import prodci public IP address
+// TODO: import prod-ci network interface
+// TODO: import ci-data disk
+// TODO: import prodci system disk
+// TODO: import prod-ci VM
+// TODO: import prodjenkinscistore storage account (used for boot diagnostics)
+
+/** Agent Resources **/
+resource "azurerm_storage_account" "ci_jenkins_io_agents" {
+  name                     = "cijenkinsiovmagents"
+  resource_group_name      = azurerm_resource_group.ci_jenkins_io_agents.name
+  location                 = azurerm_resource_group.ci_jenkins_io_agents.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2" # default value, needed for tfsec
+  tags                     = local.default_tags
+}
+
+# Azure AD resources to allow controller to spawn agents in Azure
+resource "azuread_application" "ci_jenkins_io" {
+  display_name = "ci.jenkins.io"
+  owners = [
+    data.azuread_service_principal.terraform_production.id,
+  ]
+  tags = [for key, value in local.default_tags : "${key}:${value}"]
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.Read
+      type = "Scope"
+    }
+  }
+  web {
+    homepage_url = "https://github.com/jenkins-infra/azure"
+  }
+}
+resource "azuread_service_principal" "ci_jenkins_io" {
+  application_id               = azuread_application.infra_ci_jenkins_io.application_id
+  app_role_assignment_required = false
+  owners = [
+    data.azuread_service_principal.terraform_production.id,
+  ]
+}
+resource "azuread_application_password" "ci_jenkins_io" {
+  application_object_id = azuread_application.ci_jenkins_io.object_id
+  display_name          = "ci.jenkins.io-tf-managed"
+  end_date              = "2024-03-28T00:00:00Z"
+}
+
+# Allow application to manage AzureRM resources inside the agents resource groups
+resource "azurerm_role_assignment" "ci_jenkins_io_contributor_in_agent_resourcegroup" {
+  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.ci_jenkins_io_agents.name}"
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.ci_jenkins_io.id
+}
+resource "azurerm_role_assignment" "ci_jenkins_io_read_packer_prod_images" {
+  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.packer_images["prod"].name}"
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.ci_jenkins_io.id
+}
+# Allow application to create/delete VM network interfaces in this subnet
+resource "azurerm_role_assignment" "ci_jenkins_io_manage_net_interfaces_subnet_ci_agents" {
+  // TODO: manage this subnet in jenkins-infra/azure-net along with a security group
+  scope = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.public.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.public.name}/subnets/ci.j-agents-vm"
+  // TODO: restrict to "Virtual Machine Contributor"
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.ci_jenkins_io.id
+}
+resource "azurerm_role_assignment" "ci_jenkins_io_read_public_vnets" {
+  scope              = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.public.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.public.name}"
+  role_definition_id = azurerm_role_definition.public_vnet_reader.role_definition_resource_id
+  principal_id       = azuread_service_principal.infra_ci_jenkins_io.id
+}

--- a/custom-roles.tf
+++ b/custom-roles.tf
@@ -1,0 +1,17 @@
+resource "azurerm_role_definition" "private_vnet_reader" {
+  name  = "ReadPrivateVNET"
+  scope = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}"
+
+  permissions {
+    actions = ["Microsoft.Network/virtualNetworks/read"]
+  }
+}
+
+resource "azurerm_role_definition" "public_vnet_reader" {
+  name  = "ReadPublicVNET"
+  scope = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.public.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.public.name}"
+
+  permissions {
+    actions = ["Microsoft.Network/virtualNetworks/read"]
+  }
+}

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -14,7 +14,6 @@ resource "azurerm_storage_account" "infra_ci_jenkins_io_agents" {
   min_tls_version          = "TLS1_2" # default value, needed for tfsec
   tags                     = local.default_tags
 }
-// TODO: create a virtual network/subnet for the agent VM
 
 # Azure AD resources to allow controller to spawn agents in Azure
 resource "azuread_application" "infra_ci_jenkins_io" {
@@ -62,15 +61,6 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_subnet_role" 
   scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.privatek8s_tier.name}"
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = azuread_service_principal.infra_ci_jenkins_io.id
-}
-
-resource "azurerm_role_definition" "private_vnet_reader" {
-  name  = "PrivateVNET"
-  scope = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}"
-
-  permissions {
-    actions = ["Microsoft.Network/virtualNetworks/read"]
-  }
 }
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_subnet_private_vnet_reader" {
   scope              = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}"

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,6 @@
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
+  skip_provider_registration = "true"
   features {}
 }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3459

This PR adds the required resources to manage, as code, the credentials and resources required for ci.jenkins.io's agents (VM and ACI).

