### PR TITLE
chore(ci.jenkins.io, trusted.ci.jenkins.io, cert.ci.jenkins.io) update azure VM controller module to support distinct AzureRM provider for DNS

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -1,6 +1,12 @@
 module "cert_ci_jenkins_io" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-controller"
 
+  providers = {
+    azurerm     = azurerm
+    azurerm.dns = azurerm
+    azuread     = azuread
+  }
+
   service_fqdn                 = data.azurerm_dns_zone.cert_ci_jenkins_io.name
   location                     = data.azurerm_resource_group.cert_ci_jenkins_io.location
   admin_username               = local.admin_username

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -4,6 +4,11 @@
 module "ci_jenkins_io" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-controller"
 
+  providers = {
+    azurerm     = azurerm
+    azurerm.dns = azurerm
+    azuread     = azuread
+  }
   service_fqdn                 = "ci.jenkins.io"
   location                     = data.azurerm_virtual_network.public.location
   admin_username               = local.admin_username

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -14,6 +14,12 @@ resource "azurerm_private_dns_zone_virtual_network_link" "trusted" {
 module "trusted_ci_jenkins_io" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-controller"
 
+  providers = {
+    azurerm     = azurerm
+    azurerm.dns = azurerm
+    azuread     = azuread
+  }
+
   service_fqdn                 = azurerm_private_dns_zone.trusted.name
   location                     = data.azurerm_virtual_network.trusted_ci_jenkins_io.location
   admin_username               = local.admin_username


### PR DESCRIPTION
Ref. jenkins-infra/helpdesk#3913

Blocked by https://github.com/jenkins-infra/shared-tools/pull/135

This PR expects module to be updated as it sets up providers for the 3 existing controllers