### PR TITLE
fix: increase linuxpool disk size from 30GB to 40GB

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -63,7 +63,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
   name                  = "linuxpool"
   vm_size               = "Standard_D4s_v3"
   os_disk_type          = "Ephemeral"
-  os_disk_size_gb       = 30
+  os_disk_size_gb       = 40
   kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s.id
   enable_auto_scaling   = true
   min_count             = 0


### PR DESCRIPTION
Following the switch to a percentage based alerting for the available disk size in https://github.com/jenkins-infra/datadog/pull/168, we've noticed the available disk space on linuxpool is below 20% (currently at 16,7%)

This PR is increasing the OS disk size on this node pool.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3497