### PR TITLE
fix(trusted.ci) lift SSH restrictions and cleanup admin allowed public IPs

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -37,8 +37,7 @@ locals {
   admin_allowed_ips = {
     dduportal     = "85.27.58.68"
     lemeurherve   = "176.185.227.180"
-    lemeurherve-2 = "37.170.208.133"
-    lemeurherve-3 = "176.145.123.59"
+    lemeurherve-2 = "176.145.123.59"
     smerle33      = "82.64.5.129"
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -36,13 +36,10 @@ locals {
 
   admin_allowed_ips = {
     dduportal     = "85.27.58.68"
-    dduportal-2   = "86.202.255.126"
-    dduportal-3   = "90.119.200.85"
     lemeurherve   = "176.185.227.180"
     lemeurherve-2 = "37.170.208.133"
     lemeurherve-3 = "176.145.123.59"
     smerle33      = "82.64.5.129"
-    danielbeck    = "95.208.175.232"
   }
 
   external_services = {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -584,15 +584,16 @@ resource "azurerm_network_security_rule" "allow_inbound_ssh_from_bounce_to_ephem
   resource_group_name         = data.azurerm_resource_group.trusted.name
   network_security_group_name = azurerm_network_security_group.trusted_ci.name
 }
-resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_bounce" {
-  name                        = "allow-inbound-ssh-from-admins-to-bounce"
+#tfsec:ignore:azure-network-no-public-ingress
+resource "azurerm_network_security_rule" "allow_inbound_ssh_from_internet_to_bounce" {
+  name                        = "allow-inbound-ssh-from-internet-to-bounce"
   priority                    = 4000
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "*"
+  source_address_prefix       = "Internet"
   destination_address_prefix  = azurerm_linux_virtual_machine.trusted_bounce.private_ip_address
   resource_group_name         = data.azurerm_resource_group.trusted.name
   network_security_group_name = azurerm_network_security_group.trusted_ci.name

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -592,21 +592,7 @@ resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_bounc
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefixes     = values(local.admin_allowed_ips)
-  destination_address_prefix  = azurerm_linux_virtual_machine.trusted_bounce.private_ip_address
-  resource_group_name         = data.azurerm_resource_group.trusted.name
-  network_security_group_name = azurerm_network_security_group.trusted_ci.name
-}
-# TODO: remove when data migration is complete
-resource "azurerm_network_security_rule" "allow_inbound_ssh_from_legacy_trusted_to_bounce" {
-  name                        = "allow-inbound-ssh-from-legacy-trusted-to-bounce"
-  priority                    = 4001
-  direction                   = "Inbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "22"
-  source_address_prefixes     = ["3.209.43.20", "67.202.34.237"]
+  source_address_prefix       = "*"
   destination_address_prefix  = azurerm_linux_virtual_machine.trusted_bounce.private_ip_address
   resource_group_name         = data.azurerm_resource_group.trusted.name
   network_security_group_name = azurerm_network_security_group.trusted_ci.name


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3624 (short fix).

It avoids impractical PRs such as #409 and the subsequent Terraform rework that would have make a list concatenation between "admin" and "trusted.ci users" public IPs.