### PR TITLE
fix(publick8s) ensure trusted authorized IP uses a CIDR notation

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -48,7 +48,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
       data.azurerm_subnet.privatek8s_tier.address_prefixes,
       [local.privatek8s_outbound_ip_cidr],
       # trusted.ci subnet (UC agents need to execute mirrorbits scans)
-      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],
+      formatlist("%s/32", module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"]),
     )
   }
 


### PR DESCRIPTION
This PR avoids to update the cluster on each `terraform apply`