### PR TITLE
chore(updates.jenkins.io): add NS record for `cloudflare.jenkins.io`

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -86,6 +86,17 @@ resource "azurerm_dns_a_record" "rsyncd_updates_jenkins_io" {
   tags                = local.default_tags
 }
 
+# NS records for cloudflare.jenkins.io, unused, to check if it resolve edge certificate issues in CloudFlare
+resource "azurerm_dns_ns_record" "cloudflare_jenkins_io" {
+  name                = "cloudflare"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  # Should correspond to the "zones_name_servers" output defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
+  records = ["cody.ns.cloudflare.com", "kallie.ns.cloudflare.com"]
+  tags    = local.default_tags
+}
+
 ## NS records for each CloudFlare zone defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
 # West Europe
 resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zone_westeurope" {


### PR DESCRIPTION
Trying something to help resolving edge certificate issue on CloudFlare for westeurope.cloudflare.jenkins.io zone.