### PR TITLE
chore(updates.jenkins.io): more useful File Share outputs

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -61,19 +61,14 @@ data "azurerm_storage_account_sas" "updates_jenkins_io" {
   }
 }
 
-output "updates_jenkins_io_primary_connection_string" {
+output "updates_jenkins_io_share_url" {
   sensitive = true
-  value     = azurerm_storage_account.updates_jenkins_io.primary_connection_string
+  value     = azurerm_storage_share.updates_jenkins_io.url
 }
 
-output "updates_jenkins_io_sas_url_query_string" {
+output "updates_jenkins_io_sas_query_string" {
   sensitive = true
   value     = data.azurerm_storage_account_sas.updates_jenkins_io.sas
-}
-
-output "updates_jenkins_io_storage_account_primary_access_key" {
-  sensitive = true
-  value     = azurerm_storage_account.updates_jenkins_io.primary_access_key
 }
 
 # Redis database


### PR DESCRIPTION
This PR adds an output for the File Share URL, which is needed in combination with the SAS token query string to make requests via `azcopy`.

It also removes the `updates_jenkins_io_storage_account_primary_access_key` output, not needed.

Follow-up of #493 & #494 