### PR TITLE
hotfix(publick8s) correct outbound LB SNAT port

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -67,7 +67,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     outbound_type     = "loadBalancer"
     load_balancer_sku = "standard"
     load_balancer_profile {
-      outbound_ports_allocated  = "3200"
+      outbound_ports_allocated  = "2900"
       idle_timeout_in_minutes   = "4"
       managed_outbound_ip_count = "1"
     }


### PR DESCRIPTION
Fixup of #579 

The documentation at https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#outboundrules states

> Calculate ports per instance as follows:
> Number of frontend IPs * 64K / Number of backend instances


Today, it means: 64000/22 ( 2 node pools with max 10 nodes and 2 system nodes) ~2909

(edit)

Fixes the following error from the apply of #579 

```text
Kubernetes Cluster Name: "publick8s-endless-ghoul"): managedclusters.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="InvalidLoadBalancerProfileAllocatedOutboundPorts" Message="Load balancer profile allocated ports 3200 is not in an allowable range given the number of nodes and IPs provisioned. Total node count 25 requires 80000 ports but only 64000 ports are available given 1 outbound public IPs. Refer to https://aka.ms/aks/slb-ports for more details." Target="networkProfile.loadBalancerProfile.allocatedOutboundPorts"
```