### PR TITLE
feat: allow trusted.ci.jenkins.io to manipulate storage

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -106,8 +106,8 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
 }
 
 # Required to allow azcopy sync of updates.jenkins.io File Share with the permanent agent
-module "trusted_ci_jenkins_io_storage" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-filshare-serviceprincipal-writer"
+module "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
   service_fqdn               = module.trusted_ci_jenkins_io.service_fqdn
   active_directory_owners    = [data.azuread_service_principal.terraform_production.id]

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -107,7 +107,7 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
 
 # Required to allow azcopy sync of updates.jenkins.io File Share with the permanent agent
 module "trusted_ci_jenkins_io_storage" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-storage"
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-filshare-serviceprincipal-writer"
 
   service_fqdn            = module.trusted_ci_jenkins_io.service_fqdn
   active_directory_owners = module.trusted_ci_jenkins_io.controler_service_principal_id

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -105,6 +105,17 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
   }
 }
 
+# Required to allow azcopy sync of updates.jenkins.io File Share with the permanent agent
+module "trusted_ci_jenkins_io_storage" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-storage"
+
+  service_fqdn                  = module.trusted_ci_jenkins_io.service_fqdn
+  storage_service_principal_id  = module.trusted_ci_jenkins_io.controler_service_principal_id
+  storage_active_directory_url  = "https://github.com/jenkins-infra/azure"
+  storage_file_share_ids        = [azurerm_storage_share.updates_jenkins_io.id]
+  default_tags                  = local.default_tags
+}
+
 ## Sponsorship subscription specific resources for controller
 resource "azurerm_resource_group" "trusted_ci_jenkins_io_controller_jenkins_sponsorship" {
   provider = azurerm.jenkins-sponsorship

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -109,11 +109,11 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
 module "trusted_ci_jenkins_io_storage" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-storage"
 
-  service_fqdn                  = module.trusted_ci_jenkins_io.service_fqdn
-  storage_service_principal_id  = module.trusted_ci_jenkins_io.controler_service_principal_id
-  storage_active_directory_url  = "https://github.com/jenkins-infra/azure"
-  storage_file_share_ids        = [azurerm_storage_share.updates_jenkins_io.id]
-  default_tags                  = local.default_tags
+  service_fqdn            = module.trusted_ci_jenkins_io.service_fqdn
+  active_directory_owners = module.trusted_ci_jenkins_io.controler_service_principal_id
+  active_directory_url    = "https://github.com/jenkins-infra/azure"
+  file_share_id           = azurerm_storage_share.updates_jenkins_io.id
+  default_tags            = local.default_tags
 }
 
 ## Sponsorship subscription specific resources for controller

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -109,11 +109,12 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
 module "trusted_ci_jenkins_io_storage" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-filshare-serviceprincipal-writer"
 
-  service_fqdn            = module.trusted_ci_jenkins_io.service_fqdn
-  active_directory_owners = [data.azuread_service_principal.terraform_production.id]
-  active_directory_url    = "https://github.com/jenkins-infra/azure"
-  file_share_id           = azurerm_storage_share.updates_jenkins_io.id
-  default_tags            = local.default_tags
+  service_fqdn               = module.trusted_ci_jenkins_io.service_fqdn
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = "2024-06-20T19:00:00Z"
+  file_share_id              = azurerm_storage_share.updates_jenkins_io.id
+  default_tags               = local.default_tags
 }
 
 ## Sponsorship subscription specific resources for controller

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -109,7 +109,7 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
 module "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn               = module.trusted_ci_jenkins_io.service_fqdn
+  service_fqdn               = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer"
   active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
   active_directory_url       = "https://github.com/jenkins-infra/azure"
   service_principal_end_date = "2024-06-20T19:00:00Z"

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -110,7 +110,7 @@ module "trusted_ci_jenkins_io_storage" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-filshare-serviceprincipal-writer"
 
   service_fqdn            = module.trusted_ci_jenkins_io.service_fqdn
-  active_directory_owners = module.trusted_ci_jenkins_io.controler_service_principal_id
+  active_directory_owners = [data.azuread_service_principal.terraform_production.id]
   active_directory_url    = "https://github.com/jenkins-infra/azure"
   file_share_id           = azurerm_storage_share.updates_jenkins_io.id
   default_tags            = local.default_tags

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -113,7 +113,7 @@ module "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
   active_directory_url       = "https://github.com/jenkins-infra/azure"
   service_principal_end_date = "2024-06-20T19:00:00Z"
-  file_share_id              = azurerm_storage_share.updates_jenkins_io.id
+  file_share_id              = azurerm_storage_share.updates_jenkins_io.resource_manager_id
   default_tags               = local.default_tags
 }
 


### PR DESCRIPTION
This PR uses https://github.com/jenkins-infra/shared-tools/pull/131 to allow trusted.ci.jenkins.io to manipulate the File Share content of updates.jenkins.io

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1856196680