### PR TITLE
fix(updates.jenkins.io): allow non SSL connections to Redis

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -36,7 +36,7 @@ resource "azurerm_redis_cache" "updates_jenkins_io" {
   capacity            = 1
   family              = "C"        # Basic/Standard SKU family
   sku_name            = "Standard" # A replicated cache in a two node Primary/Secondary configuration managed by Microsoft, with a high availability SLA.
-  enable_non_ssl_port = false
+  enable_non_ssl_port = true
   minimum_tls_version = "1.2"
 
   tags = local.default_tags


### PR DESCRIPTION
Fix the following error when trying to deploy https://github.com/jenkins-infra/kubernetes-management/pull/4211:

> UTC Database is down: dial tcp 52.184.161.24:6379: i/o timeout

This is the same settings (allow non SSL) which is currently configured for the mirrorbits database.

Manually tested via Azure Portal, current settings:
<img width="162" alt="image" src="https://github.com/jenkins-infra/azure/assets/91831478/0b92bb88-3321-4d74-b6a9-d57c4190045b">

Settings with this change:
<img width="159" alt="image" src="https://github.com/jenkins-infra/azure/assets/91831478/6ac15d3a-190c-4ce9-9d47-bc4e177be6ec">

Connection OK.