### PR TITLE
chore(contributors.jenkins.io): add a stored access policy to the storage account

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -35,8 +35,8 @@ resource "azurerm_storage_share" "contributors_jenkins_io" {
     id = "contributorsjenkinsio-stored-access-policy"
     access_policy {
       permissions = "rwdl"
-      start  = "2024-01-22T00:00:00Z"
-      expiry = "2024-04-21T00:00:00Z"
+      start  = "2024-01-23T00:00:00Z"
+      expiry = "2024-04-23T00:00:00Z"
     }
   }
 }

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -23,6 +23,14 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
     bypass                     = ["AzureServices"]
   }
 
+  tags = local.default_tags
+}
+
+resource "azurerm_storage_share" "contributors_jenkins_io" {
+  name                 = "contributors-jenkins-io"
+  storage_account_name = azurerm_storage_account.contributors_jenkins_io.name
+  quota                = 5
+
   acl {
     id = "contributorsjenkinsio-stored-access-policy"
     access_policy {
@@ -31,14 +39,6 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
       expiry = "2024-04-21T00:00:00Z"
     }
   }
-
-  tags = local.default_tags
-}
-
-resource "azurerm_storage_share" "contributors_jenkins_io" {
-  name                 = "contributors-jenkins-io"
-  storage_account_name = azurerm_storage_account.contributors_jenkins_io.name
-  quota                = 5
 }
 
 data "azurerm_storage_account_sas" "contributors_jenkins_io" {

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -23,6 +23,15 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
     bypass                     = ["AzureServices"]
   }
 
+  acl {
+    id = "contributorsjenkinsio-stored-access-policy"
+    access_policy {
+      permissions = "rwdl"
+      start  = "2024-01-22T00:00:00Z"
+      expiry = "2024-04-21T00:00:00Z"
+    }
+  }
+
   tags = local.default_tags
 }
 

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -35,8 +35,8 @@ resource "azurerm_storage_share" "contributors_jenkins_io" {
     id = "contributorsjenkinsio-stored-access-policy"
     access_policy {
       permissions = "rwdl"
-      start  = "2024-01-23T00:00:00Z"
-      expiry = "2024-04-23T00:00:00Z"
+      start  = "2024-01-22T00:00:00Z"
+      expiry = "2024-04-21T00:00:00Z"
     }
   }
 }

--- a/updatecli/updatecli.d/contributor.jenkins.io.expiry.yaml
+++ b/updatecli/updatecli.d/contributor.jenkins.io.expiry.yaml
@@ -60,6 +60,22 @@ targets:
       file: contributors.jenkins.io.tf
       path: data.azurerm_storage_account_sas.contributors_jenkins_io.start
     scmid: default
+  updateStoredPolicyNextExpiry:
+    name: Update Terraform file `contributors.jenkins.io.tf`
+    kind: terraform/file
+    sourceid: nextExpiry
+    spec:
+      file: contributors.jenkins.io.tf
+      path: azurerm_storage_account.contributors_jenkins_io.acl.access_policy.expiry
+    scmid: default
+  updateStoredPolicyStartDate:
+    name: Update Terraform file `contributors.jenkins.io.tf`
+    kind: terraform/file
+    sourceid: nextStartDate
+    spec:
+      file: contributors.jenkins.io.tf
+      path: azurerm_storage_account.contributors_jenkins_io.acl.access_policy.start
+    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/contributor.jenkins.io.expiry.yaml
+++ b/updatecli/updatecli.d/contributor.jenkins.io.expiry.yaml
@@ -60,22 +60,6 @@ targets:
       file: contributors.jenkins.io.tf
       path: data.azurerm_storage_account_sas.contributors_jenkins_io.start
     scmid: default
-  updateStoredPolicyNextExpiry:
-    name: Update Terraform file `contributors.jenkins.io.tf`
-    kind: terraform/file
-    sourceid: nextExpiry
-    spec:
-      file: contributors.jenkins.io.tf
-      path: azurerm_storage_account.contributors_jenkins_io.acl.access_policy.expiry
-    scmid: default
-  updateStoredPolicyStartDate:
-    name: Update Terraform file `contributors.jenkins.io.tf`
-    kind: terraform/file
-    sourceid: nextStartDate
-    spec:
-      file: contributors.jenkins.io.tf
-      path: azurerm_storage_account.contributors_jenkins_io.acl.access_policy.start
-    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
Cf https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#best-practices-when-using-sas, This PR defines a stored access policy which allows to easily revoke a SAS token by backdating its expiry date cf https://learn.microsoft.com/en-us/rest/api/storageservices/define-stored-access-policy:

> You can also use a stored access policy to revoke a signature after it has been issued.

We can then pass this stored access policy as argument to create a SAS token with `az`:
```
az storage share generate-sas --name updates-jenkins-io --account-name updatesjenkinsio  --https-only --permissions dlrw --policy-name contributorsjenkinsio-stored-access-policy --expiry 2024-01-24T00:00Z
```
(Haven't tested yet if the `permissions` parameter is needed)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414