### PR TITLE
chore(ldap): add storage account primary access key as sensitive output

### DIFF
--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -26,3 +26,8 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
   # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)
   bypass = ["AzureServices"]
 }
+
+output "ldap_backups_primary_access_key" {
+  value     = azurerm_storage_account.ldap_backups.primary_access_key
+  sensitive = true
+}


### PR DESCRIPTION
This PR is to improve quality of life. It avoids the need to manually retrieve this key via Azure Portal or `az-cli`.

Follow-up of #392 