### PR TITLE
fix(get-jenkins-io): allow release.ci.jenkins.io to interact with its storage account

### DIFF
--- a/get.jenkins.io.tf
+++ b/get.jenkins.io.tf
@@ -31,6 +31,7 @@ resource "azurerm_storage_account" "get_jenkins_io" {
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
       data.azurerm_subnet.privatek8s_tier.id,
+      data.azurerm_subnet.privatek8s_release_tier.id,
     ]
     bypass = ["Metrics", "Logging", "AzureServices"]
   }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -244,7 +244,7 @@ resource "azurerm_role_assignment" "publicip_networkcontributor" {
 
 # Allow cluster to manage get.jenkins.io storage account
 resource "azurerm_role_assignment" "getjenkinsio_storage_account_contributor" {
-  scope                            = azurerm_public_ip.public_privatek8s.id
+  scope                            = azurerm_storage_account.get_jenkins_io.id
   role_definition_name             = "Storage Account Contributor"
   principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
   skip_service_principal_aad_check = true

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -242,6 +242,14 @@ resource "azurerm_role_assignment" "publicip_networkcontributor" {
   skip_service_principal_aad_check = true
 }
 
+# Allow cluster to manage get.jenkins.io storage account
+resource "azurerm_role_assignment" "getjenkinsio_storage_account_contributor" {
+  scope                            = azurerm_public_ip.public_privatek8s.id
+  role_definition_name             = "Storage Account Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}
+
 resource "kubernetes_storage_class" "managed_csi_premium_retain" {
   metadata {
     name = "managed-csi-premium-retain"


### PR DESCRIPTION
This PR adds release.ci.jenkins.io subnet to `getjenkinsio` storage account's allowed virtual nets, and adds `Storage Account Contributor` role assignment to privatek8s's service principal.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3927