### PR TITLE
cleanup: remove unused ACI resources for trusted.ci and cert.ci

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -71,14 +71,6 @@ module "cert_ci_jenkins_io_azurevm_agents" {
   }
 }
 
-module "cert_ci_jenkins_io_aci_agents" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-aci-agents"
-
-  service_short_stripped_name     = module.cert_ci_jenkins_io.service_short_stripped_name
-  aci_agents_resource_group_name  = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name
-  controller_service_principal_id = module.cert_ci_jenkins_io.controler_service_principal_id
-}
-
 ## Service DNS records
 resource "azurerm_dns_a_record" "cert_ci_jenkins_io_controller" {
   name                = "controller"

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -68,7 +68,7 @@ data "azurerm_storage_account_sas" "contributors_jenkins_io" {
 }
 
 output "contributors_jenkins_io_share_url" {
-  value     = azurerm_storage_share.contributors_jenkins_io.url
+  value = azurerm_storage_share.contributors_jenkins_io.url
 }
 
 output "contributors_jenkins_io_sas_query_string" {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -89,14 +89,6 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
   }
 }
 
-module "trusted_ci_jenkins_io_aci_agents" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-aci-agents"
-
-  service_short_stripped_name     = module.trusted_ci_jenkins_io.service_short_stripped_name
-  aci_agents_resource_group_name  = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name
-  controller_service_principal_id = module.trusted_ci_jenkins_io.controler_service_principal_id
-}
-
 resource "azurerm_private_dns_a_record" "trusted_ci_controller" {
   name                = "@"
   zone_name           = azurerm_private_dns_zone.trusted.name

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -59,7 +59,7 @@ data "azurerm_storage_account_sas" "updates_jenkins_io" {
 }
 
 output "updates_jenkins_io_share_url" {
-  value     = azurerm_storage_share.updates_jenkins_io.url
+  value = azurerm_storage_share.updates_jenkins_io.url
 }
 
 output "updates_jenkins_io_sas_query_string" {


### PR DESCRIPTION
While working on the Terraform module split in https://github.com/jenkins-infra/helpdesk/issues/3818, it appeared that some unneeded (and unused) resources were creating by the "former module".

The migration to the "3 distinct modules" kept the resources, but this PR removes them as we won't need to use ACI with trusted and cert.