### PR TITLE
fix(uplink) correct output for proper connection chain

### DIFF
--- a/uplink.jenkins.io.tf
+++ b/uplink.jenkins.io.tf
@@ -21,6 +21,6 @@ output "uplink_dbconfig" {
   description = "YAML (secret) values for the Helm chart jenkins-infra/uplink"
   value       = <<-EOT
 postgresql:
-    url: postgres://${postgresql_role.uplink.name}@${postgresql_database.uplink.name}:${random_password.pgsql_uplink_user_password.result}@${azurerm_postgresql_flexible_server.public_db.fqdn}:5432/${postgresql_database.uplink.name}
+    url: postgres://${postgresql_role.uplink.name}:${random_password.pgsql_uplink_user_password.result}@${azurerm_postgresql_flexible_server.public_db.fqdn}:5432/${postgresql_database.uplink.name}
   EOT
 }

--- a/uplink.jenkins.io.tf
+++ b/uplink.jenkins.io.tf
@@ -10,7 +10,7 @@ resource "random_password" "pgsql_uplink_user_password" {
 }
 
 resource "postgresql_role" "uplink" {
-  name     = "uplink"
+  name     = "uplinkadmin"
   login    = true
   password = random_password.pgsql_uplink_user_password.result
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1568847649


This PR fixes the output for `uplink` and the default pgsql role to ease the migration.
