### PR TITLE
chore: use shared admins from shared-tools module

### DIFF
--- a/archives.tf
+++ b/archives.tf
@@ -15,8 +15,10 @@ resource "azurerm_storage_account" "archives" {
   min_tls_version                   = "TLS1_2" # default value, needed for tfsec
 
   network_rules {
-    default_action             = "Deny"
-    ip_rules                   = values(local.admin_allowed_ips)
+    default_action = "Deny"
+    ip_rules = flatten(concat(
+      [for key, value in module.jenkins_infra.admin_public_ips : value]
+    ))
     virtual_network_subnet_ids = [data.azurerm_subnet.privatek8s_tier.id]
     bypass                     = ["AzureServices"]
   }

--- a/archives.tf
+++ b/archives.tf
@@ -17,7 +17,7 @@ resource "azurerm_storage_account" "archives" {
   network_rules {
     default_action = "Deny"
     ip_rules = flatten(concat(
-      [for key, value in module.jenkins_infra.admin_public_ips : value]
+      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
     ))
     virtual_network_subnet_ids = [data.azurerm_subnet.privatek8s_tier.id]
     bypass                     = ["AzureServices"]

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -22,7 +22,7 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
 
   default_action = "Deny"
   ip_rules = flatten(concat(
-    [for key, value in module.jenkins_infra.admin_public_ips : value]
+    [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
   ))
   virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id]
   # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -20,8 +20,10 @@ resource "azurerm_storage_account" "ldap_backups" {
 resource "azurerm_storage_account_network_rules" "ldap_access" {
   storage_account_id = azurerm_storage_account.ldap_backups.id
 
-  default_action             = "Deny"
-  ip_rules                   = values(local.admin_allowed_ips)
+  default_action = "Deny"
+  ip_rules = flatten(concat(
+    [for key, value in module.jenkins_infra.admin_public_ips : value]
+  ))
   virtual_network_subnet_ids = [data.azurerm_subnet.publick8s_tier.id]
   # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)
   bypass = ["AzureServices"]

--- a/locals.tf
+++ b/locals.tf
@@ -34,14 +34,6 @@ locals {
     }
   }
 
-  admin_allowed_ips = {
-    dduportal     = "109.88.234.158"
-    dduportal-2   = "86.202.255.126"
-    lemeurherve   = "176.185.227.180"
-    lemeurherve-2 = "176.145.123.59"
-    smerle33      = "82.64.5.129"
-  }
-
   external_services = {
     "updates.jenkins.io" = "52.202.51.185"
     "s390x.jenkins.io"   = "148.100.84.76"

--- a/main.tf
+++ b/main.tf
@@ -7,3 +7,7 @@ data "azuread_service_principal" "terraform_production" {
 # Data source used to retrieve the subscription id
 data "azurerm_subscription" "jenkins" {
 }
+
+module "jenkins_infra" {
+  source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
+}

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,6 @@ data "azuread_service_principal" "terraform_production" {
 data "azurerm_subscription" "jenkins" {
 }
 
-module "jenkins_infra" {
+module "jenkins_infra_shared_data" {
   source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
 }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -31,7 +31,14 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
 
   api_server_access_profile {
     authorized_ip_ranges = setunion(
-      formatlist("%s/32", values(local.admin_allowed_ips)),
+      formatlist(
+        "%s/32",
+        flatten(
+          concat(
+            [for key, value in module.jenkins_infra.admin_public_ips : value]
+          )
+        )
+      ),
       data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
     )
   }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -35,7 +35,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
         "%s/32",
         flatten(
           concat(
-            [for key, value in module.jenkins_infra.admin_public_ips : value]
+            [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
           )
         )
       ),

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -38,7 +38,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
         "%s/32",
         flatten(
           concat(
-            [for key, value in module.jenkins_infra.admin_public_ips : value]
+            [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
           )
         )
       ),

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -34,7 +34,14 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   api_server_access_profile {
     authorized_ip_ranges = setunion(
       # admins
-      formatlist("%s/32", values(local.admin_allowed_ips)),
+      formatlist(
+        "%s/32",
+        flatten(
+          concat(
+            [for key, value in module.jenkins_infra.admin_public_ips : value]
+          )
+        )
+      ),
       # private VPN access
       data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
       # privatek8s nodes subnet

--- a/puppet.jenkins.io.tf
+++ b/puppet.jenkins.io.tf
@@ -68,7 +68,7 @@ resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_puppe
   destination_port_range = "22"
   source_address_prefixes = flatten(
     concat(
-      [for key, value in module.jenkins_infra.admin_public_ips : value]
+      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
     )
   )
   destination_address_prefix  = azurerm_linux_virtual_machine.puppet_jenkins_io.private_ip_address

--- a/puppet.jenkins.io.tf
+++ b/puppet.jenkins.io.tf
@@ -59,14 +59,18 @@ resource "azurerm_network_security_rule" "allow_inbound_webhooks_from_github_to_
   network_security_group_name = data.azurerm_network_security_group.private_dmz.name
 }
 resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_puppet" {
-  name                        = "allow-inbound-ssh-from-admins-to-puppet"
-  priority                    = 4000
-  direction                   = "Inbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "22"
-  source_address_prefixes     = values(local.admin_allowed_ips)
+  name                   = "allow-inbound-ssh-from-admins-to-puppet"
+  priority               = 4000
+  direction              = "Inbound"
+  access                 = "Allow"
+  protocol               = "Tcp"
+  source_port_range      = "*"
+  destination_port_range = "22"
+  source_address_prefixes = flatten(
+    concat(
+      [for key, value in module.jenkins_infra.admin_public_ips : value]
+    )
+  )
   destination_address_prefix  = azurerm_linux_virtual_machine.puppet_jenkins_io.private_ip_address
   resource_group_name         = data.azurerm_resource_group.private.name
   network_security_group_name = data.azurerm_network_security_group.private_dmz.name


### PR DESCRIPTION
Twin of of https://github.com/jenkins-infra/digitalocean/pull/165

This PR is a first try at sharing a set common values across our terraform projects.

A new [data-only Terraform module](https://developer.hashicorp.com/terraform/language/modules/develop/composition#data-only-modules) has been added in the jenkins-infra/shared-tools to hold the shared values: https://github.com/jenkins-infra/shared-tools/commit/36589078701232007dbdf8b5034fd93901d072c3.

The following changes are introduced:

- the admin IPs from the shared module are used instead of the locals ones. Ping @smerle33 @lemeurherve can you check the shared module and terraform plan maps to your public IPs (or update them on https://github.com/jenkins-infra/shared-tools/blob/main/terraform/modules/jenkins-infra-shared-data/outputs.tf)

💡 Notes:

- This module, for now, only specify a set of outputs providing the shared data to projects. It may provide data sources (Azure DNS zones or network ids?) in the future if need be for instance.
- The choice of mixing IPv6 and IPv4 in the string arrays is because most of the usages requires both. If we need to filter by type, we can use `can(cidrnetmask(...)` and `!can(cidrnetmask(...))` (ref. https://developer.hashicorp.com/terraform/language/functions/cidrnetmask)
- The idea is that, in the near future, each terraform project should be able to update the values of the module when needed (case of public or outbound IPs of our services) or a human (admin IPs).





