### PR TITLE
chore: ignore cluster node pools count changes

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -61,6 +61,10 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
     type = "SystemAssigned"
   }
 
+  lifecycle {
+    ignore_changes = [default_node_pool.node_count]
+  }
+
   tags = local.default_tags
 }
 
@@ -76,7 +80,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
   max_count             = 5
   zones                 = [3]
   vnet_subnet_id        = data.azurerm_subnet.privatek8s_tier.id
-  tags                  = local.default_tags
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
@@ -105,6 +114,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule",
   ]
 
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
   tags = local.default_tags
 }
 
@@ -123,6 +136,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "releasepool" {
   node_taints = [
     "jenkins=release.ci.jenkins.io:NoSchedule",
   ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
 
   tags = local.default_tags
 }
@@ -145,6 +162,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "windows2019pool" {
     "os=windows:NoSchedule",
     "jenkins=release.ci.jenkins.io:NoSchedule",
   ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
 
   tags = local.default_tags
 }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -62,7 +62,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
   }
 
   lifecycle {
-    ignore_changes = [default_node_pool.node_count]
+    ignore_changes = [default_node_pool[0].node_count]
   }
 
   tags = local.default_tags

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -83,7 +83,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "publicpool" {
   max_count             = 10
   zones                 = [3]
   vnet_subnet_id        = data.azurerm_subnet.publick8s_tier.id
-  tags                  = local.default_tags
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "x86medium" {
@@ -98,7 +103,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "x86medium" {
   max_count             = 10
   zones                 = [3]
   vnet_subnet_id        = data.azurerm_subnet.publick8s_tier.id
-  tags                  = local.default_tags
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "arm64small2" {
@@ -113,10 +123,16 @@ resource "azurerm_kubernetes_cluster_node_pool" "arm64small2" {
   max_count             = 10
   zones                 = [1]
   vnet_subnet_id        = data.azurerm_subnet.publick8s_tier.id
-  tags                  = local.default_tags
+
   node_taints = [
     "kubernetes.io/arch=arm64:NoSchedule",
   ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
 }
 
 # Allow cluster to manage LBs in the publick8s-tier subnet (Public LB)


### PR DESCRIPTION
From https://github.com/jenkins-infra/azure/pull/457#issuecomment-1690063668

> noticed some [automatic scaling] node pools node count changes, will probably add some ignore_changes