### PR TITLE
cleanup(packer) remove Ubuntu 20.x managed VM images from galleries

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -6,10 +6,6 @@ locals {
       description = "Shared images built by pull requests in jenkins-infra/packer-images (consider it untrusted)."
       rg_location = "eastus"
       images_location = {
-        "ubuntu-20"          = "eastus"
-        "ubuntu-20.04"       = "eastus"
-        "ubuntu-20.04-amd64" = "eastus"
-        "ubuntu-20.04-arm64" = "eastus"
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
         "windows-2019"       = "eastus"
@@ -20,10 +16,6 @@ locals {
       description = "Shared images built by the principal code branch in jenkins-infra/packer-images (ready to be tested)."
       rg_location = "eastus"
       images_location = {
-        "ubuntu-20"          = "eastus2"
-        "ubuntu-20.04"       = "eastus"
-        "ubuntu-20.04-amd64" = "eastus"
-        "ubuntu-20.04-arm64" = "eastus"
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
         "windows-2019"       = "eastus2"
@@ -34,10 +26,6 @@ locals {
       description = "Shared images built by the releases in jenkins-infra/packer-images (⚠️ Used in production.)."
       rg_location = "eastus2"
       images_location = {
-        "ubuntu-20"          = "eastus2"
-        "ubuntu-20.04"       = "eastus"
-        "ubuntu-20.04-amd64" = "eastus"
-        "ubuntu-20.04-arm64" = "eastus"
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
         "windows-2019"       = "eastus"


### PR DESCRIPTION
As part of https://github.com/jenkins-infra/helpdesk/issues/2982, we were able to switch to Ubuntu 22.04.

Let's remove remnants of Ubuntu 20.x manged images: less credits to pay for unused rersources