### PR TITLE
chore(publick8s) delete 'moved' blocks after migrating their resources

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/cyrilgdn/postgresql" {
   version = "1.19.0"
   hashes = [
+    "h1:HO5EHbffnHKU02PDcwMwh571hCzBog9w+5QLQHyrBhI=",
     "h1:TnyNonQsf+M7uOP9lxHGymiLP1VE5mPIMEsk8FspD8k=",
     "zh:00f946e9e657556234b1ab6b11ff94c1f67d2dec20a0643f5f70fd4b612167e4",
     "zh:01cac73ff59c3ee3cc3716b006266a81d182f2622e944c08081551a2688ee5bb",

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -131,11 +131,6 @@ resource "azurerm_public_ip" "publick8s_ipv6" {
   tags                = local.default_tags
 }
 
-moved {
-  from = azurerm_dns_a_record.publick8s_a
-  to   = azurerm_dns_a_record.public_publick8s
-}
-
 resource "azurerm_dns_a_record" "public_publick8s" {
   name                = "public.publick8s"
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
@@ -143,11 +138,6 @@ resource "azurerm_dns_a_record" "public_publick8s" {
   ttl                 = 300
   records             = [azurerm_public_ip.publick8s_ipv4.ip_address]
   tags                = local.default_tags
-}
-
-moved {
-  from = azurerm_dns_aaaa_record.publick8s_aaaa
-  to   = azurerm_dns_aaaa_record.public_publick8s
 }
 
 resource "azurerm_dns_aaaa_record" "public_publick8s" {


### PR DESCRIPTION
Cleanup after #364 