### PR TITLE
feat(ldap.jenkins.io): add `ldap` File Share to `ldapjenkinsiobackups`

### DIFF
--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -31,16 +31,6 @@ resource "azurerm_storage_share" "ldap" {
   name                 = "ldap"
   storage_account_name = azurerm_storage_account.ldap_backups.name
   quota                = 5120 # 5To
-
-  acl {
-    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
-
-    access_policy {
-      permissions = "rwdl"
-      start       = "2019-07-02T09:38:21.0000000Z"
-      expiry      = "2019-07-02T10:38:21.0000000Z"
-    }
-  }
 }
 
 output "ldap_backups_primary_access_key" {


### PR DESCRIPTION
This PR adds `ldap` File Share to `ldapjenkinsiobackups` Storage Account to avoid the "mount error(2): No such file or directory" error encountered when deploying https://github.com/jenkins-infra/kubernetes-management/pull/4042 on publick8s.

Troubleshooting guide: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/fail-to-mount-azure-file-share (`nslookup ldapjenkinsiobackups.file.core.windows.net` & `nc -v -w 2 ldapjenkinsiobackups.file.core.windows.net 445` both OK)

Needed for https://github.com/jenkins-infra/kubernetes-management/pull/4044

Follow-up of #392

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1576741071