### PR TITLE
hotfix(privatek8s) increase linuxpool disk size to 64 Gb

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -63,7 +63,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
   name                  = "linuxpool"
   vm_size               = "Standard_D4s_v3"
   os_disk_type          = "Ephemeral"
-  os_disk_size_gb       = 50
+  os_disk_size_gb       = 64 # 32 or 64: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types
   kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s.id
   enable_auto_scaling   = true
   min_count             = 0


### PR DESCRIPTION
Surfaced by https://github.com/jenkins-infra/helpdesk/issues/3539, this PR increases the available disk disk for `linuxpool` (and NOT `systempool`).


Since we pay for 64 Gb, let's use it!

Applied locally, will be merged "as it"