### PR TITLE
chore(contributors.jenkins.io): add SAS token output

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -31,3 +31,48 @@ resource "azurerm_storage_share" "contributors_jenkins_io" {
   storage_account_name = azurerm_storage_account.contributors_jenkins_io.name
   quota                = 5
 }
+
+data "azurerm_storage_account_sas" "contributors_jenkins_io" {
+  connection_string = azurerm_storage_account.contributors_jenkins_io.primary_connection_string
+  signed_version    = "2022-11-02"
+
+  resource_types {
+    service   = true # Ex: list Share
+    container = true # Ex: list Files and Directories
+    object    = true # Ex: create File
+  }
+
+  services {
+    blob  = false
+    queue = false
+    table = false
+    file  = true
+  }
+
+  start  = "2023-11-28T00:00:00Z"
+  expiry = "2024-01-28T00:00:00Z"
+
+  # https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas#file-service
+  permissions {
+    read    = true
+    write   = true
+    delete  = true
+    list    = true
+    add     = false
+    create  = true
+    update  = false
+    process = false
+    tag     = false
+    filter  = false
+  }
+}
+
+output "contributors_jenkins_io_share_url" {
+  sensitive = true
+  value     = azurerm_storage_share.contributors_jenkins_io.url
+}
+
+output "contributors_jenkins_io_sas_query_string" {
+  sensitive = true
+  value     = data.azurerm_storage_account_sas.contributors_jenkins_io.sas
+}


### PR DESCRIPTION
This PR adds outputs to retrieve fine grained File Share SAS token so we can use azcopy instead of blobxfer and entire Storage Account access key.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809#issuecomment-1822357561