### PR TITLE
cleanup(cert,trusted) migrate NAT gateway management to azure-net

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -111,32 +111,3 @@ resource "azurerm_dns_a_record" "cert_ci_jenkins_io" {
   ttl                 = 60
   records             = [module.cert_ci_jenkins_io.controller_private_ipv4]
 }
-
-####################################################################################
-## NAT gateway to allow outbound connection on a centralized and scalable appliance
-####################################################################################
-resource "azurerm_public_ip" "cert_ci_jenkins_io_outbound" {
-  name                = "cert-ci-jenkins-io-outbound"
-  location            = data.azurerm_resource_group.cert_ci_jenkins_io.location
-  resource_group_name = module.cert_ci_jenkins_io.controller_resourcegroup_name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-resource "azurerm_nat_gateway" "cert_ci_jenkins_io_outbound" {
-  name                = "cert-ci-jenkins-io-outbound"
-  location            = data.azurerm_resource_group.cert_ci_jenkins_io.location
-  resource_group_name = module.cert_ci_jenkins_io.controller_resourcegroup_name
-  sku_name            = "Standard"
-}
-resource "azurerm_nat_gateway_public_ip_association" "cert_ci_jenkins_io_outbound" {
-  nat_gateway_id       = azurerm_nat_gateway.cert_ci_jenkins_io_outbound.id
-  public_ip_address_id = azurerm_public_ip.cert_ci_jenkins_io_outbound.id
-}
-resource "azurerm_subnet_nat_gateway_association" "cert_ci_jenkins_io_outbound_controller" {
-  subnet_id      = data.azurerm_subnet.cert_ci_jenkins_io_controller.id
-  nat_gateway_id = azurerm_nat_gateway.cert_ci_jenkins_io_outbound.id
-}
-resource "azurerm_subnet_nat_gateway_association" "cert_ci_jenkins_io_outbound_ephemeral_agents" {
-  subnet_id      = data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.id
-  nat_gateway_id = azurerm_nat_gateway.cert_ci_jenkins_io_outbound.id
-}

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -403,39 +403,6 @@ resource "azurerm_network_security_rule" "allow_inbound_ssh_from_internet_to_bou
 }
 
 ####################################################################################
-## NAT gateway to allow outbound connection on a centralized and scalable appliance
-####################################################################################
-resource "azurerm_public_ip" "trusted_outbound" {
-  name                = "trusted-outbound"
-  location            = data.azurerm_virtual_network.trusted_ci_jenkins_io.location
-  resource_group_name = module.trusted_ci_jenkins_io.controller_resourcegroup_name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-resource "azurerm_nat_gateway" "trusted_outbound" {
-  name                = "trusted-outbound"
-  location            = data.azurerm_virtual_network.trusted_ci_jenkins_io.location
-  resource_group_name = module.trusted_ci_jenkins_io.controller_resourcegroup_name
-  sku_name            = "Standard"
-}
-resource "azurerm_nat_gateway_public_ip_association" "trusted_outbound" {
-  nat_gateway_id       = azurerm_nat_gateway.trusted_outbound.id
-  public_ip_address_id = azurerm_public_ip.trusted_outbound.id
-}
-resource "azurerm_subnet_nat_gateway_association" "trusted_outbound_controller" {
-  subnet_id      = data.azurerm_subnet.trusted_ci_jenkins_io_controller.id
-  nat_gateway_id = azurerm_nat_gateway.trusted_outbound.id
-}
-resource "azurerm_subnet_nat_gateway_association" "trusted_outbound_permanent_agents" {
-  subnet_id      = data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.id
-  nat_gateway_id = azurerm_nat_gateway.trusted_outbound.id
-}
-resource "azurerm_subnet_nat_gateway_association" "trusted_outbound_ephemeral_agents" {
-  subnet_id      = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id
-  nat_gateway_id = azurerm_nat_gateway.trusted_outbound.id
-}
-
-####################################################################################
 ## Public DNS records
 ####################################################################################
 resource "azurerm_dns_a_record" "trusted_bounce" {


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3875, the need to manage NAT gateways close to network resources appeared.

This PR removes the definitions of the 2 existing NAT gateway so we can start managing them in jenkins-infra/azure-net.

Note that the associated resources (marked as "to be deleted" in the build 1) will be removed manually from the terraform state (see command in the comment below).
Then a 2nd build will be re-triggered before merging, to ensure no changes will be done by this PR.