### PR TITLE
feat(publick8s) allow trusted.ci.jenkins.io agents to reach control plane

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -47,6 +47,8 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
       # privatek8s nodes subnet
       data.azurerm_subnet.privatek8s_tier.address_prefixes,
       [local.privatek8s_outbound_ip_cidr],
+      # trusted.ci subnet (UC agents needs to execute mirrorbits scans)
+      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],
     )
   }
 

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -47,7 +47,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
       # privatek8s nodes subnet
       data.azurerm_subnet.privatek8s_tier.address_prefixes,
       [local.privatek8s_outbound_ip_cidr],
-      # trusted.ci subnet (UC agents needs to execute mirrorbits scans)
+      # trusted.ci subnet (UC agents need to execute mirrorbits scans)
       module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],
     )
   }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1787324647

This PR allows the trusted.ci agents to reach the `publick8s` cluster API