### PR TITLE
Revert "feat(ldap.jenkins.io): add `ldap` File Share to `ldapjenkinsiobackups`"

### DIFF
--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -27,12 +27,6 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
   bypass = ["AzureServices"]
 }
 
-resource "azurerm_storage_share" "ldap" {
-  name                 = "ldap"
-  storage_account_name = azurerm_storage_account.ldap_backups.name
-  quota                = 5120 # 5To
-}
-
 output "ldap_backups_primary_access_key" {
   value     = azurerm_storage_account.ldap_backups.primary_access_key
   sensitive = true


### PR DESCRIPTION
Reverts jenkins-infra/azure#394

Error encountered:
> Error: checking for existence of existing Storage Share "ldap" (Account "ldapjenkinsiobackups" / Resource Group "ldap"): shares.Client#GetProperties: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailure" Message="This request is not authorized to perform this operation.

