### PR TITLE
feat(updates.jenkins.io) restrict SA to only a few administrative IPs

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -31,8 +31,6 @@ locals {
     "keyserver.ubuntu.com" = ["162.213.33.8", "162.213.33.9"]
   }
 
-  privatek8s_outbound_ip_cidr = "20.22.6.81/32"
-
   default_tags = {
     scope      = "terraform-managed"
     repository = "jenkins-infra/azure"

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -42,7 +42,12 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
         "%s/32",
         flatten(
           concat(
-            [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
+            [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
+            # privatek8s outbound IP (traffic routed trhough gateways)
+            module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],
+            # trusted.ci subnet (UC agents need to execute mirrorbits scans)
+            module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],
+            module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"],
           )
         )
       ),
@@ -50,9 +55,6 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
       data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
       # privatek8s nodes subnet
       data.azurerm_subnet.privatek8s_tier.address_prefixes,
-      [local.privatek8s_outbound_ip_cidr],
-      # trusted.ci subnet (UC agents need to execute mirrorbits scans)
-      formatlist("%s/32", module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"]),
     )
   }
 

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -35,6 +35,7 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
         )
       ),
     )
+    bypass = ["Metrics", "Logging", "AzureServices"]
   }
 }
 


### PR DESCRIPTION
This PR is related to both https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1874074475 and https://github.com/jenkins-infra/helpdesk/issues/3875

It restricts the Azure SA used for updates.jenkins.io to only a few administrative IPs including trusted.ci's 2 networks.

It also allows trusted.ci new network (sponsored) agents to access publick8s controler (for update center)