### PR TITLE
Set arm64 on image definition

### DIFF
--- a/packer-resources.tf
+++ b/packer-resources.tf
@@ -83,6 +83,8 @@ resource "azurerm_shared_image" "jenkins_agent_images" {
   resource_group_name = azurerm_resource_group.packer_images[split("_", each.value)[0]].name
   location            = local.shared_galleries[split("_", each.value)[0]].images_location[split("_", each.value)[1]]
 
+  architecture = endswith(split("_", each.value)[1], "arm64") ? "Arm64" : "x64"
+
   hyper_v_generation     = "V2"
   os_type                = length(regexall(".*windows.*", lower(split("_", each.value)[1]))) > 0 ? "Windows" : "Linux"
   specialized            = false

--- a/packer-resources.tf
+++ b/packer-resources.tf
@@ -83,7 +83,7 @@ resource "azurerm_shared_image" "jenkins_agent_images" {
   resource_group_name = azurerm_resource_group.packer_images[split("_", each.value)[0]].name
   location            = local.shared_galleries[split("_", each.value)[0]].images_location[split("_", each.value)[1]]
 
-  architecture = endswith(split("_", each.value)[1], "arm64") ? "Arm64" : "x64"
+  architecture = length(regexall(".+arm64", split("_", each.value)[1])) > 0 ? "Arm64" : "x64"
 
   hyper_v_generation     = "V2"
   os_type                = length(regexall(".*windows.*", lower(split("_", each.value)[1]))) > 0 ? "Windows" : "Linux"


### PR DESCRIPTION
see https://github.com/hashicorp/packer-plugin-azure/issues/287#issuecomment-1503705161

https://github.com/jenkins-infra/helpdesk/issues/3471

Terraform plan from https://infra.ci.jenkins.io/job/terraform-jobs/job/azure/job/PR-323/2/artifact/terraform-plan-for-humans.txt :
```terraform
  # azurerm_shared_image.jenkins_agent_images["staging_ubuntu-22.04-arm64"] must be replaced
-/+ resource "azurerm_shared_image" "jenkins_agent_images" {
      - accelerated_network_support_enabled = false -> null
      ~ architecture                        = "x64" -> "Arm64" # forces replacement
```
