### PR TITLE
fix(updates.jenkins.io): add service as resource type for the SAS token

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -25,9 +25,10 @@ resource "azurerm_storage_share" "updates_jenkins_io" {
 
 data "azurerm_storage_account_sas" "updates_jenkins_io" {
   connection_string = azurerm_storage_account.updates_jenkins_io.primary_connection_string
+  signed_version    = "2022-11-02"
 
   resource_types {
-    service   = false
+    service   = true # Ex: list Share
     container = true # Ex: list Files and Directories
     object    = true # Ex: create File
   }
@@ -62,7 +63,7 @@ data "azurerm_storage_account_sas" "updates_jenkins_io" {
 
 output "updates_jenkins_io_sas_url_query_string" {
   sensitive = true
-  value     = data.azurerm_storage_account_sas.updates_jenkins_io.sas
+  value     = concat(azurerm_storage_account.updates_jenkins_io.primary_connection_string, data.azurerm_storage_account_sas.updates_jenkins_io.sas)
 }
 
 output "updates_jenkins_io_storage_account_primary_access_key" {

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -61,9 +61,14 @@ data "azurerm_storage_account_sas" "updates_jenkins_io" {
   }
 }
 
+output "updates_jenkins_io_primary_connection_string" {
+  sensitive = true
+  value     = azurerm_storage_account.updates_jenkins_io.primary_connection_string
+}
+
 output "updates_jenkins_io_sas_url_query_string" {
   sensitive = true
-  value     = concat(azurerm_storage_account.updates_jenkins_io.primary_connection_string, data.azurerm_storage_account_sas.updates_jenkins_io.sas)
+  value     = data.azurerm_storage_account_sas.updates_jenkins_io.sas
 }
 
 output "updates_jenkins_io_storage_account_primary_access_key" {


### PR DESCRIPTION
This PR adds `service` as resource type so the account SAS token is accepted for commands like `azcopy list <file-share-url-with-sas-token>`.

It also adds a sensitive output to retrieve the File Share connection string (QoL).

Tested by manually generating tokens from the Azure Portal. (The added `signed_version` comes from these tests)