### PR TITLE
feat(publick8s, privatek8s) allow NAT gateways to AKS API

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -35,7 +35,9 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
         "%s/32",
         flatten(
           concat(
-            [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
+            [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
+            # privatek8s outbound IPs (traffic routed through gateways or outbound LBs)
+            module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],
           )
         )
       ),

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -43,8 +43,10 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
         flatten(
           concat(
             [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-            # privatek8s outbound IP (traffic routed trhough gateways)
+            # privatek8s outbound IPs (traffic routed through gateways or outbound LBs)
             module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],
+            # publick8s outbound IPs (traffic routed through gateways or outbound LBs)
+            module.jenkins_infra_shared_data.outbound_ips["publick8s.jenkins.io"],
             # trusted.ci subnet (UC agents need to execute mirrorbits scans)
             module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],
             module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"],


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3908

This PR adds the NAT gatewat public IP in the allow list for both `publick8s` and `privatek8s` to ensure all requests originated from inside the clusters (autoscaler, nodes healthchecks, API commands for `kubectl logs/exec`, etc.) are allowed to reach the control plane.