### PR TITLE
feat(ci.j, trusted.ci and cert.ci) migrate to separated tf modules for agents management in Azure

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -165,6 +165,10 @@ moved {
   from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_inbound_ssh_from_privatevpn_to_ephemeral_agents
   to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_inbound_ssh_from_privatevpn_to_ephemeral_agents
 }
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_ssh_from_controller_to_ephemeral_agents
+  to   = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_ssh_from_controller_to_agents
+}
 
 ## Service DNS records
 resource "azurerm_dns_a_record" "cert_ci_jenkins_io_controller" {

--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -22,7 +22,7 @@ data "azurerm_subnet" "cert_ci_jenkins_io_ephemeral_agents" {
 }
 
 module "cert_ci_jenkins_io" {
-  source = "./.shared-tools/terraform/modules/azure-jenkins-controller"
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-controller"
 
   service_fqdn                 = data.azurerm_dns_zone.cert_ci_jenkins_io.name
   location                     = data.azurerm_resource_group.cert_ci_jenkins_io.location
@@ -31,7 +31,6 @@ module "cert_ci_jenkins_io" {
   controller_network_name      = data.azurerm_virtual_network.cert_ci_jenkins_io.name
   controller_network_rg_name   = data.azurerm_resource_group.cert_ci_jenkins_io.name
   controller_subnet_name       = data.azurerm_subnet.cert_ci_jenkins_io_controller.name
-  ephemeral_agents_subnet_name = data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.name
   controller_data_disk_size_gb = 128
   controller_vm_size           = "Standard_D2as_v5"
   default_tags                 = local.default_tags
@@ -50,7 +49,123 @@ module "cert_ci_jenkins_io" {
   controller_packer_rg_ids = [
     azurerm_resource_group.packer_images["prod"].id
   ]
+
+  agent_ip_prefixes = data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.address_prefixes
 }
+
+module "cert_ci_jenkins_io_azurevm_agents" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-azurevm-agents"
+
+  # Same RG as the controller to avoid accidental deletion when managing VMs for agents
+
+  service_fqdn                     = module.cert_ci_jenkins_io.service_fqdn
+  service_short_stripped_name      = module.cert_ci_jenkins_io.service_short_stripped_name
+  ephemeral_agents_network_rg_name = data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.resource_group_name
+  ephemeral_agents_network_name    = data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.virtual_network_name
+  ephemeral_agents_subnet_name     = data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.name
+  controller_rg_name               = module.cert_ci_jenkins_io.controller_resourcegroup_name
+  controller_ips                   = compact([module.cert_ci_jenkins_io.controller_public_ipv4])
+  controller_service_principal_id  = module.cert_ci_jenkins_io.controler_service_principal_id
+  default_tags                     = local.default_tags
+  jenkins_infra_ips = {
+    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
+    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+  }
+}
+
+module "cert_ci_jenkins_io_aci_agents" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-aci-agents"
+
+  service_short_stripped_name     = module.cert_ci_jenkins_io.service_short_stripped_name
+  aci_agents_resource_group_name  = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name
+  controller_service_principal_id = module.cert_ci_jenkins_io.controler_service_principal_id
+}
+
+### ACI Agents
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_role_definition.ephemeral_agents_aci_contributor
+  to   = module.cert_ci_jenkins_io_aci_agents.azurerm_role_definition.ephemeral_agents_aci_contributor
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_role_assignment.controller_ephemeral_agents_aci_contributor
+  to   = module.cert_ci_jenkins_io_aci_agents.azurerm_role_assignment.controller_ephemeral_agents_aci_contributor
+}
+
+### Ephemeral Agents
+# Resources
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_resource_group.ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_resource_group.ephemeral_agents
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_storage_account.ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_storage_account.ephemeral_agents
+}
+
+# AzureAD
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents
+}
+
+# NSGs
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_group.ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_group.ephemeral_agents
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_subnet_network_security_group_association.ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_subnet_network_security_group_association.ephemeral_agents
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_ephemeral_agents
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_hkp_tcp_from_ephemeral_agents_subnet_to_internet
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_hkp_tcp_from_ephemeral_agents_subnet_to_internet
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_hkp_udp_from_ephemeral_agents_subnet_to_internet
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_hkp_udp_from_ephemeral_agents_subnet_to_internet
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_http_from_ephemeral_agents_to_internet
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_http_from_ephemeral_agents_to_internet
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_jenkins_from_ephemeral_agents_to_controller
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_jenkins_from_ephemeral_agents_to_controller
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_ssh_from_ephemeral_agents_to_internet
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_ssh_from_ephemeral_agents_to_internet
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.deny_all_inbound_from_vnet_to_ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_inbound_from_vnet_to_ephemeral_agents
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_internet
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_internet
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+}
+moved {
+  from = module.cert_ci_jenkins_io.azurerm_network_security_rule.allow_inbound_ssh_from_privatevpn_to_ephemeral_agents
+  to   = module.cert_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_inbound_ssh_from_privatevpn_to_ephemeral_agents
+}
+
 ## Service DNS records
 resource "azurerm_dns_a_record" "cert_ci_jenkins_io_controller" {
   name                = "controller"

--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -36,10 +36,9 @@ module "cert_ci_jenkins_io" {
   default_tags                 = local.default_tags
 
   jenkins_infra_ips = {
-    ldap_ipv4           = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
-    puppet_ipv4         = azurerm_public_ip.puppet_jenkins_io.ip_address
-    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
-    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+    ldap_ipv4         = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
+    puppet_ipv4       = azurerm_public_ip.puppet_jenkins_io.ip_address
+    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 
   controller_service_principal_ids = [
@@ -68,8 +67,7 @@ module "cert_ci_jenkins_io_azurevm_agents" {
   controller_service_principal_id  = module.cert_ci_jenkins_io.controler_service_principal_id
   default_tags                     = local.default_tags
   jenkins_infra_ips = {
-    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
-    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 }
 

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -25,10 +25,9 @@ module "ci_jenkins_io" {
   is_public                    = true
   default_tags                 = local.default_tags
   jenkins_infra_ips = {
-    ldap_ipv4           = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
-    puppet_ipv4         = azurerm_public_ip.puppet_jenkins_io.ip_address
-    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
-    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+    ldap_ipv4         = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
+    puppet_ipv4       = azurerm_public_ip.puppet_jenkins_io.ip_address
+    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
   controller_service_principal_ids = [
     data.azuread_service_principal.terraform_production.id,
@@ -56,9 +55,9 @@ module "ci_jenkins_io_azurevm_agents" {
   controller_ips                   = compact([module.ci_jenkins_io.controller_private_ipv4, module.ci_jenkins_io.controller_public_ipv4])
   controller_service_principal_id  = module.ci_jenkins_io.controler_service_principal_id
   default_tags                     = local.default_tags
+
   jenkins_infra_ips = {
-    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
-    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -3,6 +3,12 @@ provider "azurerm" {
   skip_provider_registration = "true"
   features {}
 }
+provider "azurerm" {
+  alias                      = "jenkins-sponsorship"
+  subscription_id            = "1311c09f-aee0-4d6c-99a4-392c2b543204"
+  skip_provider_registration = "true"
+  features {}
+}
 
 provider "kubernetes" {
   alias                  = "privatek8s"

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -52,10 +52,9 @@ module "trusted_ci_jenkins_io" {
   controller_datadisk_name      = "trusted-ci-controller-data-disk"
 
   jenkins_infra_ips = {
-    ldap_ipv4           = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
-    puppet_ipv4         = azurerm_public_ip.puppet_jenkins_io.ip_address
-    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
-    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+    ldap_ipv4         = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
+    puppet_ipv4       = azurerm_public_ip.puppet_jenkins_io.ip_address
+    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 
   controller_service_principal_ids = [
@@ -86,8 +85,7 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
   controller_service_principal_id  = module.trusted_ci_jenkins_io.controler_service_principal_id
   default_tags                     = local.default_tags
   jenkins_infra_ips = {
-    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
-    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 }
 

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -35,7 +35,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "trusted" {
 ## Resources for the Controller VM
 ####################################################################################
 module "trusted_ci_jenkins_io" {
-  source = "./.shared-tools/terraform/modules/azure-jenkins-controller"
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-controller"
 
   service_fqdn                 = azurerm_private_dns_zone.trusted.name
   location                     = data.azurerm_virtual_network.trusted_ci_jenkins_io.location
@@ -44,14 +44,12 @@ module "trusted_ci_jenkins_io" {
   controller_network_name      = data.azurerm_virtual_network.trusted_ci_jenkins_io.name
   controller_network_rg_name   = data.azurerm_resource_group.trusted_ci_jenkins_io.name
   controller_subnet_name       = data.azurerm_subnet.trusted_ci_jenkins_io_controller.name
-  ephemeral_agents_subnet_name = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.name
   controller_data_disk_size_gb = 128
   controller_vm_size           = "Standard_D2as_v5"
   default_tags                 = local.default_tags
 
   controller_resourcegroup_name = "jenkinsinfra-trusted-ci-controller"
   controller_datadisk_name      = "trusted-ci-controller-data-disk"
-  # ephemeral_agents_resourcegroup_name = "jenkinsinfra-trusted-ephemeral-agents"
 
   jenkins_infra_ips = {
     ldap_ipv4           = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
@@ -68,8 +66,128 @@ module "trusted_ci_jenkins_io" {
     azurerm_resource_group.packer_images["prod"].id
   ]
 
-  ephemeral_agents_resourcegroup_name = "jenkinsinfra-trusted-ephemeral-agents"
+  agent_ip_prefixes = concat(
+    data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes,
+    [azurerm_linux_virtual_machine.trusted_permanent_agent.private_ip_address],
+  )
 }
+
+module "trusted_ci_jenkins_io_azurevm_agents" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-azurevm-agents"
+
+  custom_resourcegroup_name        = "jenkinsinfra-trusted-ephemeral-agents"
+  service_fqdn                     = module.trusted_ci_jenkins_io.service_fqdn
+  service_short_stripped_name      = module.trusted_ci_jenkins_io.service_short_stripped_name
+  ephemeral_agents_network_rg_name = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.resource_group_name
+  ephemeral_agents_network_name    = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.virtual_network_name
+  ephemeral_agents_subnet_name     = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.name
+  controller_rg_name               = module.trusted_ci_jenkins_io.controller_resourcegroup_name
+  controller_ips                   = compact([module.trusted_ci_jenkins_io.controller_public_ipv4])
+  controller_service_principal_id  = module.trusted_ci_jenkins_io.controler_service_principal_id
+  default_tags                     = local.default_tags
+  jenkins_infra_ips = {
+    gpg_keyserver_ipv4s = local.gpg_keyserver_ips["keyserver.ubuntu.com"]
+    privatevpn_subnet   = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+  }
+}
+
+module "trusted_ci_jenkins_io_aci_agents" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-aci-agents"
+
+  service_short_stripped_name     = module.trusted_ci_jenkins_io.service_short_stripped_name
+  aci_agents_resource_group_name  = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name
+  controller_service_principal_id = module.trusted_ci_jenkins_io.controler_service_principal_id
+}
+
+### ACI Agents
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_role_definition.ephemeral_agents_aci_contributor
+  to   = module.trusted_ci_jenkins_io_aci_agents.azurerm_role_definition.ephemeral_agents_aci_contributor
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_role_assignment.controller_ephemeral_agents_aci_contributor
+  to   = module.trusted_ci_jenkins_io_aci_agents.azurerm_role_assignment.controller_ephemeral_agents_aci_contributor
+}
+
+### Ephemeral Agents
+# Resources
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_resource_group.ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_resource_group.ephemeral_agents
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_storage_account.ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_storage_account.ephemeral_agents
+}
+
+# AzureAD
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents
+}
+
+# NSGs
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_group.ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_group.ephemeral_agents
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_subnet_network_security_group_association.ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_subnet_network_security_group_association.ephemeral_agents
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_ephemeral_agents
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_hkp_tcp_from_ephemeral_agents_subnet_to_internet
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_hkp_tcp_from_ephemeral_agents_subnet_to_internet
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_hkp_udp_from_ephemeral_agents_subnet_to_internet
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_hkp_udp_from_ephemeral_agents_subnet_to_internet
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_http_from_ephemeral_agents_to_internet
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_http_from_ephemeral_agents_to_internet
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_jenkins_from_ephemeral_agents_to_controller
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_jenkins_from_ephemeral_agents_to_controller
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_ssh_from_ephemeral_agents_to_internet
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_outbound_ssh_from_ephemeral_agents_to_internet
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.deny_all_inbound_from_vnet_to_ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_inbound_from_vnet_to_ephemeral_agents
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_internet
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_internet
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_inbound_ssh_from_privatevpn_to_ephemeral_agents
+  to   = module.trusted_ci_jenkins_io_azurevm_agents.azurerm_network_security_rule.allow_inbound_ssh_from_privatevpn_to_ephemeral_agents
+}
+moved {
+  from = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_ssh_from_controller_to_ephemeral_agents
+  to   = module.trusted_ci_jenkins_io.azurerm_network_security_rule.allow_outbound_ssh_from_controller_to_agents
+}
+
 resource "azurerm_private_dns_a_record" "trusted_ci_controller" {
   name                = "@"
   zone_name           = azurerm_private_dns_zone.trusted.name
@@ -243,19 +361,6 @@ resource "azurerm_network_security_rule" "allow_outbound_from_bounce_to_controll
   source_address_prefix       = azurerm_linux_virtual_machine.trusted_bounce.private_ip_address
   destination_port_range      = "22"
   destination_address_prefix  = module.trusted_ci_jenkins_io.controller_private_ipv4
-  resource_group_name         = module.trusted_ci_jenkins_io.controller_resourcegroup_name
-  network_security_group_name = module.trusted_ci_jenkins_io.controller_nsg_name
-}
-resource "azurerm_network_security_rule" "allow_outbound_ssh_from_controller_to_permanent_agent" {
-  name                        = "allow-outbound-ssh-from-controller-to-permanent-agent"
-  priority                    = 4091
-  direction                   = "Outbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "22"
-  source_address_prefix       = module.trusted_ci_jenkins_io.controller_private_ipv4
-  destination_address_prefix  = azurerm_linux_virtual_machine.trusted_permanent_agent.private_ip_address
   resource_group_name         = module.trusted_ci_jenkins_io.controller_resourcegroup_name
   network_security_group_name = module.trusted_ci_jenkins_io.controller_nsg_name
 }


### PR DESCRIPTION
This PR is a (mandatory) preparatory step for https://github.com/jenkins-infra/helpdesk/issues/3818 .

It split the controller/azurevm-agents/aci-agent scopes in 3 terraform modules. The goal is to allow instantiating the (*)agents module for the new sponsorship subscrption without repeating code.


To avoid any breakage on the principal branch (which uses the latest reference of the `main` branch on https://github.com/jenkins-infra/shared-tools/), I've created 3 brand new modules in https://github.com/jenkins-infra/shared-tools/commit/c7ec5b0b350abfb195f191056ad6877073aa1e7c . It should make the PR here autonomous to merge (but the aformentionned commit is also to be reviewed and we can update modules).


💡 A few notes on the introduces changes:

- The ci.jenkins.io's Network Security Group rule `allow_outbound_ssh_from_ci_controller_to_s390x` is removed. Its integrated into the new controller module as one of the agent IP prefixes passed as argument.
- Same for the trusted.ci.jenkins.io's `allow_outbound_ssh_from_controller_to_permanent_agent`
- The 3 Network Security Group rules `allow_inbound_ssh_from_controller_to_ephemeral_agents` (1 for each controller) are changed from a single `source_address_prefix` to `source_address_prefixes` collection
  - For ci.jenkins.io, it also adds the Public IP of the controller VM in this collection (along to the private VM IP) to cover cases where the requests are routed through the Internet instead of the internal network peerings