### PR TITLE
chore: simplify role_assignment scopes 

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -62,12 +62,12 @@ resource "azuread_application_password" "cert_ci_jenkins_io" {
 }
 # Allow Service Principal to manage AzureRM resources inside the agents resource groups
 resource "azurerm_role_assignment" "cert_ci_jenkins_io_allow_azurerm" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.cert_ci_jenkins_io_agents.name}"
+  scope                = azurerm_resource_group.cert_ci_jenkins_io_agents.id
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.cert_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "cert_ci_jenkins_io_allow_packer" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/prod-packer-images"
+  scope                = azurerm_resource_group.packer_images["prod"].id
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.cert_ci_jenkins_io.id
 }

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -10,10 +10,6 @@ resource "azurerm_resource_group" "ci_jenkins_io_controller" {
 #   name     = "eastus-cijenkinsio"
 #   location = "East US"
 # }
-moved {
-  from = azurerm_resource_group.ci_jenkins_io_agents
-  to   = azurerm_resource_group.eastus_ci_jenkins_io_agents
-}
 resource "azurerm_resource_group" "eastus_ci_jenkins_io_agents" {
   name     = "eastus-cijenkinsio"
   location = "East US"
@@ -142,10 +138,6 @@ resource "azurerm_virtual_machine_data_disk_attachment" "ci_jenkins_io_data" {
 }
 
 /** Agent Resources **/
-moved {
-  from = azurerm_storage_account.ci_jenkins_io_agents
-  to   = azurerm_storage_account.eastus_ci_jenkins_io_agents
-}
 resource "azurerm_storage_account" "eastus_ci_jenkins_io_agents" {
   name                     = "cijenkinsiovmagents"
   resource_group_name      = azurerm_resource_group.eastus_ci_jenkins_io_agents.name
@@ -189,10 +181,6 @@ resource "azuread_application_password" "ci_jenkins_io" {
 }
 
 # Allow application to manage AzureRM resources inside the agents resource groups
-moved {
-  from = azurerm_role_assignment.ci_jenkins_io_contributor_in_agent_resourcegroup
-  to   = azurerm_role_assignment.ci_jenkins_io_contributor_in_eastus_agent_resourcegroup
-}
 resource "azurerm_role_assignment" "ci_jenkins_io_contributor_in_eastus_agent_resourcegroup" {
   scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.eastus_ci_jenkins_io_agents.name}"
   role_definition_name = "Contributor"

--- a/custom-roles.tf
+++ b/custom-roles.tf
@@ -1,6 +1,6 @@
 resource "azurerm_role_definition" "private_vnet_reader" {
   name  = "ReadPrivateVNET"
-  scope = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}"
+  scope = data.azurerm_virtual_network.private.id
 
   permissions {
     actions = ["Microsoft.Network/virtualNetworks/read"]
@@ -9,7 +9,7 @@ resource "azurerm_role_definition" "private_vnet_reader" {
 
 resource "azurerm_role_definition" "prod_public_vnet_reader" {
   name  = "ReadProdPublicVNET"
-  scope = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.public_prod.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.public_prod.name}"
+  scope = data.azurerm_virtual_network.public_prod.id
 
   permissions {
     actions = ["Microsoft.Network/virtualNetworks/read"]

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -48,22 +48,22 @@ resource "azuread_application_password" "infra_ci_jenkins_io" {
 }
 # Allow Service Principal to manage AzureRM resources inside the agents resource groups
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_azurerm" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.infra_ci_jenkins_io_agents.name}"
+  scope                = azurerm_resource_group.infra_ci_jenkins_io_agents.id
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.infra_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/prod-packer-images"
+  scope                = azurerm_resource_group.packer_images["prod"].id
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.infra_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_subnet_role" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.privatek8s_tier.name}"
+  scope                = data.azurerm_subnet.privatek8s_tier.id
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = azuread_service_principal.infra_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_subnet_private_vnet_reader" {
-  scope              = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}"
+  scope              = data.azurerm_virtual_network.private.id
   role_definition_id = azurerm_role_definition.private_vnet_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.infra_ci_jenkins_io.id
 }

--- a/packer-resources.tf
+++ b/packer-resources.tf
@@ -111,7 +111,7 @@ resource "azurerm_shared_image" "jenkins_agent_images" {
 resource "azurerm_role_assignment" "packer_role_images_assignement" {
   for_each = azurerm_resource_group.packer_images
 
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${each.value.name}"
+  scope                = each.value.id
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.packer.id
 }
@@ -119,7 +119,7 @@ resource "azurerm_role_assignment" "packer_role_images_assignement" {
 resource "azurerm_role_assignment" "packer_role_builds_assignement" {
   for_each = azurerm_resource_group.packer_builds
 
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${each.value.name}"
+  scope                = each.value.id
   role_definition_name = "Contributor"
   principal_id         = azuread_service_principal.packer.id
 }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -146,7 +146,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "windows2019pool" {
 
 # Allow cluster to manage LBs in the privatek8s-tier subnet (Public LB)
 resource "azurerm_role_assignment" "privatek8s_networkcontributor" {
-  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.privatek8s_tier.name}"
+  scope                            = data.azurerm_subnet.privatek8s_tier.id
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
   skip_service_principal_aad_check = true
@@ -154,7 +154,7 @@ resource "azurerm_role_assignment" "privatek8s_networkcontributor" {
 
 # Allow cluster to manage LBs in the data-tier subnet (internal LBs)
 resource "azurerm_role_assignment" "datatier_networkcontributor" {
-  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.private.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.private.name}/subnets/${data.azurerm_subnet.private_vnet_data_tier.name}"
+  scope                            = data.azurerm_subnet.private_vnet_data_tier.id
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
   skip_service_principal_aad_check = true

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -111,7 +111,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "arm64small" {
 
 # Allow cluster to manage LBs in the publick8s-tier subnet (Public LB)
 resource "azurerm_role_assignment" "publick8s_networkcontributor" {
-  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.public.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.public.name}/subnets/${data.azurerm_subnet.publick8s_tier.name}"
+  scope                            = data.azurerm_subnet.publick8s_tier.id
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
   skip_service_principal_aad_check = true
@@ -119,7 +119,7 @@ resource "azurerm_role_assignment" "publick8s_networkcontributor" {
 
 # Allow cluster to manage LBs in the public-vnet-data-tier subnet (internal LBs)
 resource "azurerm_role_assignment" "public_vnet_data_tier_networkcontributor" {
-  scope                            = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.public.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.public.name}/subnets/${data.azurerm_subnet.public_vnet_data_tier.name}"
+  scope                            = data.azurerm_subnet.public_vnet_data_tier.id
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
   skip_service_principal_aad_check = true

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -80,29 +80,29 @@ resource "azuread_application_password" "trusted_ci_jenkins_io" {
 }
 resource "azurerm_role_definition" "trusted_vnet_reader" {
   name  = "ReadTrustedVNET"
-  scope = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.trusted.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.trusted.name}"
+  scope = data.azurerm_virtual_network.trusted.id
   permissions {
     actions = ["Microsoft.Network/virtualNetworks/read"]
   }
 }
 # Allow Service Principal to manage AzureRM resources inside the ephemeral agents resource group
 resource "azurerm_role_assignment" "trusted_ci_jenkins_io_allow_vmcontribution_in_ephemeralagents_rg" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${azurerm_resource_group.trusted_ci_jenkins_io_ephemeral_agents.name}"
+  scope                = azurerm_resource_group.trusted_ci_jenkins_io_ephemeral_agents.id
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = azuread_service_principal.trusted_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "trusted_ci_jenkins_io_allow_packer" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/prod-packer-images"
+  scope                = azurerm_resource_group.packer_images["prod"].id
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.trusted_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "trusted_ci_jenkins_io_allow_azurevm_agents_subnet" {
-  scope                = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.trusted.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.trusted.name}/subnets/${data.azurerm_subnet.trusted_ephemeral_agents.name}"
+  scope                = data.azurerm_subnet.trusted_ephemeral_agents.id
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = azuread_service_principal.trusted_ci_jenkins_io.id
 }
 resource "azurerm_role_assignment" "trusted_ci_jenkins_io_allow_read_trustedvnet" {
-  scope              = "${data.azurerm_subscription.jenkins.id}/resourceGroups/${data.azurerm_resource_group.trusted.name}/providers/Microsoft.Network/virtualNetworks/${data.azurerm_virtual_network.trusted.name}"
+  scope              = data.azurerm_virtual_network.trusted.id
   role_definition_id = azurerm_role_definition.trusted_vnet_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.trusted_ci_jenkins_io.id
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -331,10 +331,6 @@ resource "azurerm_private_dns_a_record" "trusted_permanent_agent" {
 ####################################################################################
 ## Network Security Groups for TRUSTED subnets
 ####################################################################################
-moved {
-  from = azurerm_network_security_group.trusted_ci_controller
-  to   = azurerm_network_security_group.trusted_ci
-}
 resource "azurerm_network_security_group" "trusted_ci" {
   name                = data.azurerm_subnet.trusted_ci_controller.name
   location            = data.azurerm_resource_group.trusted.location


### PR DESCRIPTION
As per https://github.com/jenkins-infra/azure/pull/412, the `id` atttributes works as expected for scopes

Thanks @timja !