### PR TITLE
fix(ci.jenkins.io) re-create the new VM (sponsored) with proper DNS

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -52,8 +52,9 @@ module "ci_jenkins_io_sponsorship" {
     azuread     = azuread
   }
 
-  service_custom_name          = "ci.jenkins.io-sponsorship"
-  service_fqdn                 = "ci.jenkins.io"
+  service_fqdn                 = "sponsorship.ci.jenkins.io"
+  dns_zone_name                = data.azurerm_dns_zone.jenkinsio.name
+  dns_resourcegroup_name       = data.azurerm_resource_group.proddns_jenkinsio.name
   location                     = data.azurerm_virtual_network.public_jenkins_sponsorship.location
   admin_username               = local.admin_username
   admin_ssh_publickey          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKvZ23dkvhjSU0Gxl5+mKcBOwmR7gqJDYeA1/Xzl3otV4CtC5te5Vx7YnNEFDXD6BsNkFaliXa34yE37WMdWl+exIURBMhBLmOPxEP/cWA5ZbXP//78ejZsxawBpBJy27uQhdcR0zVoMJc8Q9ShYl5YT/Tq1UcPq2wTNFvnrBJL1FrpGT+6l46BTHI+Wpso8BK64LsfX3hKnJEGuHSM0GAcYQSpXAeGS9zObKyZpk3of/Qw/2sVilIOAgNODbwqyWgEBTjMUln71Mjlt1hsEkv3K/VdvpFNF8VNq5k94VX6Rvg5FQBRL5IrlkuNwGWcBbl8Ydqk4wrD3b/PrtuLBEUsqbNhLnlEvFcjak+u2kzCov73csN/oylR0Tkr2y9x2HfZgDJVtvKjkkc4QERo7AqlTuy1whGfDYsioeabVLjZ9ahPjakv9qwcBrEEF+pAya7Q3AgNFVSdPgLDEwEO8GUHaxAjtyXXv9+yPdoDGmG3Pfn3KqM6UZjHCxne3Dr5ZE="

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -35,8 +35,8 @@ resource "azurerm_storage_share" "contributors_jenkins_io" {
     id = "contributorsjenkinsio-stored-access-policy"
     access_policy {
       permissions = "rwdl"
-      start  = "2024-01-23T00:00:00Z"
-      expiry = "2024-04-23T00:00:00Z"
+      start       = "2024-01-23T00:00:00Z"
+      expiry      = "2024-04-23T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
The goal of this PR is to recreate  the new (sponsored) VM and ensure it has a proper DNS (and hostname) so that Puppet can manage it properly.

Related to https://github.com/jenkins-infra/helpdesk/issues/3913