### PR TITLE
feat(cert.ci) migrate DNS apex to new VM

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -45,7 +45,7 @@ resource "azurerm_dns_a_record" "cert_ci_jenkins_io_controller" {
   ttl                 = 60
   records             = [module.cert_ci_jenkins_io.controller_private_ipv4]
 }
-resource "azurerm_private_dns_a_record" "cert_ci_jenkins_io" {
+resource "azurerm_dns_a_record" "cert_ci_jenkins_io" {
   name                = "@" # Child zone: no CNAME possible!
   zone_name           = data.azurerm_dns_zone.cert_ci_jenkins_io.name
   resource_group_name = data.azurerm_dns_zone.cert_ci_jenkins_io.resource_group_name

--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -45,14 +45,13 @@ resource "azurerm_dns_a_record" "cert_ci_jenkins_io_controller" {
   ttl                 = 60
   records             = [module.cert_ci_jenkins_io.controller_private_ipv4]
 }
-## TODO: uncomment and import when migrating
-# resource "azurerm_private_dns_a_record" "cert_ci_jenkins_io" {
-#   name                = "@" # Child zone: no CNAME possible!
-#   zone_name           = data.azurerm_dns_zone.cert_ci_jenkins_io.name
-#   resource_group_name = data.azurerm_dns_zone.cert_ci_jenkins_io.resource_group_name
-#   ttl                 = 60
-#   records             = [module.cert_ci_jenkins_io.controller_private_ipv4]
-# }
+resource "azurerm_private_dns_a_record" "cert_ci_jenkins_io" {
+  name                = "@" # Child zone: no CNAME possible!
+  zone_name           = data.azurerm_dns_zone.cert_ci_jenkins_io.name
+  resource_group_name = data.azurerm_dns_zone.cert_ci_jenkins_io.resource_group_name
+  ttl                 = 60
+  records             = [module.cert_ci_jenkins_io.controller_private_ipv4]
+}
 
 ######### Legacy resources (TODO: delete everything below once https://github.com/jenkins-infra/helpdesk/issues/3688 is migrated)
 /** Two resources groups: one for the controller, the second for the agents **/

--- a/locals.tf
+++ b/locals.tf
@@ -35,8 +35,8 @@ locals {
   }
 
   admin_allowed_ips = {
-    dduportal     = "85.27.34.43"     # Home
-    dduportal-2   = "86.202.255.126"  # Cowork
+    dduportal     = "85.27.34.43"    # Home
+    dduportal-2   = "86.202.255.126" # Cowork
     lemeurherve   = "176.185.227.180"
     lemeurherve-2 = "176.145.123.59"
     smerle33      = "82.64.5.129"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3688, this PR tracks the cert.ci DNS record.

The old record was deleted: it was not managed as code so better to re-create it from scratch.

For history:

![Capture d’écran 2023-08-28 à 15 46 00](https://github.com/jenkins-infra/azure/assets/1522731/d8a55c2d-c29e-4294-bc85-96fad370f7af)
