### PR TITLE
hotfix(publick8s) remove AAAA (IPv6) DNS record for `get.jenkins.io`

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -180,14 +180,15 @@ resource "azurerm_dns_a_record" "public_publick8s" {
   tags                = local.default_tags
 }
 
-resource "azurerm_dns_aaaa_record" "public_publick8s" {
-  name                = "public.publick8s"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 300
-  records             = [azurerm_public_ip.publick8s_ipv6.ip_address]
-  tags                = local.default_tags
-}
+## TODO: uncomment for https://github.com/jenkins-infra/helpdesk/issues/3639
+# resource "azurerm_dns_aaaa_record" "public_publick8s" {
+#   name                = "public.publick8s"
+#   zone_name           = data.azurerm_dns_zone.jenkinsio.name
+#   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+#   ttl                 = 300
+#   records             = [azurerm_public_ip.publick8s_ipv6.ip_address]
+#   tags                = local.default_tags
+# }
 
 resource "azurerm_dns_a_record" "private_publick8s" {
   name                = "private.publick8s"


### PR DESCRIPTION
Until ingress works with direct IPv6 (ref. https://github.com/jenkins-infra/helpdesk/issues/3639\#issuecomment-1610982919)