### PR TITLE
fix: add website file share to getjenkinsio storage account

### DIFF
--- a/get.jenkins.io.tf
+++ b/get.jenkins.io.tf
@@ -43,6 +43,12 @@ resource "azurerm_storage_share" "get_jenkins_io" {
   quota                = 700 # 512.14GiB used (Begining 2024)
 }
 
+resource "azurerm_storage_share" "get_jenkins_io_website" {
+  name                 = "website"
+  storage_account_name = azurerm_storage_account.get_jenkins_io.name
+  quota                = 50 # 1.6GiB used in 2020
+}
+
 data "azurerm_storage_account_sas" "get_jenkins_io" {
   connection_string = azurerm_storage_account.get_jenkins_io.primary_connection_string
   signed_version    = "2022-11-02"


### PR DESCRIPTION
This PR recreates the file share deleted in https://github.com/jenkins-infra/helpdesk/issues/3917#issuecomment-1912026208, needed for the Core release process.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3927