### PR TITLE
feat(ci.jenkins.io) add required resources for ephemeral Azure VM agents in the new public-vnet

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -1,21 +1,12 @@
-/** Two resources groups: one for the controller, the second for the agents **/
+####################################################################################
+## Resources for the Controller VM
+####################################################################################
 resource "azurerm_resource_group" "ci_jenkins_io_controller" {
   name     = "ci-jenkins-io-controller"
-  location = "East US 2"
-
-  tags = local.default_tags
+  location = data.azurerm_virtual_network.public.location
+  tags     = local.default_tags
 }
 
-# resource "azurerm_resource_group" "ci_jenkins_io_agents" {
-#   name     = "eastus-cijenkinsio"
-#   location = "East US"
-# }
-resource "azurerm_resource_group" "eastus_ci_jenkins_io_agents" {
-  name     = "eastus-cijenkinsio"
-  location = "East US"
-}
-
-/** Controller Resources **/
 # Defined in https://github.com/jenkins-infra/azure-net/blob/d30a37c27b649aebd158ecb5d631ff8d7f1bab4e/vnets.tf#L175-L183
 data "azurerm_subnet" "ci_jenkins_io_controller" {
   name                 = "${data.azurerm_virtual_network.public.name}-ci_jenkins_io_controller"
@@ -137,7 +128,152 @@ resource "azurerm_virtual_machine_data_disk_attachment" "ci_jenkins_io_data" {
   caching            = "ReadWrite"
 }
 
-/** Agent Resources **/
+####################################################################################
+## Resources for the Ephemeral Agents
+####################################################################################
+# TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3535 is done
+resource "azurerm_resource_group" "eastus_ci_jenkins_io_agents" {
+  name     = "eastus-cijenkinsio"
+  location = "East US"
+}
+resource "azurerm_resource_group" "ci_jenkins_io_ephemeral_agents" {
+  name     = "ci-jenkins-io-ephemeral-agents"
+  location = data.azurerm_virtual_network.public.location
+  tags     = local.default_tags
+}
+data "azurerm_subnet" "ci_jenkins_io_ephemeral_agents" {
+  name                 = "${data.azurerm_virtual_network.public.name}-ci_jenkins_io_agents"
+  virtual_network_name = data.azurerm_virtual_network.public.name
+  resource_group_name  = data.azurerm_resource_group.public.name
+}
+resource "azurerm_network_security_group" "ci_jenkins_io_ephemeral_agents" {
+  name                = data.azurerm_subnet.ci_jenkins_io_ephemeral_agents.name
+  location            = data.azurerm_resource_group.public.location
+  resource_group_name = data.azurerm_resource_group.public.name
+  tags                = local.default_tags
+}
+resource "azurerm_subnet_network_security_group_association" "ci_jenkins_io_ephemeral_agents" {
+  subnet_id                 = data.azurerm_subnet.ci_jenkins_io_ephemeral_agents.id
+  network_security_group_id = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.id
+}
+## Outbound Rules (different set of priorities than Inbound rules) ##
+# This rule overrides an Azure-Default rule. its priority must be < 65000.
+resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ci_jenkins_io_ephemeral_agents_subnet_to_internet" {
+  name                        = "allow-outbound-ssh-from-ci_jenkins_io_ephemeral_agents-subnet-to-internet"
+  priority                    = 4092
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  source_address_prefix       = "VirtualNetwork"
+  destination_port_range      = "22"
+  destination_address_prefix  = "Internet" # TODO: restrict to GitHub IPs from their meta endpoint (subsection git) - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-githubs-ip-addresses
+  resource_group_name         = data.azurerm_resource_group.public.name
+  network_security_group_name = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
+#tfsec:ignore:azure-network-no-public-egress
+resource "azurerm_network_security_rule" "allow_outbound_jenkins_usage_from_ci_jenkins_io_ephemeral_agents_subnet_to_controller" {
+  name                  = "allow-outbound-jenkins-usage-from-ci_jenkins_io_ephemeral_agents-subnet-to-controller"
+  priority              = 4093
+  direction             = "Outbound"
+  access                = "Allow"
+  protocol              = "Tcp"
+  source_port_range     = "*"
+  source_address_prefix = "VirtualNetwork"
+  destination_port_ranges = [
+    "443",   # Only HTTPS
+    "50000", # Direct TCP Inbound protocol
+  ]
+  destination_address_prefixes = [
+    azurerm_linux_virtual_machine.ci_jenkins_io.private_ip_address, # New controller VM
+    # TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3535 is done
+    "104.208.238.39", # Old azure.ci.jenkins.io VM
+  ]
+  resource_group_name         = data.azurerm_resource_group.public.name
+  network_security_group_name = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
+resource "azurerm_network_security_rule" "allow_outbound_http_from_ci_jenkins_io_ephemeral_agents_subnet_to_internet" {
+  name                        = "allow-outbound-http-from-ci_jenkins_io_ephemeral_agents-subnet-to-internet"
+  priority                    = 4094
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  source_address_prefixes     = data.azurerm_subnet.ci_jenkins_io_ephemeral_agents.address_prefixes
+  destination_port_ranges     = ["80", "443"]
+  destination_address_prefix  = "Internet"
+  resource_group_name         = data.azurerm_resource_group.public.name
+  network_security_group_name = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
+resource "azurerm_network_security_rule" "deny_all_outbound_from_ci_jenkins_io_ephemeral_agents_subnet_to_internet" {
+  name                        = "deny-all-outbound-from-ci_jenkins_io_ephemeral_agents-subnet-to-internet"
+  priority                    = 4095
+  direction                   = "Outbound"
+  access                      = "Deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "Internet"
+  resource_group_name         = data.azurerm_resource_group.public.name
+  network_security_group_name = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
+# This rule overrides an Azure-Default rule. its priority must be < 65000.
+resource "azurerm_network_security_rule" "deny_all_outbound_from_ci_jenkins_io_ephemeral_agents_subnet_to_vnet" {
+  name                         = "deny-all-outbound-from-ci_jenkins_io_ephemeral_agents-subnet-to-vnet"
+  priority                     = 4096 # Maximum value allowed by the provider
+  direction                    = "Outbound"
+  access                       = "Deny"
+  protocol                     = "*"
+  source_port_range            = "*"
+  destination_port_range       = "*"
+  source_address_prefix        = "VirtualNetwork"
+  destination_address_prefixes = data.azurerm_virtual_network.trusted.address_space
+  resource_group_name          = data.azurerm_resource_group.public.name
+  network_security_group_name  = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
+## Inbound Rules (different set of priorities than Outbound rules) ##
+resource "azurerm_network_security_rule" "allow_inbound_ssh_from_privatevpn_to_ephemeral_agents" {
+  name                         = "allow-inbound-ssh-from-privatevpn-to-ephemeral-agents"
+  priority                     = 4094
+  direction                    = "Inbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefixes      = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+  destination_address_prefixes = data.azurerm_subnet.ci_jenkins_io_ephemeral_agents.address_prefixes
+  resource_group_name          = data.azurerm_resource_group.public.name
+  network_security_group_name  = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
+# This rule overrides an Azure-Default rule. its priority must be < 65000.
+resource "azurerm_network_security_rule" "deny_all_inbound_from_internet_to_ci_jenkins_io_ephemeral_agents_subnet" {
+  name                        = "deny-all-inbound-from-internet-to-ci_jenkins_io_ephemeral_agents-subnet"
+  priority                    = 4095
+  direction                   = "Inbound"
+  access                      = "Deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "Internet"
+  destination_address_prefix  = "*"
+  resource_group_name         = data.azurerm_resource_group.public.name
+  network_security_group_name = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
+# This rule overrides an Azure-Default rule. its priority must be < 65000
+resource "azurerm_network_security_rule" "deny_all_inbound_from_vnet_to_ci_jenkins_io_ephemeral_agents_subnet" {
+  name                        = "deny-all-inbound-from-vnet-to-ci_jenkins_io_ephemeral_agents-subnet"
+  priority                    = 4096 # Maximum value allowed by the Azure Terraform Provider
+  direction                   = "Inbound"
+  access                      = "Deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "VirtualNetwork"
+  destination_address_prefix  = "*"
+  resource_group_name         = data.azurerm_resource_group.public.name
+  network_security_group_name = azurerm_network_security_group.ci_jenkins_io_ephemeral_agents.name
+}
 resource "azurerm_storage_account" "eastus_ci_jenkins_io_agents" {
   name                     = "cijenkinsiovmagents"
   resource_group_name      = azurerm_resource_group.eastus_ci_jenkins_io_agents.name
@@ -147,8 +283,19 @@ resource "azurerm_storage_account" "eastus_ci_jenkins_io_agents" {
   min_tls_version          = "TLS1_2" # default value, needed for tfsec
   tags                     = local.default_tags
 }
+resource "azurerm_storage_account" "ci_jenkins_io_ephemeral_agents" {
+  name                     = "cijenkinsioagents"
+  resource_group_name      = azurerm_resource_group.ci_jenkins_io_ephemeral_agents.name
+  location                 = azurerm_resource_group.ci_jenkins_io_ephemeral_agents.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2" # default value, needed for tfsec
+  tags                     = local.default_tags
+}
 
-# Azure AD resources to allow controller to spawn agents in Azure
+####################################################################################
+## Azure Active Directory Resources to allow controller spawning ephemeral agents
+####################################################################################
 resource "azuread_application" "ci_jenkins_io" {
   display_name = "ci.jenkins.io"
   owners = [
@@ -179,28 +326,46 @@ resource "azuread_application_password" "ci_jenkins_io" {
   display_name          = "ci.jenkins.io-tf-managed"
   end_date              = "2024-03-28T00:00:00Z"
 }
-
-# Allow application to manage AzureRM resources inside the agents resource groups
-resource "azurerm_role_assignment" "ci_jenkins_io_contributor_in_eastus_agent_resourcegroup" {
-  scope                = azurerm_resource_group.eastus_ci_jenkins_io_agents.id
-  role_definition_name = "Contributor"
-  principal_id         = azuread_service_principal.ci_jenkins_io.id
-}
 resource "azurerm_role_assignment" "ci_jenkins_io_read_packer_prod_images" {
   scope                = azurerm_resource_group.packer_images["prod"].id
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.ci_jenkins_io.id
 }
+resource "azurerm_role_assignment" "ci_jenkins_io_contributor_in_ephemeral_agent_resourcegroup" {
+  scope                = azurerm_resource_group.ci_jenkins_io_ephemeral_agents.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.ci_jenkins_io.id
+}
+resource "azurerm_role_assignment" "ci_jenkins_io_manage_net_interfaces_subnet_ci_jenkins_io_ephemeral_agents" {
+  scope                = data.azurerm_subnet.ci_jenkins_io_ephemeral_agents.id
+  role_definition_name = "Virtual Machine Contributor"
+  principal_id         = azuread_service_principal.ci_jenkins_io.id
+}
+resource "azurerm_role_assignment" "ci_jenkins_io_read_publicvnet_subnets" {
+  scope              = data.azurerm_virtual_network.public.id
+  role_definition_id = azurerm_role_definition.prod_public_vnet_reader.role_definition_resource_id
+  principal_id       = azuread_service_principal.ci_jenkins_io.id
+}
+###
+# TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3535 is done
+resource "azurerm_role_assignment" "ci_jenkins_io_contributor_in_eastus_agent_resourcegroup" {
+  scope                = azurerm_resource_group.eastus_ci_jenkins_io_agents.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.ci_jenkins_io.id
+}
+# TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3535 is done
 data "azurerm_subnet" "eastus_ci_jenkins_io_agents" {
   name                 = "ci.j-agents-vm"
   virtual_network_name = data.azurerm_virtual_network.public_prod.name
   resource_group_name  = data.azurerm_resource_group.public_prod.name
 }
+# TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3535 is done
 resource "azurerm_role_assignment" "ci_jenkins_io_manage_net_interfaces_subnet_ci_agents" {
   scope                = data.azurerm_subnet.eastus_ci_jenkins_io_agents.id
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = azuread_service_principal.ci_jenkins_io.id
 }
+# TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3535 is done
 resource "azurerm_role_assignment" "ci_jenkins_io_read_public_vnets" {
   scope              = data.azurerm_virtual_network.public_prod.id
   role_definition_id = azurerm_role_definition.prod_public_vnet_reader.role_definition_resource_id


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3535#issuecomment-1591610874

Follow-up of https://github.com/jenkins-infra/azure/pull/412

This PR creates the required resources for the ephemeral agents for ci.jenkins.io in US East 2 in the new public-vnet network

