### PR TITLE
feat(publick8s,privatek8s) set up outbound LB to support more SNAT connections

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -44,8 +44,15 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
   }
 
   network_profile {
-    network_plugin = "azure"
-    network_policy = "azure"
+    network_plugin    = "azure"
+    network_policy    = "azure"
+    outbound_type     = "loadBalancer"
+    load_balancer_sku = "standard"
+    load_balancer_profile {
+      outbound_ports_allocated  = "1600"
+      idle_timeout_in_minutes   = "4"
+      managed_outbound_ip_count = "1"
+    }
   }
 
   default_node_pool {

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -62,8 +62,15 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   network_profile {
     network_plugin = "kubenet"
     # These ranges must NOT overlap with any of the subnets
-    pod_cidrs   = ["10.100.0.0/16", "fd12:3456:789a::/64"]
-    ip_versions = ["IPv4", "IPv6"]
+    pod_cidrs         = ["10.100.0.0/16", "fd12:3456:789a::/64"]
+    ip_versions       = ["IPv4", "IPv6"]
+    outbound_type     = "loadBalancer"
+    load_balancer_sku = "standard"
+    load_balancer_profile {
+      outbound_ports_allocated  = "3200"
+      idle_timeout_in_minutes   = "4"
+      managed_outbound_ip_count = "1"
+    }
   }
 
   default_node_pool {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3908

This PR tunes the network outbound method used for both `publick8s` and `privatek8s` (using loadbalancers) with:

- TCP idle timeout decrease from 30 min (default) to 4 min to recycle sockets way more often
- Force static allocation of `3200` (and `1600`)  port on the public outbound IPs as per the Azure Metrics (these values are the upper of each amount of SNAT connection diagrams). 
  - Note it disable the dynamic allocation: this should be a problem if we have more than 50 nodes per cluster. Not the case for these 2.