### PR TITLE
fix(updates.jenkins.io) allow publick8s cluster to reach the `updates.jenkins.io` storage account

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -27,6 +27,7 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
       data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,
       data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.id,
       data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id,
+      data.azurerm_subnet.publick8s_tier.id,
       data.azurerm_subnet.privatek8s_tier.id,
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id,
     ]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1884905867

This PR adds the `publick8s_tier` subnet in the list of allowed subnet for the `updates-jenkins-io` storage account.

The goal is to avoid the `mount error(13): Permission denied` error when pods are trying to mount the file storage.