### PR TITLE
chore(contributors.jenkins.io): use ISO8601 datetime for SA ACL

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -39,6 +39,13 @@ resource "azurerm_storage_share" "contributors_jenkins_io" {
       expiry      = "2024-04-23T00:00:00Z"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes for acl as it's recreated identically everytime
+      acl
+    ]
+  }
 }
 
 data "azurerm_storage_account_sas" "contributors_jenkins_io" {

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -35,8 +35,8 @@ resource "azurerm_storage_share" "contributors_jenkins_io" {
     id = "contributorsjenkinsio-stored-access-policy"
     access_policy {
       permissions = "rwdl"
-      start       = "2024-01-23T00:00:00Z"
-      expiry      = "2024-04-23T00:00:00Z"
+      start       = "2024-01-23T00:00:00.0000000Z"
+      expiry      = "2024-04-23T00:00:00.0000000Z"
     }
   }
 


### PR DESCRIPTION
This PR adds a lifecycle to contributors.jenkins.io file share to ignore its acl changes, recreated identically every time:

```diff
- acl {
    - id = "contributorsjenkinsio-stored-access-policy" -> null

    - access_policy {
        - expiry      = "2024-04-23T00:00:00.0000000Z" -> null
        - permissions = "rwdl" -> null
        - start       = "2024-01-23T00:00:00.0000000Z" -> null
      }
  }
+ acl {
    + id = "contributorsjenkinsio-stored-access-policy"

    + access_policy {
        + expiry      = "2024-04-23T00:00:0000000Z"
        + permissions = "rwdl"
        + start       = "2024-01-23T00:00:0000000Z"
      }
  }
```

Follow-up of:
- #595 