### PR TITLE
test(contributors.jenkins.io): revoke SAS token by backdating its expiry date

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -50,7 +50,7 @@ data "azurerm_storage_account_sas" "contributors_jenkins_io" {
   }
 
   start  = "2023-11-28T00:00:00Z"
-  expiry = "2024-01-28T00:00:00Z"
+  expiry = "2024-01-01T00:00:00Z"
 
   # https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas#file-service
   permissions {


### PR DESCRIPTION
This PR backdates contributors.jenkins.io File Share SAS token to a past date in order to check if it revokes the token.