### PR TITLE
fix(get.jenkins.io) correct SA parameter to allow creation

### DIFF
--- a/get.jenkins.io.tf
+++ b/get.jenkins.io.tf
@@ -6,12 +6,16 @@ resource "azurerm_resource_group" "get_jenkins_io" {
 }
 
 resource "azurerm_storage_account" "get_jenkins_io" {
-  name                     = "getjenkinsio"
-  resource_group_name      = azurerm_resource_group.get_jenkins_io.name
-  location                 = azurerm_resource_group.get_jenkins_io.location
-  account_tier             = "Premium"
-  account_replication_type = "ZRS"
-  min_tls_version          = "TLS1_2" # default value, needed for tfsec
+  name                = "getjenkinsio"
+  resource_group_name = azurerm_resource_group.get_jenkins_io.name
+  location            = azurerm_resource_group.get_jenkins_io.location
+
+  account_tier                      = "Premium"
+  account_kind                      = "FileStorage"
+  access_tier                       = "Hot"
+  account_replication_type          = "ZRS"
+  min_tls_version                   = "TLS1_2" # default value, needed for tfsec
+  infrastructure_encryption_enabled = true
 
   tags = local.default_tags
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3917

Fixup of #598 

This PR correct attributes, mainly `account_kind` which must have the value `FileStorage`