### PR TITLE
feat(archives.jenkins.io) import existing CNAME records for archives jenkins.io and archives.jenkins-ci.org

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -1,0 +1,12 @@
+resource "azurerm_dns_cname_record" "archives_jenkins_io" {
+  for_each = {
+    "${data.azurerm_dns_zone.jenkinsio.name}"    = "${data.azurerm_dns_zone.jenkinsio.resource_group_name}",
+    "${data.azurerm_dns_zone.jenkinsciorg.name}" = "${data.azurerm_dns_zone.jenkinsciorg.resource_group_name}",
+  }
+  name                = "archives"
+  zone_name           = each.key
+  resource_group_name = each.value
+  ttl                 = 60
+  record              = "archives.do.jenkins.io" # Digital Ocean VM
+  tags                = local.default_tags
+}

--- a/dns.tf
+++ b/dns.tf
@@ -1,8 +1,17 @@
+# Jenkins.io DNS zone
 data "azurerm_resource_group" "proddns_jenkinsio" {
   name = "proddns_jenkinsio"
 }
-
 data "azurerm_dns_zone" "jenkinsio" {
   name                = "jenkins.io"
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+}
+
+# Jenkins-ci.org DNS zone
+data "azurerm_resource_group" "proddns_jenkinsci" {
+  name = "proddns_jenkinsci"
+}
+data "azurerm_dns_zone" "jenkinsciorg" {
+  name                = "jenkins-ci.org"
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsci.name
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3760

This PR defines the existing `CNAME` DNS records for `archives.jenkins.io` and `archives.jenkins-ci.org`.

These records have been imported in the terraform state. Merging this PR will apply the following changes (only add tags to the records):

```
Terraform will perform the following actions:

  # azurerm_dns_cname_record.archives_jenkins_io["jenkins-ci.org"] will be updated in-place
  ~ resource "azurerm_dns_cname_record" "archives_jenkins_io" {
        id                  = "/subscriptions/<redacted>/resourceGroups/proddns_jenkinsci/providers/Microsoft.Network/dnsZones/jenkins-ci.org/CNAME/archives"
        name                = "archives"
      ~ tags                = {
          + "repository" = "jenkins-infra/azure"
          + "scope"      = "terraform-managed"
        }
        # (5 unchanged attributes hidden)
    }

  # azurerm_dns_cname_record.archives_jenkins_io["jenkins.io"] will be updated in-place
  ~ resource "azurerm_dns_cname_record" "archives_jenkins_io" {
        id                  = "/subscriptions/<redacted>/resourceGroups/proddns_jenkinsio/providers/Microsoft.Network/dnsZones/jenkins.io/CNAME/archives"
        name                = "archives"
      ~ tags                = {
          + "repository" = "jenkins-infra/azure"
          + "scope"      = "terraform-managed"
        }
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```