### PR TITLE
wip

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -20,10 +20,10 @@ provider "kubernetes" {
 
 provider "kubernetes" {
   alias                  = "publick8s"
-  host                   = azurerm_kubernetes_cluster.publick8s.kube_config.0.host
-  client_certificate     = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.client_certificate)
-  client_key             = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.client_key)
-  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate)
+  host                   = data.azurerm_kubernetes_cluster.publick8s.kube_config.0.host
+  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.publick8s.kube_config.0.client_certificate)
+  client_key             = base64decode(data.azurerm_kubernetes_cluster.publick8s.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate)
 }
 
 provider "postgresql" {

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -66,7 +66,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
 
   default_node_pool {
     name                         = "systempool3"
-    only_critical_addons_enabled = true
+    only_critical_addons_enabled = true               # This property is the only valid way to add the "CriticalAddonsOnly=true:NoSchedule" taint to the default node pool
     vm_size                      = "Standard_D2as_v4" # 2 vCPU, 8 GB RAM, 16 GB disk, 4000 IOPS
     kubelet_disk_type            = "OS"
     os_disk_type                 = "Ephemeral"
@@ -77,9 +77,6 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     vnet_subnet_id               = data.azurerm_subnet.publick8s_tier.id
     tags                         = local.default_tags
     zones                        = local.publick8s_compute_zones
-    # node_taints = [
-    #   "CriticalAddonsOnly=true:NoSchedule",
-    # ]
   }
 
   identity {
@@ -213,31 +210,31 @@ resource "kubernetes_storage_class" "managed_csi_premium_retain_public" {
   allow_volume_expansion = true
 }
 
-# resource "kubernetes_storage_class" "managed_csi_premium_ZRS_retain_public" {
-#   metadata {
-#     name = "managed-csi-premium-zrs-retain"
-#   }
-#   storage_provisioner = "disk.csi.azure.com"
-#   reclaim_policy      = "Retain"
-#   parameters = {
-#     skuname = "Premium_ZRS"
-#   }
-#   provider               = kubernetes.publick8s
-#   allow_volume_expansion = true
-# }
+resource "kubernetes_storage_class" "managed_csi_premium_ZRS_retain_public" {
+  metadata {
+    name = "managed-csi-premium-zrs-retain"
+  }
+  storage_provisioner = "disk.csi.azure.com"
+  reclaim_policy      = "Retain"
+  parameters = {
+    skuname = "Premium_ZRS"
+  }
+  provider               = kubernetes.publick8s
+  allow_volume_expansion = true
+}
 
-# resource "kubernetes_storage_class" "azurefile_csi_premium_retain_public" {
-#   metadata {
-#     name = "azurefile-csi-premium-retain"
-#   }
-#   storage_provisioner = "file.csi.azure.com"
-#   reclaim_policy      = "Retain"
-#   parameters = {
-#     skuname = "Premium_LRS"
-#   }
-#   mount_options = ["dir_mode=0777", "file_mode=0777", "uid=1000", "gid=1000", "mfsymlinks", "nobrl"]
-#   provider      = kubernetes.publick8s
-# }
+resource "kubernetes_storage_class" "azurefile_csi_premium_retain_public" {
+  metadata {
+    name = "azurefile-csi-premium-retain"
+  }
+  storage_provisioner = "file.csi.azure.com"
+  reclaim_policy      = "Retain"
+  parameters = {
+    skuname = "Premium_LRS"
+  }
+  mount_options = ["dir_mode=0777", "file_mode=0777", "uid=1000", "gid=1000", "mfsymlinks", "nobrl"]
+  provider      = kubernetes.publick8s
+}
 
 # Used later by the load balancer deployed on the cluster, see https://github.com/jenkins-infra/kubernetes-management/config/publick8s.yaml
 resource "azurerm_public_ip" "publick8s_ipv4" {

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -332,20 +332,20 @@ output "ldap_jenkins_io_ipv4_address" {
 }
 
 # Configure the jenkins-infra/kubernetes-management admin service account
-# module "publick8s_admin_sa" {
-#   providers = {
-#     kubernetes = kubernetes.publick8s
-#   }
-#   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
-#   cluster_name               = azurerm_kubernetes_cluster.publick8s.name
-#   cluster_hostname           = azurerm_kubernetes_cluster.publick8s.kube_config.0.host
-#   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate
-# }
+module "publick8s_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.publick8s
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = azurerm_kubernetes_cluster.publick8s.name
+  cluster_hostname           = azurerm_kubernetes_cluster.publick8s.kube_config.0.host
+  cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate
+}
 
-# output "kubeconfig_publick8s" {
-#   sensitive = true
-#   value     = module.publick8s_admin_sa.kubeconfig
-# }
+output "kubeconfig_publick8s" {
+  sensitive = true
+  value     = module.publick8s_admin_sa.kubeconfig
+}
 
 output "publick8s_kube_config_command" {
   value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.publick8s.name} --resource-group ${azurerm_kubernetes_cluster.publick8s.resource_group_name}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3827#issuecomment-1840264684

- Trick Terraform into thinking the AKS `publick8s`'s default node pool is `systempool3` created in https://github.com/jenkins-infra/azure/pull/537
  - Note that that since https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.47.0, we have to specify the `only_critical_addons_enabled` attribute of the `default_node_pool` block to configure the taint `"CriticalAddonsOnly=true:NoSchedule"` 
- We had to remove/reimport the clutser from state otherwise we were receiving the following error during apply:

  ```
  Error: expanding default_node_pool: The AKS API has removed support for tainting all nodes in the default node pool and it is no longer possible to configure this. To taint a node pool, create a separate one.
  ```

  - To ease future operations, we decoupled the provider from the AKS resource by using a data source acting as intermediate