### PR TITLE
feat(packer) migrate all resources to `eastus2`

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -5,17 +5,14 @@ locals {
   shared_galleries = {
     "dev" = {
       description = "Shared images built by pull requests in jenkins-infra/packer-images (consider it untrusted)."
-      rg_location = "eastus"
       images      = ["ubuntu-22.04-amd64", "ubuntu-22.04-arm64", "windows-2019-amd64", "windows-2022-amd64"]
     }
     "staging" = {
       description = "Shared images built by the principal code branch in jenkins-infra/packer-images (ready to be tested)."
-      rg_location = "eastus"
       images      = ["ubuntu-22.04-amd64", "ubuntu-22.04-arm64", "windows-2019-amd64", "windows-2022-amd64"]
     }
     "prod" = {
       description = "Shared images built by the releases in jenkins-infra/packer-images (⚠️ Used in production.)."
-      rg_location = "eastus2"
       images      = ["ubuntu-22.04-amd64", "ubuntu-22.04-arm64", "windows-2019-amd64", "windows-2022-amd64"]
     }
   }

--- a/packer-resources.tf
+++ b/packer-resources.tf
@@ -42,7 +42,7 @@ resource "azurerm_resource_group" "packer_images" {
   for_each = local.shared_galleries
 
   name     = "${each.key}-packer-images"
-  location = each.value.rg_location
+  location = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.location # Location of the packer subnet in infra.ci
 }
 
 resource "azurerm_resource_group" "packer_builds" {
@@ -50,7 +50,7 @@ resource "azurerm_resource_group" "packer_builds" {
   for_each = local.shared_galleries
 
   name     = "${each.key}-packer-builds"
-  location = each.value.rg_location
+  location = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.location # Location of the packer subnet in infra.ci
 }
 
 resource "azurerm_shared_image_gallery" "packer_images" {
@@ -60,7 +60,7 @@ resource "azurerm_shared_image_gallery" "packer_images" {
 
   name                = "${each.key}_packer_images"
   resource_group_name = azurerm_resource_group.packer_images[each.key].name
-  location            = "eastus" #azurerm_resource_group.packer_images[each.key].location
+  location            = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.location # Location of the packer subnet in infra.ci
   description         = each.value.description
 
   tags = {
@@ -86,7 +86,7 @@ resource "azurerm_shared_image" "jenkins_agent_images" {
   name                = format("jenkins-agent-%s", split("_", each.value)[1])
   gallery_name        = azurerm_shared_image_gallery.packer_images[split("_", each.value)[0]].name
   resource_group_name = azurerm_resource_group.packer_images[split("_", each.value)[0]].name
-  location            = "eastus" # local.shared_galleries[split("_", each.value)[0]].images_location[split("_", each.value)[1]]
+  location            = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.location # Location of the packer subnet in infra.ci
 
   architecture = length(regexall(".+arm64", split("_", each.value)[1])) > 0 ? "Arm64" : "x64"
 


### PR DESCRIPTION
Follow up of #560 

Ref. https://github.com/jenkins-infra/helpdesk/issues/3818#issuecomment-1866118776

This PR ensures that all the packer resources defined in the new subscription (and only these) are migrated to US East 2 to solve errors found in https://github.com/jenkins-infra/packer-images/pull/959


Expecting 23 resources to be re-created:
- 4 RGs on the 6 are in us east today
- 4 role assignements (as the 4 RGs changed)
- 3 galleries
- 12 images (4 per gallery