### PR TITLE
fix(infra.ci.jenkins.io): correct scope on contributors.jenkins.io resource group

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -76,7 +76,7 @@ module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
   active_directory_url       = "https://github.com/jenkins-infra/azure"
   service_principal_end_date = "2024-06-20T23:00:00Z"
-  file_share_id              = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
+  file_share_id              = azurerm_resource_group.contributors_jenkins_io.io
   default_tags               = local.default_tags
 }
 output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -76,7 +76,7 @@ module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
   active_directory_url       = "https://github.com/jenkins-infra/azure"
   service_principal_end_date = "2024-06-20T23:00:00Z"
-  file_share_id              = azurerm_resource_group.contributors_jenkins_io.io
+  file_share_id              = azurerm_resource_group.contributors_jenkins_io.id
   default_tags               = local.default_tags
 }
 output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {


### PR DESCRIPTION
This PR sets the misnamed `file_share_id` (it should be renamed to `scope` in another PR) from contributors.jenkins.io File Share id to its resource group id.

It's used in the fileshare-writer module to define the scope of the role assignment given to the service principal.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414