### PR TITLE
feat(locks) add locks on all public IPs that should not change

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -58,6 +58,12 @@ resource "azurerm_public_ip" "ci_jenkins_io_controller" {
   sku                 = "Standard"
   tags                = local.default_tags
 }
+resource "azurerm_management_lock" "ci_jenkins_io_controller_publicip" {
+  name       = "ci-jenkins-io-controller-publicip"
+  scope      = azurerm_public_ip.ci_jenkins_io_controller.id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a sensitive resource that should not be removed"
+}
 resource "azurerm_network_interface" "ci_jenkins_io_controller" {
   name                = "controller.${local.service_fqdn}"
   location            = azurerm_resource_group.ci_jenkins_io_controller.location

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -199,6 +199,12 @@ resource "azurerm_public_ip" "public_privatek8s" {
   sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"
   tags                = local.default_tags
 }
+resource "azurerm_management_lock" "public_privatek8s_publicip" {
+  name       = "public-privatek8s-publicip"
+  scope      = azurerm_public_ip.public_privatek8s.id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a sensitive resource that should not be removed when privatek8s is removed"
+}
 
 resource "azurerm_dns_a_record" "public_privatek8s" {
   name                = "public.privatek8s"

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -186,6 +186,12 @@ resource "azurerm_public_ip" "publick8s_ipv4" {
   sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"
   tags                = local.default_tags
 }
+resource "azurerm_management_lock" "publick8s_ipv4" {
+  name       = "public-publick8s-ipv4"
+  scope      = azurerm_public_ip.publick8s_ipv4.id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a sensitive resource that should not be removed when publick8s cluster is re-created"
+}
 
 # The LDAP service deployed on this cluster is using TCP not HTTP/HTTPS, it needs its own load balancer
 # Setting it with this determined public IP will ease DNS setup and changes
@@ -198,6 +204,12 @@ resource "azurerm_public_ip" "ldap_jenkins_io_ipv4" {
   sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"
   tags                = local.default_tags
 }
+resource "azurerm_management_lock" "ldap_jenkins_io_ipv4" {
+  name       = "ldap-jenkins-io-ipv4"
+  scope      = azurerm_public_ip.ldap_jenkins_io_ipv4.id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a sensitive resource that should not be removed when publick8s cluster is re-created"
+}
 
 resource "azurerm_public_ip" "publick8s_ipv6" {
   name                = "public-publick8s-ipv6"
@@ -207,6 +219,12 @@ resource "azurerm_public_ip" "publick8s_ipv6" {
   allocation_method   = "Static"
   sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"
   tags                = local.default_tags
+}
+resource "azurerm_management_lock" "publick8s_ipv6" {
+  name       = "public-publick8s-ipv6"
+  scope      = azurerm_public_ip.publick8s_ipv6.id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a sensitive resource that should not be removed when publick8s cluster is re-created"
 }
 
 resource "azurerm_dns_a_record" "public_publick8s" {

--- a/puppet.jenkins.io.tf
+++ b/puppet.jenkins.io.tf
@@ -11,6 +11,12 @@ resource "azurerm_public_ip" "puppet_jenkins_io" {
   sku                 = "Standard"
   tags                = local.default_tags
 }
+resource "azurerm_management_lock" "puppet_jenkins_io_publicip" {
+  name       = "puppet.jenkins.io-publicip"
+  scope      = azurerm_public_ip.puppet_jenkins_io.id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a sensitive resource that should not be removed"
+}
 # Defined in https://github.com/jenkins-infra/azure-net/tree/main/vnets.tf
 data "azurerm_subnet" "dmz" {
   name                 = "${data.azurerm_virtual_network.private.name}-dmz"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3582#issuecomment-1629210833

Notes:

- The public IPs on trusted.ci (for the inbound SSH to bounce VM and for the subnet's gateway) are not required to be locked
- Additional locks might be added to the data disks of ci.j or trusted.ci.j for instance, as part of https://github.com/jenkins-infra/helpdesk/issues/3479 if this works as expected