### PR TITLE
fix(trusted) use existing DNS zone for bounce record

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -666,11 +666,16 @@ resource "azurerm_subnet_nat_gateway_association" "trusted_outbound_ephemeral_ag
 }
 
 ####################################################################################
-## DNS records
+## Public DNS records
 ####################################################################################
+# Managed in jenkins-infra/azure-net for the letsencrypt IDP
+data "azurerm_dns_zone" "trusted_ci_jenkins_io" {
+  name                = azurerm_private_dns_zone.trusted.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+}
 resource "azurerm_dns_a_record" "trusted_bounce" {
-  name                = "bounce.trusted.ci"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  name                = "bounce"
+  zone_name           = data.azurerm_dns_zone.trusted_ci_jenkins_io.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
   records             = [azurerm_public_ip.trusted_bounce.ip_address]


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3486

There already was a public DNS zone acting as authority for `*.trusted.ci.jenkins.io` so better using it to make the `bounce` IN `A` record to be visible for public DNS clients