### PR TITLE
fix(ldap/public8s): move LDAP dedicated IPv4 definition from `ldap.jenkins.io.tf` to `publick8s.tf`

### DIFF
--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -34,21 +34,7 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
 #   quota                = 5120 # 5To
 # }
 
-resource "azurerm_public_ip" "ldap_jenkins_io_ipv4" {
-  name                = "ldap-jenkins-io-ipv4"
-  resource_group_name = azurerm_resource_group.ldap.name
-  location            = var.location
-  ip_version          = "IPv4"
-  allocation_method   = "Static"
-  sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"
-  tags                = local.default_tags
-}
-
 output "ldap_backups_primary_access_key" {
   value     = azurerm_storage_account.ldap_backups.primary_access_key
   sensitive = true
-}
-
-output "ldap_public_ipv4_address" {
-  value = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
 }

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -149,6 +149,18 @@ resource "azurerm_public_ip" "publick8s_ipv4" {
   tags                = local.default_tags
 }
 
+# The LDAP service deployed on this cluster is using TCP not HTTP/HTTPS, it needs its own load balancer
+# Setting it with this determined public IP will ease DNS setup and changes
+resource "azurerm_public_ip" "ldap_jenkins_io_ipv4" {
+  name                = "ldap-jenkins-io-ipv4"
+  resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
+  location            = var.location
+  ip_version          = "IPv4"
+  allocation_method   = "Static"
+  sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"
+  tags                = local.default_tags
+}
+
 resource "azurerm_public_ip" "publick8s_ipv6" {
   name                = "public-publick8s-ipv6"
   resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
@@ -197,6 +209,10 @@ output "publick8s_public_ipv4_address" {
 
 output "publick8s_public_ipv6_address" {
   value = azurerm_public_ip.publick8s_ipv6.ip_address
+}
+
+output "ldap_jenkins_io_ipv4_address" {
+  value = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
 }
 
 output "publick8s_kube_config_command" {


### PR DESCRIPTION
As https://github.com/jenkins-infra/kubernetes-management/pull/4044 failed as the IP created in #400 should have been in the `publick8s` cluster's node resource group instead of the `ldap` one, this PR moves its definition and output from LDAP resources definition to `publick8s` resources definition (coupled)

Fixup of #400