### PR TITLE
feat(shared images galleries): add amd64 and arm64 galleries

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,11 @@ locals {
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
         "windows-2019"       = "eastus"
+        "windows-2019-amd64" = "eastus"
+        "windows-2019-arm64" = "eastus"
         "windows-2022"       = "eastus"
+        "windows-2022-amd64" = "eastus"
+        "windows-2022-arm64" = "eastus"
       }
     }
     "staging" = {
@@ -26,8 +30,12 @@ locals {
         "ubuntu-20.04-arm64" = "eastus"
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
-        "windows-2019"       = "eastus2"
+        "windows-2019"       = "eastus"
+        "windows-2019-amd64" = "eastus"
+        "windows-2019-arm64" = "eastus"
         "windows-2022"       = "eastus"
+        "windows-2022-amd64" = "eastus"
+        "windows-2022-arm64" = "eastus"
       }
     }
     "prod" = {
@@ -41,7 +49,11 @@ locals {
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
         "windows-2019"       = "eastus"
+        "windows-2019-amd64" = "eastus"
+        "windows-2019-arm64" = "eastus"
         "windows-2022"       = "eastus"
+        "windows-2022-amd64" = "eastus"
+        "windows-2022-arm64" = "eastus"
       }
     }
   }


### PR DESCRIPTION
add galleries for amd64 and arm64 for windows also as it's now mandatory to have the architecture within the gallery name for our packer to upload images.
windows ARM64 is not used yet.