### PR TITLE
feat(updates.jenkins.io): NS records for CloudFlare zones

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -69,10 +69,4 @@ locals {
     "privatek8s" = "1.25.6"
     "publick8s"  = "1.25.6"
   }
-
-  # Should have the same keys as the "regions" defined in https://github.com/jenkins-infra/cloudflare/blob/main/locals.tf
-  # The values should correspond to the "zones_name_servers" output defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
-  updates_jenkins_io_cloudflare_regions = {
-    westeurope = ["cody.ns.cloudflare.com", "kallie.ns.cloudflare.com"]
-  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -69,4 +69,10 @@ locals {
     "privatek8s" = "1.25.6"
     "publick8s"  = "1.25.6"
   }
+
+  # Should have the same keys as the "regions" defined in https://github.com/jenkins-infra/cloudflare/blob/main/locals.tf
+  # The values should correspond to the "zones_name_servers" output defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
+  updates_jenkins_io_cloudflare_regions = {
+    westeurope = ["cody.ns.cloudflare.com", "kallie.ns.cloudflare.com"]
+  }
 }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -86,14 +86,14 @@ resource "azurerm_dns_a_record" "rsyncd_updates_jenkins_io" {
   tags                = local.default_tags
 }
 
-# NS records for each CloudFlare zone defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
-resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zones" {
-  for_each = local.updates_jenkins_io_cloudflare_regions
 
-  name                = "${each.key}.cloudflare"
+## NS records for each CloudFlare zone defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
+# West Europe
+resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zones" {
+  name                = "westeurope.cloudflare"
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
-  records             = each.value
+  records             = ["cody.ns.cloudflare.com", "kallie.ns.cloudflare.com"]
   tags                = local.default_tags
 }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -85,3 +85,15 @@ resource "azurerm_dns_a_record" "rsyncd_updates_jenkins_io" {
   records             = [azurerm_public_ip.rsyncd_jenkins_io_ipv4.ip_address]
   tags                = local.default_tags
 }
+
+# NS records for each CloudFlare zone defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
+resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zones" {
+  for_each = local.updates_jenkins_io_cloudflare_regions
+
+  name                = "${each.key}.cloudflare"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  records             = each.value
+  tags                = local.default_tags
+}

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -94,6 +94,7 @@ resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zones" {
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
-  records             = ["cody.ns.cloudflare.com", "kallie.ns.cloudflare.com"]
-  tags                = local.default_tags
+  # Should correspond to the "zones_name_servers" output defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
+  records = ["cody.ns.cloudflare.com", "kallie.ns.cloudflare.com"]
+  tags    = local.default_tags
 }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -88,7 +88,7 @@ resource "azurerm_dns_a_record" "rsyncd_updates_jenkins_io" {
 
 ## NS records for each CloudFlare zone defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
 # West Europe
-resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zones" {
+resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zone_westeurope" {
   name                = "westeurope.cloudflare"
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -86,7 +86,6 @@ resource "azurerm_dns_a_record" "rsyncd_updates_jenkins_io" {
   tags                = local.default_tags
 }
 
-
 ## NS records for each CloudFlare zone defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
 # West Europe
 resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zones" {


### PR DESCRIPTION
This PR allows the creation of NS records for each CloudFlare zone created for updates.jenkins.io so the corresponding subdomains can be delegated to CloudFlare.

Follow-up of https://github.com/jenkins-infra/cloudflare/pull/13

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649