### PR TITLE
chore(infra.ci.jenkins.io): add contributors.jenkins.io service principal outputs

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -86,6 +86,16 @@ output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_password" {
   sensitive = true
   value     = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
 }
+output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_sp_id" {
+  value = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_id
+}
+output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_sp_password" {
+  sensitive = true
+  value     = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
+}
 
 locals {
   infra_ci_jenkins_io_fqdn                        = "infra.ci.jenkins.io"


### PR DESCRIPTION
This PR adds outputs for contributors.jenkins.io service principal.

Follow-up of:
- https://github.com/jenkins-infra/shared-tools/pull/138

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414