### PR TITLE
Revert "feat(publick8s/arm64): increment minimum node for autoscaling to 2"

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -119,7 +119,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "arm64small2" {
   orchestrator_version  = local.kubernetes_versions["publick8s"]
   kubernetes_cluster_id = azurerm_kubernetes_cluster.publick8s.id
   enable_auto_scaling   = true
-  min_count             = 2
+  min_count             = 0
   max_count             = 10
   zones                 = [1]
   vnet_subnet_id        = data.azurerm_subnet.publick8s_tier.id


### PR DESCRIPTION
Reverts jenkins-infra/azure#475
Related to https://github.com/jenkins-infra/helpdesk/issues/3719
Since https://github.com/jenkins-infra/kubernetes-management/pull/4385, we realized that anti affinity is working as expected *if* we configure it properly 😅

This minimum of 2 nodes is not needed anymore then