### PR TITLE
feat(matomo) add a MySQL database on the public-db instance

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -134,3 +134,27 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
   ]
 }
+
+provider "registry.terraform.io/petoju/mysql" {
+  version = "3.0.42"
+  hashes = [
+    "h1:3/bWdjp/WAXZpHBieVX9nuxGFoOl3hFpI5r6irE1m7c=",
+    "h1:5PtirEXNuhg5ZKfgXSFNOwkD8J3xA5PZGss/L13oMEY=",
+    "h1:HbceyeJybYV+iY+1YxpzJGJ9pkPCsQa/fWajPkhKksc=",
+    "h1:yi+HUR3QQg1EMg8KHla4J4o7YAukttSDwc8ylS5QDjU=",
+    "zh:0533ef304c98e2ccfd7e4532cea4c2f00eb0a3665be8940ac0c4ba0e3a0d0946",
+    "zh:08935a6b627a42d2537d64c1cf885291722296599a554c8e48a3706b49e7e67f",
+    "zh:5108b7f30ce99a87ad34060a7a5be4f3a33c8f8412576a01128c0f53a4afb0f5",
+    "zh:541c5b5afcdb46536b70830246b9623e99377e310c116087294956379159f4c8",
+    "zh:60b49340aa356d28079de3169996972d61c7ad5bef431372ee50183470bfea78",
+    "zh:87928e55436b2c7875dc4c0389f073105a82918288cf281a42be2f9d2a6f8960",
+    "zh:91fa069739caa618151bf265d1e78b21a752a3b8e875c339d948fad4c7cbeb7d",
+    "zh:c168801ed90680ec0e77ee7e2b3251cfe4a59cd76780602a557951fb9b7d7bde",
+    "zh:cc6667bf04c97dcb2c54b877951b037f6496e6fc1e306d38533aa6b84047243c",
+    "zh:d442f1a22bbc33970e38dccd6ab9e921dcdf205e8f12f9eb14bc256e73710aec",
+    "zh:df9d8bcd2dbae63910a1e182216f0a3ad09af4180f533da62737bef0bbaa4bad",
+    "zh:e1a439dd7ec1e81e545bd64e494cde796af807d745e5ae0fd6650c9bc70c69ed",
+    "zh:e1c40d3bad0aacc9c0242953d63206f55cc9122ad6313cf77e72ceebc1dfa389",
+    "zh:f85fba5a0ea2e0bdbd96e9bb8ad46d1293b6b6b03df141c2fc52a1e76644600b",
+  ]
+}

--- a/matomo.jenkins.io.tf
+++ b/matomo.jenkins.io.tf
@@ -1,0 +1,44 @@
+## Matomo Resources
+
+# Database - ref. https://matomo.org/faq/how-to-install/faq_23484/
+resource "mysql_database" "matomo" {
+  name = "matomo"
+}
+resource "random_password" "matomo_mysql_password" {
+  length           = 81
+  lower            = true
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  numeric          = true
+  override_special = "_"
+  special          = true
+  upper            = true
+}
+resource "mysql_user" "matomo" {
+  user               = "matomo"
+  host               = "*" # Default "localhost" forbids access from clusters
+  plaintext_password = random_password.matomo_mysql_password.result
+}
+resource "mysql_grant" "matomo" {
+  user       = mysql_user.matomo.user
+  host       = mysql_user.matomo.host
+  database   = mysql_database.matomo.name
+  privileges = ["SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "INDEX", "DROP", "ALTER", "CREATE TEMPORARY TABLES", "LOCK TABLES"]
+}
+
+# This (sensitive) output is meant to be encrypted into the production secret system, to be provided as a secret to the matomo application
+output "matomo_dbconfig" {
+  # Value of the port is fixed to 3306 (https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-networking and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_flexible_server#attributes-reference)
+  sensitive   = true
+  description = "YAML (secret) values for the Helm chart bitnami/matomo"
+  value       = <<-EOT
+externalDatabase:
+  host: ${azurerm_mysql_flexible_server.public_db_mysql.fqdn}
+  port: 3306
+  database: ${mysql_database.matomo.name}
+  user: ${mysql_user.matomo.user}
+  password: ${random_password.matomo_mysql_password.result}
+EOT
+}

--- a/providers.tf
+++ b/providers.tf
@@ -23,7 +23,7 @@ provider "kubernetes" {
 provider "postgresql" {
   /**
   Important: terraform must be allowed to reach this instance through the network. Check the followings:
-  - If running in Jenkins, ensure that the subnet of the agents is peered to the subnet of this pgsql instance
+  - If running in Jenkins, ensure that the subnet of the agents is peered to the subnet of this postgreSQL instance
     * Don't forget to also check the network security group rules
   - If running locally, ensure that:
     * your /etc/hosts defines an entry with <azurerm_postgresql_flexible_server.public.fqdn> to 127.0.0.1
@@ -33,4 +33,18 @@ provider "postgresql" {
   username  = local.public_db_pgsql_admin_login
   password  = random_password.public_db_pgsql_admin_password.result
   superuser = false
+}
+
+provider "mysql" {
+  /**
+  Important: terraform must be allowed to reach this instance through the network. Check the followings:
+  - If running in Jenkins, ensure that the subnet of the agents is peered to the subnet of this mysql instance
+    * Don't forget to also check the network security group rules
+  - If running locally, ensure that:
+    * your /etc/hosts defines an entry with <azurerm_mysql_flexible_server.public.fqdn> to 127.0.0.1
+    * you've opened an SSH tunnel such as `ssh -L 3306:<azurerm_mysql_flexible_server.public.fqdn>:3306` through a machine of the private network
+  **/
+  endpoint = "${azurerm_mysql_flexible_server.public_db_mysql.fqdn}:3306"
+  username = local.public_db_mysql_admin_login
+  password = random_password.public_db_mysql_admin_login.result
 }

--- a/updatecli/updatecli.d/terraform-providers/mysql.yaml
+++ b/updatecli/updatecli.d/terraform-providers/mysql.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `mysql` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `mysql` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: petoju
+      name: mysql
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: petoju/mysql
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `petoju/mysql` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - petoju/mysql

--- a/versions.tf
+++ b/versions.tf
@@ -20,5 +20,8 @@ terraform {
     random = {
       source = "hashicorp/random"
     }
+    mysql = {
+      source = "petoju/mysql"
+    }
   }
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3602

This PR adds a managed MySQL database for matomo with an associated user and password.

The grants are also applied to this user as per https://matomo.org/faq/how-to-install/faq_23484/. Note that the `FILE` grant is not added because it would be global to the `public-db` instance while we're not even sure it is needed (or if the mentionned file load extension is present on Azure flexible instances)