### PR TITLE
feat(ci.jenkins.io) define a new VM + datadisk + public IP in a custom resource group

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -2,6 +2,8 @@
 resource "azurerm_resource_group" "ci_jenkins_io_controller" {
   name     = "ci-jenkins-io-controller"
   location = "East US 2"
+  
+  tags = local.default_tags
 }
 
 resource "azurerm_resource_group" "ci_jenkins_io_agents" {

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "ci_jenkins_io" {
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "StandardSSD_LRS"
-    disk_size_gb         = 32 # Minimal size for ubuntu 22.04 image
+    disk_size_gb         = 64 # Minimal size for ubuntu 22.04 image
   }
 
   source_image_reference {

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -1,8 +1,8 @@
 /** Two resources groups: one for the controller, the second for the agents **/
-# resource "azurerm_resource_group" "ci_jenkins_io_controller" {
-#   name     = "prodjenkinsci"
-#   location = "East US 2"
-# }
+resource "azurerm_resource_group" "ci_jenkins_io_controller" {
+  name     = "ci-jenkins-io-controller"
+  location = "East US 2"
+}
 
 resource "azurerm_resource_group" "ci_jenkins_io_agents" {
   name     = "eastus-cijenkinsio"
@@ -10,13 +10,85 @@ resource "azurerm_resource_group" "ci_jenkins_io_agents" {
 }
 
 /** Controller Resources **/
+# Defined in https://github.com/jenkins-infra/azure-net/blob/d30a37c27b649aebd158ecb5d631ff8d7f1bab4e/vnets.tf#L175-L183
+data "azurerm_subnet" "ci_jenkins_io_controller" {
+  name                 = "${data.azurerm_virtual_network.public.name}-ci_jenkins_io_controller"
+  virtual_network_name = data.azurerm_virtual_network.public.name
+  resource_group_name  = data.azurerm_resource_group.public.name
+}
+resource "azurerm_public_ip" "ci_jenkins_io" {
+  name                = "ci-jenkins-io"
+  location            = azurerm_resource_group.ci_jenkins_io_controller.location
+  resource_group_name = azurerm_resource_group.ci_jenkins_io_controller.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = local.default_tags
+}
+resource "azurerm_network_interface" "ci_jenkins_io" {
+  name                = "ci-jenkins-io"
+  location            = azurerm_resource_group.ci_jenkins_io_controller.location
+  resource_group_name = azurerm_resource_group.ci_jenkins_io_controller.name
+  tags                = local.default_tags
 
-// TODO: import prodci public IP address
-// TODO: import prod-ci network interface
-// TODO: import ci-data disk
-// TODO: import prodci system disk
-// TODO: import prod-ci VM
-// TODO: import prodjenkinscistore storage account (used for boot diagnostics)
+  ip_configuration {
+    name                          = "external"
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.ci_jenkins_io.id
+    subnet_id                     = data.azurerm_subnet.ci_jenkins_io_controller.id
+  }
+}
+resource "azurerm_managed_disk" "ci_jenkins_io_data" {
+  name                 = "ci-jenkins-io-data"
+  location             = azurerm_resource_group.ci_jenkins_io_controller.location
+  resource_group_name  = azurerm_resource_group.ci_jenkins_io_controller.name
+  storage_account_type = "StandardSSD_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "512"
+
+  tags = local.default_tags
+}
+resource "azurerm_linux_virtual_machine" "ci_jenkins_io" {
+  name                            = "ci-jenkins-io"
+  resource_group_name             = azurerm_resource_group.ci_jenkins_io_controller.name
+  location                        = azurerm_resource_group.ci_jenkins_io_controller.location
+  tags                            = local.default_tags
+  size                            = "Standard_D8as_v5"
+  admin_username                  = local.admin_username
+  disable_password_authentication = true
+  network_interface_ids = [
+    azurerm_network_interface.ci_jenkins_io.id,
+  ]
+
+  admin_ssh_key {
+    username   = local.admin_username
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKvZ23dkvhjSU0Gxl5+mKcBOwmR7gqJDYeA1/Xzl3otV4CtC5te5Vx7YnNEFDXD6BsNkFaliXa34yE37WMdWl+exIURBMhBLmOPxEP/cWA5ZbXP//78ejZsxawBpBJy27uQhdcR0zVoMJc8Q9ShYl5YT/Tq1UcPq2wTNFvnrBJL1FrpGT+6l46BTHI+Wpso8BK64LsfX3hKnJEGuHSM0GAcYQSpXAeGS9zObKyZpk3of/Qw/2sVilIOAgNODbwqyWgEBTjMUln71Mjlt1hsEkv3K/VdvpFNF8VNq5k94VX6Rvg5FQBRL5IrlkuNwGWcBbl8Ydqk4wrD3b/PrtuLBEUsqbNhLnlEvFcjak+u2kzCov73csN/oylR0Tkr2y9x2HfZgDJVtvKjkkc4QERo7AqlTuy1whGfDYsioeabVLjZ9ahPjakv9qwcBrEEF+pAya7Q3AgNFVSdPgLDEwEO8GUHaxAjtyXXv9+yPdoDGmG3Pfn3KqM6UZjHCxne3Dr5ZE="
+  }
+
+  user_data     = base64encode(templatefile("./.shared-tools/terraform/cloudinit.tftpl", { hostname = "ci.jenkins.io" }))
+  computer_name = "ci-jenkins-io"
+
+  # Encrypt all disks (ephemeral, temp dirs and data volumes) - https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+  encryption_at_host_enabled = true
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
+    disk_size_gb         = 32 # Minimal size for ubuntu 22.04 image
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-minimal-jammy"
+    sku       = "minimal-22_04-lts-gen2"
+    version   = "latest"
+  }
+}
+resource "azurerm_virtual_machine_data_disk_attachment" "ci_jenkins_io_data" {
+  managed_disk_id    = azurerm_managed_disk.ci_jenkins_io_data.id
+  virtual_machine_id = azurerm_linux_virtual_machine.ci_jenkins_io.id
+  lun                = "10"
+  caching            = "ReadWrite"
+}
 
 /** Agent Resources **/
 resource "azurerm_storage_account" "ci_jenkins_io_agents" {

--- a/locals.tf
+++ b/locals.tf
@@ -47,7 +47,5 @@ locals {
     repository = "jenkins-infra/azure"
   }
 
-  trusted_ci_jenkins_io = {
-    admin_username = "jenkins-infra-team"
-  }
+  admin_username = "jenkins-infra-team"
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -124,14 +124,14 @@ resource "azurerm_linux_virtual_machine" "trusted_bounce" {
   resource_group_name             = azurerm_resource_group.trusted_ci_jenkins_io_controller.name
   location                        = azurerm_resource_group.trusted_ci_jenkins_io_controller.location
   size                            = "Standard_B1s"
-  admin_username                  = local.trusted_ci_jenkins_io.admin_username
+  admin_username                  = local.admin_username
   disable_password_authentication = true
   network_interface_ids = [
     azurerm_network_interface.trusted_bounce.id,
   ]
 
   admin_ssh_key {
-    username   = local.trusted_ci_jenkins_io.admin_username
+    username   = local.admin_username
     public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5K7Ro7jBl5Kc68RdzG6EXHstIBFSxO5Da8SQJSMeCbb4cHTYuBBH8jNsAFcnkN64kEu+YhmlxaWEVEIrPgfGfs13ZL7v9p+Nt76tsz6gnVdAy2zCz607pAWe7p4bBn6T9zdZcBSnvjawO+8t/5ue4ngcfAjanN5OsOgLeD6yqVyP8YTERjW78jvp2TFrIYmgWMI5ES1ln32PQmRZwc1eAOsyGJW/YIBdOxaSkZ41qUvb9b3dCorGuCovpSK2EeNphjLPpVX/NRpVY4YlDqAcTCdLdDrEeVqkiA/VDCYNhudZTDa8f1iHwBE/GEtlKmoO6dxJ5LAkRk3RIVHYrmI6XXSw5l0tHhW5D12MNwzUfDxQEzBpGK5iSfOBt5zJ5OiI9ftnsq/GV7vCXfvMVGDLUC551P5/s/wM70QmHwhlGQNLNeJxRTvd6tL11bof3K+29ivFYUmpU17iVxYOWhkNY86WyngHU6Ux0zaczF3H6H0tpg1Ca/cFO428AVPw/RTJpcAe6OVKq5zwARNApQ/p6fJKUAdXap+PpQGZlQhPLkUbwtFXGTrpX9ePTcdzryCYjgrZouvy4ZMzruJiIbFUH8mRY3xVREVaIsJakruvgw3b14oQgcB4BwYVBBqi62xIvbRzAv7Su9t2jK6OR2z3sM/hLJRqIJ5oILMORa7XqrQ=="
   }
 
@@ -178,14 +178,14 @@ resource "azurerm_linux_virtual_machine" "trusted_ci_controller" {
   location                        = azurerm_resource_group.trusted_ci_jenkins_io_controller.location
   tags                            = local.default_tags
   size                            = "Standard_D2as_v5"
-  admin_username                  = local.trusted_ci_jenkins_io.admin_username
+  admin_username                  = local.admin_username
   disable_password_authentication = true
   network_interface_ids = [
     azurerm_network_interface.trusted_ci_controller.id,
   ]
 
   admin_ssh_key {
-    username   = local.trusted_ci_jenkins_io.admin_username
+    username   = local.admin_username
     public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5K7Ro7jBl5Kc68RdzG6EXHstIBFSxO5Da8SQJSMeCbb4cHTYuBBH8jNsAFcnkN64kEu+YhmlxaWEVEIrPgfGfs13ZL7v9p+Nt76tsz6gnVdAy2zCz607pAWe7p4bBn6T9zdZcBSnvjawO+8t/5ue4ngcfAjanN5OsOgLeD6yqVyP8YTERjW78jvp2TFrIYmgWMI5ES1ln32PQmRZwc1eAOsyGJW/YIBdOxaSkZ41qUvb9b3dCorGuCovpSK2EeNphjLPpVX/NRpVY4YlDqAcTCdLdDrEeVqkiA/VDCYNhudZTDa8f1iHwBE/GEtlKmoO6dxJ5LAkRk3RIVHYrmI6XXSw5l0tHhW5D12MNwzUfDxQEzBpGK5iSfOBt5zJ5OiI9ftnsq/GV7vCXfvMVGDLUC551P5/s/wM70QmHwhlGQNLNeJxRTvd6tL11bof3K+29ivFYUmpU17iVxYOWhkNY86WyngHU6Ux0zaczF3H6H0tpg1Ca/cFO428AVPw/RTJpcAe6OVKq5zwARNApQ/p6fJKUAdXap+PpQGZlQhPLkUbwtFXGTrpX9ePTcdzryCYjgrZouvy4ZMzruJiIbFUH8mRY3xVREVaIsJakruvgw3b14oQgcB4BwYVBBqi62xIvbRzAv7Su9t2jK6OR2z3sM/hLJRqIJ5oILMORa7XqrQ=="
   }
 
@@ -259,14 +259,14 @@ resource "azurerm_linux_virtual_machine" "trusted_permanent_agent" {
   location                        = azurerm_resource_group.trusted_ci_jenkins_io_permanent_agents.location
   tags                            = local.default_tags
   size                            = "Standard_D2as_v5"
-  admin_username                  = local.trusted_ci_jenkins_io.admin_username
+  admin_username                  = local.admin_username
   disable_password_authentication = true
   network_interface_ids = [
     azurerm_network_interface.trusted_permanent_agent.id,
   ]
 
   admin_ssh_key {
-    username   = local.trusted_ci_jenkins_io.admin_username
+    username   = local.admin_username
     public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5K7Ro7jBl5Kc68RdzG6EXHstIBFSxO5Da8SQJSMeCbb4cHTYuBBH8jNsAFcnkN64kEu+YhmlxaWEVEIrPgfGfs13ZL7v9p+Nt76tsz6gnVdAy2zCz607pAWe7p4bBn6T9zdZcBSnvjawO+8t/5ue4ngcfAjanN5OsOgLeD6yqVyP8YTERjW78jvp2TFrIYmgWMI5ES1ln32PQmRZwc1eAOsyGJW/YIBdOxaSkZ41qUvb9b3dCorGuCovpSK2EeNphjLPpVX/NRpVY4YlDqAcTCdLdDrEeVqkiA/VDCYNhudZTDa8f1iHwBE/GEtlKmoO6dxJ5LAkRk3RIVHYrmI6XXSw5l0tHhW5D12MNwzUfDxQEzBpGK5iSfOBt5zJ5OiI9ftnsq/GV7vCXfvMVGDLUC551P5/s/wM70QmHwhlGQNLNeJxRTvd6tL11bof3K+29ivFYUmpU17iVxYOWhkNY86WyngHU6Ux0zaczF3H6H0tpg1Ca/cFO428AVPw/RTJpcAe6OVKq5zwARNApQ/p6fJKUAdXap+PpQGZlQhPLkUbwtFXGTrpX9ePTcdzryCYjgrZouvy4ZMzruJiIbFUH8mRY3xVREVaIsJakruvgw3b14oQgcB4BwYVBBqi62xIvbRzAv7Su9t2jK6OR2z3sM/hLJRqIJ5oILMORa7XqrQ== smerle@MacBook-Pro-de-Stephane.local"
   }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3535, this PR is the first major step to create a new (faster + cheaper) ci.jenkins.io VM managed as code.

Please note the following elements:

- A new resource group is created to avoid messing up with the current one (to avoid any confusion). The goal will be to remove the older resource group once the migration will be complete
  - Neither DNS record, subnets or snapshot (of the data disk for migration) are constrained by this
- StandardSSD are used instead of PremiumSSD (V1/V2). The goal is to start with a cheaper storage and see the current IOPS usage (since we [removed the plugin-config-history plugin](https://github.com/jenkins-infra/helpdesk/issues/3528) and [added an S3 artifact caching proxy](https://github.com/jenkins-infra/helpdesk/issues/3496) the need for IOPS is lowered).
  - Keep using a 512 Gb SSD though, because current usage is ~ 240 Gb: if we want to stay under 80% usage, AND since [Azure managed disks](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#standard-ssds) are either making you pay for 256 or 512 Gb (unless Premium SSD v2), better to have the bigger disk as possible.

- No need for a storage account (it was only used for boot diagnostics, which we should not need with Terrafomr IAC based VM)

- Registration to Puppet is done under the name `ci.jenkins.io` : the current VM is [registered as `azure.ci.jenkins.io`](https://github.com/jenkins-infra/jenkins-infra/blob/e425203e0ffafdcf8b2d5e675ad838c5e73cd687/manifests/site.pp#L76-L79) so no risk of conflicts

Please note that no security group is added...yet. I want to start with an "open VM" before applying security groups in a subsequent PR (everything will be removed and re-created once verified functionnal).

