### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,39 +1,28 @@
-parallel(
-  failFast: false,
-  'terraform': {
-    terraform(
-      stagingCredentials: [
-        azureServicePrincipal(
-          credentialsId: 'staging-terraform-azure-serviceprincipal',
-          subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
-          clientIdVariable: 'ARM_CLIENT_ID',
-          clientSecretVariable: 'ARM_CLIENT_SECRET',
-          tenantIdVariable: 'ARM_TENANT_ID',
-        ),
-        file(
-          credentialsId: 'staging-terraform-azure-backend-config',
-          variable: 'BACKEND_CONFIG_FILE',
-        ),
-      ],
-      productionCredentials: [
-        azureServicePrincipal(
-          credentialsId: 'production-terraform-azure-serviceprincipal',
-          subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
-          clientIdVariable: 'ARM_CLIENT_ID',
-          clientSecretVariable: 'ARM_CLIENT_SECRET',
-          tenantIdVariable: 'ARM_TENANT_ID',
-        ),
-        file(
-          credentialsId: 'production-terraform-azure-backend-config',
-          variable: 'BACKEND_CONFIG_FILE',
-        ),
-      ],
-    )
-  },
-  'updatecli': {
-    updatecli(action: 'diff')
-    if (env.BRANCH_IS_PRIMARY) {
-      updatecli(action: 'apply', cronTriggerExpression: '@daily')
-    }
-  },
+terraform(
+  stagingCredentials: [
+    azureServicePrincipal(
+      credentialsId: 'staging-terraform-azure-serviceprincipal',
+      subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
+      clientIdVariable: 'ARM_CLIENT_ID',
+      clientSecretVariable: 'ARM_CLIENT_SECRET',
+      tenantIdVariable: 'ARM_TENANT_ID',
+    ),
+    file(
+      credentialsId: 'staging-terraform-azure-backend-config',
+      variable: 'BACKEND_CONFIG_FILE',
+    ),
+  ],
+  productionCredentials: [
+    azureServicePrincipal(
+      credentialsId: 'production-terraform-azure-serviceprincipal',
+      subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
+      clientIdVariable: 'ARM_CLIENT_ID',
+      clientSecretVariable: 'ARM_CLIENT_SECRET',
+      tenantIdVariable: 'ARM_TENANT_ID',
+    ),
+    file(
+      credentialsId: 'production-terraform-azure-backend-config',
+      variable: 'BACKEND_CONFIG_FILE',
+    ),
+  ],
 )

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+}


### PR DESCRIPTION
This PR separates updatecli to its own pipeline.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778