### PR TITLE
feat(rating.jenkins.io) add a managed DB in 'public-db' instance

### DIFF
--- a/rating.jenkins.io.tf
+++ b/rating.jenkins.io.tf
@@ -1,7 +1,7 @@
-# resource "postgresql_database" "rating" {
-#   name  = "rating"
-#   owner = postgresql_role.rating.name
-# }
+resource "postgresql_database" "rating" {
+  name  = "rating"
+  owner = postgresql_role.rating.name
+}
 
 resource "random_password" "pgsql_rating_user_password" {
   length           = 24
@@ -9,21 +9,21 @@ resource "random_password" "pgsql_rating_user_password" {
   special          = true
 }
 
-# resource "postgresql_role" "rating" {
-#   name     = "rating"
-#   login    = true
-#   password = random_password.pgsql_rating_user_password.result
-# }
+resource "postgresql_role" "rating" {
+  name     = "rating"
+  login    = true
+  password = random_password.pgsql_rating_user_password.result
+}
 
-# # This (sensitive) output is meant to be encrypted into the production secret system, to be provided as a secret to the ratings.jenkins.io application
-# output "rating_dbconfig" {
-#   sensitive   = true
-#   description = "YAML (secret) values for the Helm chart jenkins-infra/rating"
-#   value       = <<-EOT
-# database:
-#   username: "${postgresql_role.rating.name}"
-#   password: "${random_password.pgsql_rating_user_password.result}"
-#   server: "${azurerm_postgresql_flexible_server.public.fqdn}"
-#   name: "${postgresql_database.rating.name}"
-#   EOT
-# }
+# This (sensitive) output is meant to be encrypted into the production secret system, to be provided as a secret to the ratings.jenkins.io application
+output "rating_dbconfig" {
+  sensitive   = true
+  description = "YAML (secret) values for the Helm chart jenkins-infra/rating"
+  value       = <<-EOT
+database:
+  username: "${postgresql_role.rating.name}"
+  password: "${random_password.pgsql_rating_user_password.result}"
+  server: "${azurerm_postgresql_flexible_server.public_db.fqdn}"
+  name: "${postgresql_database.rating.name}"
+  EOT
+}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3351

This PR adds a managed DB in the `public-db` Postgres instance for the Rating service