### PR TITLE
chore(updates.jenkins.io): remove IP restriction on File Share SAS token

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -33,9 +33,6 @@ data "azurerm_storage_account_sas" "updates_jenkins_io" {
     object    = true # Ex: create File
   }
 
-  # Only one IP or a range of IPs can be set for a SAS (https://stackoverflow.com/a/57147683/4074148)
-  ip_addresses = module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"][0]
-
   services {
     blob  = false
     queue = false


### PR DESCRIPTION
Unfortunately, including an IP restriction on the File Share SAS token results in 403 errors with `azcopy`.

Tested a token without IP restriction, worked as expected.

As the trusted job where I need to use this token is already using other credentials without any IP restriction, and as the workaround isn't trivial (https://github.com/Azure/azure-storage-azcopy/wiki/Troubleshooting---FAQ#workaround-1), this PR removes the IP restriction on this one too.