### PR TITLE
fix(ldap,trusted) use the new public_ip resource for the LDAP connection from trusted.ci

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -46,7 +46,6 @@ locals {
 
   external_services = {
     "puppet.jenkins.io"  = azurerm_public_ip.puppet_jenkins_io.ip_address
-    "ldap.jenkins.io"    = "52.184.219.77"
     "updates.jenkins.io" = "52.202.51.185"
   }
 

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -376,7 +376,7 @@ resource "azurerm_network_security_rule" "allow_outbound_ldap_from_controller_to
   source_port_range           = "*"
   source_address_prefix       = azurerm_linux_virtual_machine.trusted_ci_controller.private_ip_address
   destination_port_range      = "636" # LDAP over TLS
-  destination_address_prefix  = local.external_services["ldap.jenkins.io"]
+  destination_address_prefix  = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
   resource_group_name         = data.azurerm_resource_group.trusted.name
   network_security_group_name = azurerm_network_security_group.trusted_ci.name
 }


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/3622, the controller trusted.ci.jenkins.io is having issues.

These issues are caused to connections timing out when trying to reach ldap.jenkins.io in the 636 port:

```
Jun 13 06:52:27 controller docker-jenkins[8264]: Caused: org.springframework.ldap.CommunicationException: ldap.jenkins.io:636; nested exception is javax.naming.CommunicationException: ldap.jenkins.io:636 [Root exception is java.net.SocketTimeoutException: connect timed out]
```

It's because we migrated the LDAP which changed its IP.

Thanks to https://github.com/jenkins-infra/azure/pull/400, the LDAP external IP is now part of the Terraform resources: let's use it to ensure that NSGs of trusted.ci.jenkins.io are always up to date.

