### PR TITLE
chore(contributors.jenkins.io): recreate Storage Account and File Share

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -13,10 +13,19 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
   resource_group_name       = azurerm_resource_group.contributors_jenkins_io.name
   location                  = azurerm_resource_group.contributors_jenkins_io.location
   account_tier              = "Standard"
-  account_replication_type  = "GRS"
-  account_kind              = "Storage"
+  account_replication_type  = "ZRS"
+  account_kind              = "StorageV2"
   enable_https_traffic_only = true
   min_tls_version           = "TLS1_2"
+
+  network_rules {
+    default_action = "Deny"
+    ip_rules = flatten(concat(
+      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
+    ))
+    virtual_network_subnet_ids = [data.azurerm_subnet.privatek8s_tier.id, data.azurerm_subnet.publick8s_tier.id]
+    bypass                     = ["AzureServices"]
+  }
 
   tags = local.default_tags
 }


### PR DESCRIPTION
This PR recreates the storage account and the file share for contributors.jenkins.io

The network rules deleted in a hotfix commit were still present when looking at the storage account in Azure Portal.
I've deleted the (empty) storage account to recreate it with this PR.

Other changes:
- ZRS: no need for GRS, ZRS is sufficient
- Type StorageV2: default value from the terraform provider, "Storage" (v1) is the legacy one, no cost change between them.
- Add back network rules, allowing our IPs and the ones from publick8s and privatek8s vnets.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809#issuecomment-1822357561