### PR TITLE
hotfix(ci.j, trusted.ci.j) ensure controller can reach agent with SSH

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -47,6 +47,7 @@ module "ci_jenkins_io" {
   agent_ip_prefixes = concat(
     [local.external_services["s390x.${data.azurerm_dns_zone.jenkinsio.name}"]],
     data.azurerm_subnet.ci_jenkins_io_ephemeral_agents.address_prefixes,
+    data.azurerm_subnet.ci_jenkins_io_ephemeral_agents_jenkins_sponsorship.address_prefixes,
   )
 }
 

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -82,6 +82,7 @@ module "trusted_ci_jenkins_io" {
 
   agent_ip_prefixes = concat(
     data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes,
+    data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefixes,
     [azurerm_linux_virtual_machine.trusted_permanent_agent.private_ip_address],
   )
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3818#issuecomment-1855950963

Caught while testing the new azure VM agent cloud on trusted.ci: the agent were created but the controller wasn't able to reach them.

Not seen on ci.jenkins.io because agents are using the inbound launcher while trusted.ci uses SSH launcher.