### PR TITLE
feat(ldap.jenkins.io): add `ldap` File Share to `ldapjenkinsiobackups`

### DIFF
--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -22,7 +22,8 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
 
   default_action             = "Deny"
   ip_rules                   = values(local.admin_allowed_ips)
-  virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id]
+  # Allow cluster where the consumer service is, and also privatek8s so it can create the File Share inside
+  virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id, data.azurerm_subnet.privatek8s_tier.id]
   # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)
   bypass = ["AzureServices"]
 }

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -22,8 +22,7 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
 
   default_action             = "Deny"
   ip_rules                   = values(local.admin_allowed_ips)
-  # Allow cluster where the consumer service is, and also privatek8s so it can create the File Share inside
-  virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id, data.azurerm_subnet.privatek8s_tier.id]
+  virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id]
   # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)
   bypass = ["AzureServices"]
 }

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -31,16 +31,6 @@ resource "azurerm_storage_share" "ldap" {
   name                 = "ldap"
   storage_account_name = azurerm_storage_account.ldap_backups.name
   quota                = 5120 # 5To
-
-  acl {
-    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
-
-    access_policy {
-      permissions = "rwdl"
-      start       = "2019-07-02T09:38:21.0000000Z"
-      expiry      = "2019-07-02T10:38:21.0000000Z"
-    }
-  }
 }
 
 output "ldap_backups_primary_access_key" {

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -27,6 +27,22 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
   bypass = ["AzureServices"]
 }
 
+resource "azurerm_storage_share" "ldap" {
+  name                 = "ldap"
+  storage_account_name = azurerm_storage_account.ldap_backups.name
+  quota                = 5120 # 5To
+
+  acl {
+    id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI"
+
+    access_policy {
+      permissions = "rwdl"
+      start       = "2019-07-02T09:38:21.0000000Z"
+      expiry      = "2019-07-02T10:38:21.0000000Z"
+    }
+  }
+}
+
 output "ldap_backups_primary_access_key" {
   value     = azurerm_storage_account.ldap_backups.primary_access_key
   sensitive = true


### PR DESCRIPTION
Same as #394 (I'd like to try it first without adding privatek8s subnet to the network rules like in #396), but this time with the `Storage Account Contributor` role added to the Azure terraform agent (commit in the private repo: https://github.com/jenkins-infra/terraform-states/commit/23bfdcee2f166b93d635a80c9c1851bfb6e67d6c) to avoid the following error:
> Error: checking for existence of existing Storage Share "ldap" (Account "ldapjenkinsiobackups" / Resource Group "ldap"): shares.Client#GetProperties: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailure" Message="This request is not authorized to perform this operation.

This PR adds `ldap` File Share to `ldapjenkinsiobackups` Storage Account.

Needed for https://github.com/jenkins-infra/kubernetes-management/pull/4044

Follow-up of #392

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1576741071