### PR TITLE
feat(contributors.jenkins.io): add File Share

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -32,6 +32,6 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
 
 resource "azurerm_storage_share" "contributors_jenkins_io" {
   name                 = "contributors-jenkins-io"
-  storage_account_name = azurerm_storage_account.contributorsjenkinsio.name
+  storage_account_name = azurerm_storage_account.contributors_jenkins_io.name
   quota                = 5
 }

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -8,7 +8,7 @@ moved {
   from = azurerm_storage_account.contributorsjenkinsio
   to   = azurerm_storage_account.contributors_jenkins_io
 }
-resource "azurerm_storage_account" "contributorsjenkinsio" {
+resource "azurerm_storage_account" "contributors_jenkins_io" {
   name                      = "contributorsjenkinsio"
   resource_group_name       = azurerm_resource_group.contributors_jenkins_io.name
   location                  = azurerm_resource_group.contributors_jenkins_io.location

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -4,6 +4,10 @@ resource "azurerm_resource_group" "contributors_jenkins_io" {
   tags     = local.default_tags
 }
 
+moved {
+  from = azurerm_storage_account.contributorsjenkinsio
+  to   = azurerm_storage_account.contributors_jenkins_io
+}
 resource "azurerm_storage_account" "contributorsjenkinsio" {
   name                      = "contributorsjenkinsio"
   resource_group_name       = azurerm_resource_group.contributors_jenkins_io.name
@@ -26,3 +30,8 @@ resource "azurerm_storage_account" "contributorsjenkinsio" {
   tags = local.default_tags
 }
 
+resource "azurerm_storage_share" "contributors_jenkins_io" {
+  name                 = "contributors-jenkins-io"
+  storage_account_name = azurerm_storage_account.contributorsjenkinsio.name
+  quota                = 5
+}


### PR DESCRIPTION
This PR adds the File Share that will be used by the nginx-website release on publick8s cluster to serve on contributors.origin.jenkins.io the content generated in https://github.com/jenkins-infra/contributor-spotlight/.

It also rename the storage account resource to be uniform.

Follow-up of #523 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809#issuecomment-1822357561