### PR TITLE
feat(packer) create image galleries in the new subscription

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -6,32 +6,17 @@ locals {
     "dev" = {
       description = "Shared images built by pull requests in jenkins-infra/packer-images (consider it untrusted)."
       rg_location = "eastus"
-      images_location = {
-        "ubuntu-22.04-amd64" = "eastus"
-        "ubuntu-22.04-arm64" = "eastus"
-        "windows-2019-amd64" = "eastus"
-        "windows-2022-amd64" = "eastus"
-      }
+      images      = ["ubuntu-22.04-amd64", "ubuntu-22.04-arm64", "windows-2019-amd64", "windows-2022-amd64"]
     }
     "staging" = {
       description = "Shared images built by the principal code branch in jenkins-infra/packer-images (ready to be tested)."
       rg_location = "eastus"
-      images_location = {
-        "ubuntu-22.04-amd64" = "eastus"
-        "ubuntu-22.04-arm64" = "eastus"
-        "windows-2019-amd64" = "eastus"
-        "windows-2022-amd64" = "eastus"
-      }
+      images      = ["ubuntu-22.04-amd64", "ubuntu-22.04-arm64", "windows-2019-amd64", "windows-2022-amd64"]
     }
     "prod" = {
       description = "Shared images built by the releases in jenkins-infra/packer-images (⚠️ Used in production.)."
       rg_location = "eastus2"
-      images_location = {
-        "ubuntu-22.04-amd64" = "eastus"
-        "ubuntu-22.04-arm64" = "eastus"
-        "windows-2019-amd64" = "eastus"
-        "windows-2022-amd64" = "eastus"
-      }
+      images      = ["ubuntu-22.04-amd64", "ubuntu-22.04-arm64", "windows-2019-amd64", "windows-2022-amd64"]
     }
   }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3818#issuecomment-1864023952

This PR creates the shared gallery in the new subscription:

- 3 resource groups (dev, staging and prod) with one gallery each
- 4 images on each gallery

IMPORTANT: this PR sets the ground to move everything to US East 2 (faster packer builds and we don't use East US since 1.5 years for agents). It cannot do all "eastus" -> "eastus**2**" changes yet though as changing location marks a resource group/gallery to be deleted, while we only want to create new resources (terraform forgets the old resource when only changing provider).

IMPORTANT (2): I've removed the 4 role assignments which are required for the 4 controllers (ci, trusted, cert and infra) to read the shared gallery to spin up agent. The build >= 3 for this PR should only mark 3 resources to delete (the role assignment of the packer_sp itself):

```
terraform state rm 'module.cert_ci_jenkins_io.azurerm_role_assignment.controller_read_packer_prod_images[0]'
terraform state rm 'module.trusted_ci_jenkins_io.azurerm_role_assignment.controller_read_packer_prod_images[0]'
terraform state rm 'module.ci_jenkins_io.azurerm_role_assignment.controller_read_packer_prod_images[0]'
terraform state rm 'azurerm_role_assignment.infra_ci_jenkins_io_allow_packer'
```