### PR TITLE
chore(updates.jenkins.io): update `westeurope.cloudflare.jenkins.io` nameservers

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -94,6 +94,6 @@ resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zone_westeurope"
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
   # Should correspond to the "zones_name_servers" output defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
-  records = ["cody.ns.cloudflare.com", "kallie.ns.cloudflare.com"]
+  records = ["jaxson.ns.cloudflare.com", "mira.ns.cloudflare.com"]
   tags    = local.default_tags
 }


### PR DESCRIPTION
This PR updates `westeurope.cloudflare.jenkins.io` nameservers which changed after its recreation in CloudFlare.