### PR TITLE
feat(cert.ci.jenkins.io) create a new controller VM and associated resources in the new network

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -1,3 +1,50 @@
+# Data of resources defined in https://github.com/jenkins-infra/azure-net
+data "azurerm_resource_group" "cert_ci_jenkins_io" {
+  name = "cert-ci-jenkins-io"
+}
+
+module "cert_ci_jenkins_io" {
+  source = "./.shared-tools/terraform/modules/azure-jenkins-controller"
+
+  service_fqdn                 = "cert.ci.jenkins.io"
+  location                     = data.azurerm_resource_group.cert_ci_jenkins_io.location
+  admin_username               = local.admin_username
+  admin_ssh_publickey          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDpxwvySus2OWViWfJ02XMYr+Qa/uPADhjt/4el2SmEf7NlJXzq5vc8imcw8YxQZKwuuKJhonlTYTpk1Cjka4bJKWNOSQ8+Kx0O2ZnNjKn3ZETWJB90bZXHVqbrNHDtu6lN6S/yRW9Q+6fuDbHBW0MXWI8Lsv+bU5v8Zll6m62rc00/I/IT9c1TX1qjCtjf5XHMFw7nVxQiTX2Zf5UKG3RI7mkCMDIvx2H9kXdzM8jtYwATZPHKHuLzffARmvy1FpNPVuLLEGYE3hljP82rll1WZbbl1ZrhjzbFUUYO4fsA7AOQHWhHiVLvtnreB269JOl/ZkHgk37zcdwJMkqKpqoEbjP9z8PURf5uMA7TiDGcpgcFMzoaFk1ueqoHM2JaM2AZQAkPhbUfT7MSOFYRx91OEg5pg5N17zNeaBM6fyxl3v7mkxSOTkKlzjAXPRyo7XsosUVQ4qb4DfsAAJ0Rynts2olRQLEzJku0ZxbbXotuoppI8HivRl7PoTsAASJRpc="
+  controller_network_name      = "cert-ci-jenkins-io-vnet"
+  controller_network_rg_name   = data.azurerm_resource_group.cert_ci_jenkins_io.name
+  controller_subnet_name       = "cert-ci-jenkins-io-vnet-controller"
+  ephemeral_agents_subnet_name = "cert-ci-jenkins-io-vnet-ephemeral-agents"
+  controller_data_disk_size_gb = 128
+  controller_vm_size           = "Standard_D2as_v5"
+  default_tags                 = local.default_tags
+
+  jenkins_infra_ips = {
+    ldap_ipv4           = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
+    puppet_ipv4         = azurerm_public_ip.puppet_jenkins_io.ip_address
+    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
+    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+  }
+
+  controller_service_principal_ids = [
+    data.azuread_service_principal.terraform_production.id,
+  ]
+  controller_service_principal_end_date = "2024-08-24T12:00:00Z"
+  controller_packer_rg_ids = [
+    azurerm_resource_group.packer_images["prod"].id
+  ]
+}
+## Service DNS records
+## TODO: uncomment and import when migrating
+# resource "azurerm_dns_cname_record" "cert_ci_jenkins_io" {
+#   name                = trimsuffix(trimsuffix(module.cert_ci_jenkins_io.service_fqdn, data.azurerm_dns_zone.jenkinsio.name), ".")
+#   zone_name           = data.azurerm_dns_zone.jenkinsio.name
+#   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+#   ttl                 = 60
+#   record              = module.cert_ci_jenkins_io.controller_public_fqdn
+#   tags                = local.default_tags
+# }
+
+######### Legacy resources (TODO: delete everything below once https://github.com/jenkins-infra/helpdesk/issues/3688 is migrated)
 /** Two resources groups: one for the controller, the second for the agents **/
 resource "azurerm_resource_group" "cert_ci_jenkins_io_controller" {
   name     = "prodcertci"
@@ -8,14 +55,6 @@ resource "azurerm_resource_group" "cert_ci_jenkins_io_agents" {
   name     = "certci-agents-2"
   location = "East US 2"
 }
-
-/** Controller Resources **/
-
-// TODO: import prodcertci public IP address
-// TODO: import prod-certci network interface
-// TODO: import certci-data disk
-// TODO: import prodcertci system disk
-// TODO: import prod-certci VM
 
 /** Agent Resources **/
 resource "azurerm_storage_account" "cert_ci_jenkins_io_agents" {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -1,4 +1,4 @@
-# Network resources defined in https://github.com/jenkins-infra/azure-net
+# Data of resources defined in https://github.com/jenkins-infra/azure-net
 data "azurerm_resource_group" "trusted" {
   name = "trusted"
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3688

A few notes:

- The VM size changed by following the Azure advisory recommandation (except it is a `_v5` instead of `_v4` which is the same as trusted.ci.jenkins.io):

<img width="1899" alt="Capture d’écran 2023-08-17 à 10 21 25" src="https://github.com/jenkins-infra/azure/assets/1522731/2567d2ed-ce7c-418d-a9bf-f76aedf48538">

- Data disk set to 128 like trusted.ci.jenkins.io as the current VM does not use a lot of data in the Jenkins home:

```
$ df -h /var/lib/jenkins/
Filesystem                Size  Used Avail Use% Mounted on
/dev/mapper/jenkins-home  295G   27G  253G  10% /var/lib/jenkins
```

- The new terraform module is used to have the same kind of resources (NSG, VM, etc.) as for ci.jenkins.io and trusted.ci.jenkins.io
