### PR TITLE
chore: set File Share URLs as not sensitive

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -68,7 +68,6 @@ data "azurerm_storage_account_sas" "contributors_jenkins_io" {
 }
 
 output "contributors_jenkins_io_share_url" {
-  sensitive = true
   value     = azurerm_storage_share.contributors_jenkins_io.url
 }
 

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -59,7 +59,6 @@ data "azurerm_storage_account_sas" "updates_jenkins_io" {
 }
 
 output "updates_jenkins_io_share_url" {
-  sensitive = true
   value     = azurerm_storage_share.updates_jenkins_io.url
 }
 


### PR DESCRIPTION
As these URL aren't sensitive and can already be obtained from public info in this repo, this PR removes the `sensitive` property of the corresponding outputs.

```console
$ terraform output updates_jenkins_io_share_url
"https://updatesjenkinsio.file.core.windows.net/updates-jenkins-io"

$ terraform output contributors_jenkins_io_share_url
"https://contributorsjenkinsio.file.core.windows.net/contributors-jenkins-io"
```