### PR TITLE
feat(ci.jenkins.io) add a secondary (empty) VM to prepare moving controller to secondary sponsored subscription

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -67,9 +67,9 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     outbound_type     = "loadBalancer"
     load_balancer_sku = "standard"
     load_balancer_profile {
-      outbound_ports_allocated  = "2560" # Max 25 Nodes, 64000 ports total per public IP
-      idle_timeout_in_minutes   = "4"
-      managed_outbound_ip_count = "3"
+      outbound_ports_allocated    = "2560" # Max 25 Nodes, 64000 ports total per public IP
+      idle_timeout_in_minutes     = "4"
+      managed_outbound_ip_count   = "3"
       managed_outbound_ipv6_count = "2"
     }
   }

--- a/vnets.tf
+++ b/vnets.tf
@@ -89,6 +89,12 @@ data "azurerm_subnet" "private_vnet_data_tier" {
   virtual_network_name = data.azurerm_virtual_network.private.name
   resource_group_name  = data.azurerm_resource_group.private.name
 }
+data "azurerm_subnet" "ci_jenkins_io_controller_sponsorship" {
+  provider             = azurerm.jenkins-sponsorship
+  name                 = "${data.azurerm_virtual_network.public_jenkins_sponsorship.name}-ci_jenkins_io_controller"
+  virtual_network_name = data.azurerm_virtual_network.public_jenkins_sponsorship.name
+  resource_group_name  = data.azurerm_virtual_network.public_jenkins_sponsorship.resource_group_name
+}
 data "azurerm_subnet" "ci_jenkins_io_ephemeral_agents" {
   name                 = "${data.azurerm_virtual_network.public.name}-ci_jenkins_io_agents"
   virtual_network_name = data.azurerm_virtual_network.public.name


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3913

This PR adds a new ci.jenkins.io controller VM in the new subscription.

Blocked by:
- Subnet to add for the controller in the new subscription: https://github.com/jenkins-infra/azure-net/pull/195 
- Update the terraform module for azure vm controllers to support different AzureRM providers between resources and DNS records (Link to be added)