### PR TITLE
feat: add LDAP resource group and storage account with separated network rules

### DIFF
--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -1,26 +1,28 @@
-# resource "azurerm_resource_group" "ldap" {
-#   name     = "ldap"
-#   location = var.location
-#   tags     = local.default_tags
-# }
+resource "azurerm_resource_group" "ldap" {
+  name     = "ldap"
+  location = var.location
+  tags     = local.default_tags
+}
 
-# resource "azurerm_storage_account" "ldap_backups" {
-#   name                     = "ldapjenkinsiobackups"
-#   resource_group_name      = azurerm_resource_group.ldap.name
-#   location                 = azurerm_resource_group.ldap.location
-#   account_tier             = "Standard"
-#   account_replication_type = "GRS" # recommended for backups
-#   # https://learn.microsoft.com/en-gb/azure/storage/common/infrastructure-encryption-enable
-#   infrastructure_encryption_enabled = true
-#   min_tls_version                   = "TLS1_2" # default value, needed for tfsec
+resource "azurerm_storage_account" "ldap_backups" {
+  name                     = "ldapjenkinsiobackups"
+  resource_group_name      = azurerm_resource_group.ldap.name
+  location                 = azurerm_resource_group.ldap.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS" # recommended for backups
+  # https://learn.microsoft.com/en-gb/azure/storage/common/infrastructure-encryption-enable
+  infrastructure_encryption_enabled = true
+  min_tls_version                   = "TLS1_2" # default value, needed for tfsec
 
-#   network_rules {
-#     default_action             = "Deny"
-#     ip_rules                   = values(local.admin_allowed_ips)
-#     virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id]
-#     # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)
-#     bypass = ["AzureServices"]
-#   }
+  tags = local.default_tags
+}
 
-#   tags = local.default_tags
-# }
+resource "azurerm_storage_account_network_rules" "ldap_access" {
+  storage_account_id = azurerm_storage_account.ldap_backups.id
+
+  default_action             = "Deny"
+  ip_rules                   = values(local.admin_allowed_ips)
+  virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id]
+  # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)
+  bypass = ["AzureServices"]
+}


### PR DESCRIPTION
This PR creates a new storage account in its own resource group to store LDAP backups (LDIF dumps) instead of the existing `prodldap` one in the `prodldap` resource group, with network access limited to the admin IPs and to the publick8s cluster.

Follow-up of https://github.com/jenkins-infra/azure/pull/385#issuecomment-1577251779

Needs https://github.com/jenkins-infra/azure-net/pull/96

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1576741071