### PR TITLE
refactor(publick8s,privatek8s) define infraciadmin SA with a terraform module

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -233,6 +233,22 @@ output "privatek8s_public_ip_address" {
   value = azurerm_public_ip.public_privatek8s.ip_address
 }
 
+# Configure the jenkins-infra/kubernetes-management admin service account
+module "privatek8s_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.privatek8s
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = azurerm_kubernetes_cluster.privatek8s.name
+  cluster_hostname           = azurerm_kubernetes_cluster.privatek8s.kube_config.0.host
+  cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.privatek8s.kube_config.0.cluster_ca_certificate
+}
+
+output "kubeconfig_privatek8s" {
+  sensitive = true
+  value     = module.privatek8s_admin_sa.kubeconfig
+}
+
 output "privatek8s_kube_config_command" {
   value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.privatek8s.name} --resource-group ${azurerm_kubernetes_cluster.privatek8s.resource_group_name}"
 }

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -256,6 +256,22 @@ output "ldap_jenkins_io_ipv4_address" {
   value = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
 }
 
+# Configure the jenkins-infra/kubernetes-management admin service account
+module "publick8s_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.publick8s
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = azurerm_kubernetes_cluster.publick8s.name
+  cluster_hostname           = azurerm_kubernetes_cluster.publick8s.kube_config.0.host
+  cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate
+}
+
+output "kubeconfig_publick8s" {
+  sensitive = true
+  value     = module.publick8s_admin_sa.kubeconfig
+}
+
 output "publick8s_kube_config_command" {
   value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.publick8s.name} --resource-group ${azurerm_kubernetes_cluster.publick8s.resource_group_name}"
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3679

Same as https://github.com/jenkins-infra/digitalocean/pull/134 + https://github.com/jenkins-infra/digitalocean/pull/136 but for Azure

Please note that the `privatek8s` SA can be used directly by the pod of jenkins-infra/kubernetes-management by mounting the token in the pod directly.