### PR TITLE
cleanup(publick8s) remove x86medium node pool

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -113,26 +113,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "x86small" {
   tags = local.default_tags
 }
 
-resource "azurerm_kubernetes_cluster_node_pool" "x86medium" {
-  name                  = "x86medium"
-  vm_size               = "Standard_D8s_v3" # 8 vCPU, 32 GB RAM, 64 GB disk, 16 000 IOPS
-  os_disk_type          = "Ephemeral"
-  os_disk_size_gb       = 200 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["publick8s"]
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.publick8s.id
-  enable_auto_scaling   = false
-  zones                 = local.publick8s_compute_zones
-  vnet_subnet_id        = data.azurerm_subnet.publick8s_tier.id
-
-  lifecycle {
-    ignore_changes = [
-      node_count, # as per https://github.com/jenkins-infra/helpdesk/issues/3827
-    ]
-  }
-
-  tags = local.default_tags
-}
-
 resource "azurerm_kubernetes_cluster_node_pool" "arm64small2" {
   name                  = "arm64small2"
   vm_size               = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3827

- Node pool has been drained and cordoned
- All workloads have migrated to the `x86small` node pool