### PR TITLE
fix(infra.ci.jenkins.io.tf): use File Share's `resource_manager_id` as scope for contributors.jenkins.io

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -76,7 +76,7 @@ module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
   active_directory_url       = "https://github.com/jenkins-infra/azure"
   service_principal_end_date = "2024-06-20T23:00:00Z"
-  file_share_id              = azurerm_resource_group.contributors_jenkins_io.id
+  file_share_id              = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
   default_tags               = local.default_tags
 }
 output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {


### PR DESCRIPTION
This PR set `file_share_id` to contributors.jenkins.io File Share's `resource_manager_id` as it's set for the updates.jenkins.io File Share and trusted.ci.jenkins.io service principal: https://github.com/jenkins-infra/azure/blob/4aea9949038d69bd22bf5618a324ddb541f0b69e/trusted.ci.jenkins.io.tf#L84

Fixup of:
- #602 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414