### PR TITLE
fix(ci.jenkins.io, trusted.ci.jenkins.io) fix controler module initial usage

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -50,6 +50,10 @@ moved {
   to   = module.ci_jenkins_io.azurerm_dns_a_record.controller
 }
 moved {
+  from = module.ci_jenkins_io.azurerm_dns_a_record.controller
+  to   = module.ci_jenkins_io.azurerm_dns_a_record.controller[0]
+}
+moved {
   from = azurerm_dns_a_record.private_ci_jenkins_io_controller
   to   = module.ci_jenkins_io.azurerm_dns_a_record.private_controller[0]
 }

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -8,27 +8,10 @@ data "azurerm_subnet" "ci_jenkins_io_controller" {
 ####################################################################################
 ## Resources for the Controller VM
 ####################################################################################
-## Service DNS records
-resource "azurerm_dns_cname_record" "ci_jenkins_io" {
-  name                = module.ci_jenkins_io.service_short_hostname
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  record              = module.ci_jenkins_io.controller_public_fqdn
-  tags                = local.default_tags
-}
-resource "azurerm_dns_cname_record" "assets_ci_jenkins_io" {
-  name                = "assets.${module.ci_jenkins_io.service_short_hostname}"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  record              = module.ci_jenkins_io.controller_public_fqdn
-  tags                = local.default_tags
-}
 module "ci_jenkins_io" {
   source = "./.shared-tools/terraform/modules/azure-jenkins-controller"
 
-  controller_short_hostname    = "ci"
+  service_fqdn                 = "ci.jenkins.io"
   location                     = data.azurerm_virtual_network.public.location
   admin_username               = local.admin_username
   admin_ssh_publickey          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKvZ23dkvhjSU0Gxl5+mKcBOwmR7gqJDYeA1/Xzl3otV4CtC5te5Vx7YnNEFDXD6BsNkFaliXa34yE37WMdWl+exIURBMhBLmOPxEP/cWA5ZbXP//78ejZsxawBpBJy27uQhdcR0zVoMJc8Q9ShYl5YT/Tq1UcPq2wTNFvnrBJL1FrpGT+6l46BTHI+Wpso8BK64LsfX3hKnJEGuHSM0GAcYQSpXAeGS9zObKyZpk3of/Qw/2sVilIOAgNODbwqyWgEBTjMUln71Mjlt1hsEkv3K/VdvpFNF8VNq5k94VX6Rvg5FQBRL5IrlkuNwGWcBbl8Ydqk4wrD3b/PrtuLBEUsqbNhLnlEvFcjak+u2kzCov73csN/oylR0Tkr2y9x2HfZgDJVtvKjkkc4QERo7AqlTuy1whGfDYsioeabVLjZ9ahPjakv9qwcBrEEF+pAya7Q3AgNFVSdPgLDEwEO8GUHaxAjtyXXv9+yPdoDGmG3Pfn3KqM6UZjHCxne3Dr5ZE="
@@ -40,6 +23,23 @@ module "ci_jenkins_io" {
   controller_vm_size           = "Standard_D8as_v5"
   is_public                    = true
   default_tags                 = local.default_tags
+}
+## Service DNS records
+resource "azurerm_dns_cname_record" "ci_jenkins_io" {
+  name                = trimsuffix(trimsuffix(module.ci_jenkins_io.service_fqdn, data.azurerm_dns_zone.jenkinsio.name), ".")
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  record              = module.ci_jenkins_io.controller_public_fqdn
+  tags                = local.default_tags
+}
+resource "azurerm_dns_cname_record" "assets_ci_jenkins_io" {
+  name                = "assets.${azurerm_dns_cname_record.ci_jenkins_io.name}"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  record              = module.ci_jenkins_io.controller_public_fqdn
+  tags                = local.default_tags
 }
 moved {
   from = azurerm_resource_group.ci_jenkins_io_controller
@@ -132,7 +132,7 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ci_controller_
   source_port_range           = "*"
   source_address_prefix       = module.ci_jenkins_io.controller_private_ipv4
   destination_port_ranges     = ["22"]
-  destination_address_prefix  = local.external_services["s390x.jenkins.io"]
+  destination_address_prefix  = local.external_services["s390x.${data.azurerm_dns_zone.jenkinsio.name}"]
   resource_group_name         = module.ci_jenkins_io.controller_resourcegroup_name
   network_security_group_name = azurerm_network_security_group.ci_jenkins_io_controller.name
 }
@@ -421,7 +421,7 @@ resource "azurerm_storage_account" "ci_jenkins_io_ephemeral_agents" {
 ## Azure Active Directory Resources to allow controller spawning ephemeral agents
 ####################################################################################
 resource "azuread_application" "ci_jenkins_io" {
-  display_name = "ci.jenkins.io"
+  display_name = module.ci_jenkins_io.service_fqdn
   owners = [
     data.azuread_service_principal.terraform_production.id,
   ]
@@ -447,7 +447,7 @@ resource "azuread_service_principal" "ci_jenkins_io" {
 }
 resource "azuread_application_password" "ci_jenkins_io" {
   application_object_id = azuread_application.ci_jenkins_io.object_id
-  display_name          = "ci.jenkins.io-tf-managed"
+  display_name          = "${module.ci_jenkins_io.service_fqdn}-tf-managed"
   end_date              = "2024-03-28T00:00:00Z"
 }
 resource "azurerm_role_assignment" "ci_jenkins_io_read_packer_prod_images" {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -41,9 +41,6 @@ module "trusted_ci_jenkins_io" {
   location                     = data.azurerm_virtual_network.trusted.location
   admin_username               = local.admin_username
   admin_ssh_publickey          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5K7Ro7jBl5Kc68RdzG6EXHstIBFSxO5Da8SQJSMeCbb4cHTYuBBH8jNsAFcnkN64kEu+YhmlxaWEVEIrPgfGfs13ZL7v9p+Nt76tsz6gnVdAy2zCz607pAWe7p4bBn6T9zdZcBSnvjawO+8t/5ue4ngcfAjanN5OsOgLeD6yqVyP8YTERjW78jvp2TFrIYmgWMI5ES1ln32PQmRZwc1eAOsyGJW/YIBdOxaSkZ41qUvb9b3dCorGuCovpSK2EeNphjLPpVX/NRpVY4YlDqAcTCdLdDrEeVqkiA/VDCYNhudZTDa8f1iHwBE/GEtlKmoO6dxJ5LAkRk3RIVHYrmI6XXSw5l0tHhW5D12MNwzUfDxQEzBpGK5iSfOBt5zJ5OiI9ftnsq/GV7vCXfvMVGDLUC551P5/s/wM70QmHwhlGQNLNeJxRTvd6tL11bof3K+29ivFYUmpU17iVxYOWhkNY86WyngHU6Ux0zaczF3H6H0tpg1Ca/cFO428AVPw/RTJpcAe6OVKq5zwARNApQ/p6fJKUAdXap+PpQGZlQhPLkUbwtFXGTrpX9ePTcdzryCYjgrZouvy4ZMzruJiIbFUH8mRY3xVREVaIsJakruvgw3b14oQgcB4BwYVBBqi62xIvbRzAv7Su9t2jK6OR2z3sM/hLJRqIJ5oILMORa7XqrQ=="
-  dns_zone                     = azurerm_private_dns_zone.trusted.name
-  dns_zone_name                = azurerm_private_dns_zone.trusted.name
-  dns_resourcegroup_name       = data.azurerm_resource_group.trusted.name
   controller_subnet_id         = data.azurerm_subnet.trusted_ci_controller.id
   controller_data_disk_size_gb = 128
   controller_vm_size           = "Standard_D2as_v5"


### PR DESCRIPTION
Follow up https://github.com/jenkins-infra/azure/pull/450#discussion_r1296854845

It also fixes the error detected during the apply of #450:

```
Error: creating/updating DNS A Record "controller.trusted.ci" (Zone "trusted.ci.jenkins.io" / Resource Group "trusted"): unexpected status 404 with error: ParentResourceNotFound: Failed to perform 'write' on resource(s) of type 'dnszones/A', because the parent resource '/subscriptions/****/resourceGroups/trusted/providers/Microsoft.Network/dnszones/trusted.ci.jenkins.io' could not be found.
```





