### PR TITLE
hotfix(publick8s,privatek8s) set up LB ports amount to valid values

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -49,7 +49,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
     outbound_type     = "loadBalancer"
     load_balancer_sku = "standard"
     load_balancer_profile {
-      outbound_ports_allocated  = "1600"
+      outbound_ports_allocated  = "1280" # Max 50 Nodes, 64000 total
       idle_timeout_in_minutes   = "4"
       managed_outbound_ip_count = "1"
     }

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -67,7 +67,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     outbound_type     = "loadBalancer"
     load_balancer_sku = "standard"
     load_balancer_profile {
-      outbound_ports_allocated  = "2900"
+      outbound_ports_allocated  = "2896"
       idle_timeout_in_minutes   = "4"
       managed_outbound_ip_count = "1"
     }

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -67,7 +67,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     outbound_type     = "loadBalancer"
     load_balancer_sku = "standard"
     load_balancer_profile {
-      outbound_ports_allocated  = "2896"
+      outbound_ports_allocated  = "2560" # Max 25 Nodes, 64000 ports total
       idle_timeout_in_minutes   = "4"
       managed_outbound_ip_count = "1"
     }


### PR DESCRIPTION
Fixup of #580 

Correct the error

```
Kubernetes Cluster Name: "publick8s-endless-ghoul"): managedclusters.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="InvalidLoadBalancerProfileAllocatedOutboundPorts" Message="Load balancer profile allocated ports must be a multiple of 8. Refer to https://aka.ms/aks/slb-ports for more details." Target="networkProfile.loadBalancerProfile.allocatedOutboundPorts"
```

🤦 