### PR TITLE
cleanup(packer) remove legacy VM images (without the CPU suffix)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -8,9 +8,7 @@ locals {
       images_location = {
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
-        "windows-2019"       = "eastus"
         "windows-2019-amd64" = "eastus"
-        "windows-2022"       = "eastus"
         "windows-2022-amd64" = "eastus"
       }
     }
@@ -20,9 +18,7 @@ locals {
       images_location = {
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
-        "windows-2019"       = "eastus"
         "windows-2019-amd64" = "eastus"
-        "windows-2022"       = "eastus"
         "windows-2022-amd64" = "eastus"
       }
     }
@@ -32,9 +28,7 @@ locals {
       images_location = {
         "ubuntu-22.04-amd64" = "eastus"
         "ubuntu-22.04-arm64" = "eastus"
-        "windows-2019"       = "eastus"
         "windows-2019-amd64" = "eastus"
-        "windows-2022"       = "eastus"
         "windows-2022-amd64" = "eastus"
       }
     }


### PR DESCRIPTION
https://github.com/jenkins-infra/packer-images/pull/627 works as expected but is really slow (the Azure API takes a few minute for each version deletion).

Optimization is being done, but removing the (now) unused galleries would also help (and save some precious credits)