### PR TITLE
fix(trusted.ci.jenkins.io) add missing outbound rules to allow SSH internally

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -399,10 +399,10 @@ resource "azurerm_network_security_rule" "deny_all_to_vnet" {
 }
 
 # TODO: add all ips from people needing access to trusted.ci.jenkins.io, or remove the rule at final migration. (Cf https://github.com/jenkins-infra/azure/pull/334#discussion_r1179955821)
-resource "azurerm_network_security_rule" "allow_ssh_from_admins_to_bounce" {
+resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_bounce" {
   for_each = local.admin_allowed_ips
 
-  name                        = "allow-22-from-${each.key}-to-bounce"
+  name                        = "allow-inbound-ssh-from-${each.key}-to-bounce"
   priority                    = 4000 + index(keys(local.admin_allowed_ips), each.key)
   direction                   = "Inbound"
   access                      = "Allow"
@@ -415,8 +415,8 @@ resource "azurerm_network_security_rule" "allow_ssh_from_admins_to_bounce" {
   network_security_group_name = azurerm_network_security_group.trusted_ci_controller.name
 }
 
-resource "azurerm_network_security_rule" "allow_ssh_from_bounce_to_controller" {
-  name                        = "allow-22-from-bounce-to-controller"
+resource "azurerm_network_security_rule" "allow_inbound_ssh_from_bounce_to_controller" {
+  name                        = "allow-inbound-ssh-from-bounce-to-controller"
   priority                    = 3500
   direction                   = "Inbound"
   access                      = "Allow"
@@ -429,8 +429,8 @@ resource "azurerm_network_security_rule" "allow_ssh_from_bounce_to_controller" {
   network_security_group_name = azurerm_network_security_group.trusted_ci_controller.name
 }
 
-resource "azurerm_network_security_rule" "allow_ssh_from_controller_to_permanent_agent" {
-  name                        = "allow-22-from-controller-to-permanent-agent"
+resource "azurerm_network_security_rule" "allow_inbound_ssh_from_controller_to_permanent_agent" {
+  name                        = "allow-inbound-ssh-from-controller-to-permanent-agent"
   priority                    = 3600
   direction                   = "Inbound"
   access                      = "Allow"
@@ -443,8 +443,8 @@ resource "azurerm_network_security_rule" "allow_ssh_from_controller_to_permanent
   network_security_group_name = azurerm_network_security_group.trusted_ci_controller.name
 }
 
-resource "azurerm_network_security_rule" "allow_ssh_from_controller_to_ephemeral_agents" {
-  name                        = "allow-22-from-controller-to-ephemeral-agents"
+resource "azurerm_network_security_rule" "allow_inbound_ssh_from_controller_to_ephemeral_agents" {
+  name                        = "allow-inbound-ssh-from-controller-to-ephemeral-agents"
   priority                    = 3700
   direction                   = "Inbound"
   access                      = "Allow"

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -334,8 +334,8 @@ resource "azurerm_subnet_network_security_group_association" "trusted_ci_control
   network_security_group_id = azurerm_network_security_group.trusted_ci_controller.id
 }
 
-resource "azurerm_network_security_rule" "allow_outbound_from_bounce_to_controller" {
-  name = "allow-outbound-from-bounce-to-controller"
+resource "azurerm_network_security_rule" "allow_outbound_ssh_from_bounce_to_controller" {
+  name = "allow-outbound-ssh-from-bounce-to-controller"
   # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
   # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
   priority                     = 4090
@@ -402,7 +402,7 @@ resource "azurerm_network_security_rule" "deny_all_to_vnet" {
 resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_bounce" {
   for_each = local.admin_allowed_ips
 
-  name                        = "allow-inbound-ssh-from-${each.key}-to-bounce"
+  name                        = "allow-inbound-ssh-from-admin-${each.key}-to-bounce"
   priority                    = 4000 + index(keys(local.admin_allowed_ips), each.key)
   direction                   = "Inbound"
   access                      = "Allow"

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -334,58 +334,50 @@ resource "azurerm_subnet_network_security_group_association" "trusted_ci_control
   network_security_group_id = azurerm_network_security_group.trusted_ci_controller.id
 }
 
-resource "azurerm_network_security_rule" "allow_outbound_ssh_from_bounce_to_controller" {
-  name = "allow-outbound-ssh-from-bounce-to-controller"
-  # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
-  # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
-  priority                     = 4090
-  direction                    = "Outbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "22"
+resource "azurerm_network_security_rule" "allow_outbound_from_bounce_to_controller" {
+  name                        = "allow-outbound-from-bounce-to-controller"
+  priority                    = 4090
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
   source_address_prefix       = azurerm_linux_virtual_machine.trusted_bounce.private_ip_address
   destination_address_prefix  = azurerm_linux_virtual_machine.trusted_ci_controller.private_ip_address
-  resource_group_name          = data.azurerm_resource_group.trusted.name
-  network_security_group_name  = azurerm_network_security_group.trusted_ci_controller.name
+  resource_group_name         = data.azurerm_resource_group.trusted.name
+  network_security_group_name = azurerm_network_security_group.trusted_ci_controller.name
 }
 
 resource "azurerm_network_security_rule" "allow_outbound_ssh_from_controller_to_permanent_agent" {
-  name = "allow-outbound-ssh-from-controller-to-permanent-agent"
-  # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
-  # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
-  priority                     = 4091
-  direction                    = "Outbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "22"
+  name                        = "allow-outbound-ssh-from-controller-to-permanent-agent"
+  priority                    = 4091
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
   source_address_prefix       = azurerm_linux_virtual_machine.trusted_ci_controller.private_ip_address
   destination_address_prefix  = azurerm_linux_virtual_machine.trusted_permanent_agent.private_ip_address
-  resource_group_name          = data.azurerm_resource_group.trusted.name
-  network_security_group_name  = azurerm_network_security_group.trusted_ci_controller.name
+  resource_group_name         = data.azurerm_resource_group.trusted.name
+  network_security_group_name = azurerm_network_security_group.trusted_ci_controller.name
 }
 
 resource "azurerm_network_security_rule" "allow_outbound_ssh_from_controller_to_ephemeral_agents" {
-  name = "allow-outbound-ssh-from-controller-to-ephemeral-agents"
-  # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
-  # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
-  priority                     = 4092
-  direction                    = "Outbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "22"
+  name                        = "allow-outbound-ssh-from-controller-to-ephemeral-agents"
+  priority                    = 4092
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
   source_address_prefix       = azurerm_linux_virtual_machine.trusted_ci_controller.private_ip_address
   destination_address_prefix  = data.azurerm_subnet.trusted_ephemeral_agents.address_prefix
-  resource_group_name          = data.azurerm_resource_group.trusted.name
-  network_security_group_name  = azurerm_network_security_group.trusted_ci_controller.name
+  resource_group_name         = data.azurerm_resource_group.trusted.name
+  network_security_group_name = azurerm_network_security_group.trusted_ci_controller.name
 }
 
 resource "azurerm_network_security_rule" "deny_all_to_vnet" {
-  name = "deny-all-to-vnet"
-  # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
-  # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
+  name                         = "deny-all-to-vnet"
   priority                     = 4095
   direction                    = "Outbound"
   access                       = "Deny"
@@ -398,7 +390,6 @@ resource "azurerm_network_security_rule" "deny_all_to_vnet" {
   network_security_group_name  = azurerm_network_security_group.trusted_ci_controller.name
 }
 
-# TODO: add all ips from people needing access to trusted.ci.jenkins.io, or remove the rule at final migration. (Cf https://github.com/jenkins-infra/azure/pull/334#discussion_r1179955821)
 resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_bounce" {
   for_each = local.admin_allowed_ips
 

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -334,6 +334,54 @@ resource "azurerm_subnet_network_security_group_association" "trusted_ci_control
   network_security_group_id = azurerm_network_security_group.trusted_ci_controller.id
 }
 
+resource "azurerm_network_security_rule" "allow_outbound_from_bounce_to_controller" {
+  name = "allow-outbound-from-bounce-to-controller"
+  # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
+  # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
+  priority                     = 4090
+  direction                    = "Outbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefix       = azurerm_linux_virtual_machine.trusted_bounce.private_ip_address
+  destination_address_prefix  = azurerm_linux_virtual_machine.trusted_ci_controller.private_ip_address
+  resource_group_name          = data.azurerm_resource_group.trusted.name
+  network_security_group_name  = azurerm_network_security_group.trusted_ci_controller.name
+}
+
+resource "azurerm_network_security_rule" "allow_outbound_ssh_from_controller_to_permanent_agent" {
+  name = "allow-outbound-ssh-from-controller-to-permanent-agent"
+  # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
+  # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
+  priority                     = 4091
+  direction                    = "Outbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefix       = azurerm_linux_virtual_machine.trusted_ci_controller.private_ip_address
+  destination_address_prefix  = azurerm_linux_virtual_machine.trusted_permanent_agent.private_ip_address
+  resource_group_name          = data.azurerm_resource_group.trusted.name
+  network_security_group_name  = azurerm_network_security_group.trusted_ci_controller.name
+}
+
+resource "azurerm_network_security_rule" "allow_outbound_ssh_from_controller_to_ephemeral_agents" {
+  name = "allow-outbound-ssh-from-controller-to-ephemeral-agents"
+  # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules
+  # ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/11137 and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#priority
+  priority                     = 4092
+  direction                    = "Outbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefix       = azurerm_linux_virtual_machine.trusted_ci_controller.private_ip_address
+  destination_address_prefix  = data.azurerm_subnet.trusted_ephemeral_agents.address_prefix
+  resource_group_name          = data.azurerm_resource_group.trusted.name
+  network_security_group_name  = azurerm_network_security_group.trusted_ci_controller.name
+}
+
 resource "azurerm_network_security_rule" "deny_all_to_vnet" {
   name = "deny-all-to-vnet"
   # Priority should be the highest value possible (lower than the default 65000 "default" rules not overidable) but higher than the other security rules


### PR DESCRIPTION
This PR is a fixup of #343 .

It allows SSH connections internally (bounce -> controller, controller ->.*-agents) to work as expected by opening the missing outbound connections in the security groups (the inbounds were already specified).


Please note that it also add a 2nd commit which rename the existing inbound rules to make it easier to visually differentiate inbound/outbound rules.