### PR TITLE
feat(publick8s) add a DNS record for the private nginx ingress

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -131,7 +131,12 @@ resource "azurerm_public_ip" "publick8s_ipv6" {
   tags                = local.default_tags
 }
 
-resource "azurerm_dns_a_record" "publick8s_a" {
+moved {
+  from = azurerm_dns_a_record.publick8s_a
+  to   = azurerm_dns_a_record.public_publick8s
+}
+
+resource "azurerm_dns_a_record" "public_publick8s" {
   name                = "public.publick8s"
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
@@ -140,12 +145,26 @@ resource "azurerm_dns_a_record" "publick8s_a" {
   tags                = local.default_tags
 }
 
-resource "azurerm_dns_aaaa_record" "publick8s_aaaa" {
+moved {
+  from = azurerm_dns_aaaa_record.publick8s_aaaa
+  to   = azurerm_dns_aaaa_record.public_publick8s
+}
+
+resource "azurerm_dns_aaaa_record" "public_publick8s" {
   name                = "public.publick8s"
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 300
   records             = [azurerm_public_ip.publick8s_ipv6.ip_address]
+  tags                = local.default_tags
+}
+
+resource "azurerm_dns_a_record" "private_publick8s" {
+  name                = "private.publick8s"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 300
+  records             = ["10.245.1.4"] # External IP of the private-nginx ingress LoadBalancer, created by https://github.com/jenkins-infra/kubernetes-management/blob/54a0d4aa72b15f4236abcfbde00a080905bbb890/clusters/publick8s.yaml#L63-L69
   tags                = local.default_tags
 }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1562482092

This PR adds a DNS record for the private Nginx ingress of the `publick8s` cluster. 
It's required to migrate keycloak (which exposes the `admin.accounts.jenkins.io` ingress through the private-nginx).


Please note the following elements:

- Nit: this PR renames the 2 terraform resources for the existing DNS records of the public loadbalancer, to have homogeneous names
  - Will need a subsequent PR to delete the `moved` blocks once applied

- The private IP is written "raw": automation of this could be done through [AKS](https://learn.microsoft.com/en-us/azure/aks/static-ip#apply-a-dns-label-to-the-service) or as seen below, but it's not needed immediatly at all:
  - The change of value for this one does not happen often (once?) so automation value is not obvious on short term
  - The IP is created AFTER the whole cluster initialization, when the `private-nginx` helm release is installed for the first time: it dynamically allocates the IP in the private network as per a Kubernetes event: liefcylce is NOT coupeld to terraform
  - Automation could be to manage the private Azure LB as a Terraform resource and pass it as an argument to the private-nginx helm-release (like it's done witht the public one). But https://github.com/kubernetes/kubernetes/pull/107235 shows that the `loadBalancdrIP` field for Service is uncertain (so another reason to delay automation)

- No IPv6 DNS record for the private ingress. We don't need toi use Ipv6 today to reach these internal services.