### PR TITLE
fix(publick8s) add more public IPs for outbound connection to avoid SNAT exhaustion

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -67,9 +67,9 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     outbound_type     = "loadBalancer"
     load_balancer_sku = "standard"
     load_balancer_profile {
-      outbound_ports_allocated  = "2560" # Max 25 Nodes, 64000 ports total
+      outbound_ports_allocated  = "2560" # Max 25 Nodes, 64000 ports total per public IP
       idle_timeout_in_minutes   = "4"
-      managed_outbound_ip_count = "1"
+      managed_outbound_ip_count = "3"
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3908

This PR increases the amount of public IPs used for outbound connection in `publick8s` as a tentative to increase the SNAT exhaustion threshold.