### PR TITLE
fix(contributor/updates): set Storage Account Contributor role for fileshare-writer service principals

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -72,12 +72,13 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_subnet_privat
 module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
-  active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
-  active_directory_url       = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date = "2024-06-20T23:00:00Z"
-  file_share_id              = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
-  default_tags               = local.default_tags
+  service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-06-20T23:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
+  storage_account_scope          = azurerm_storage_account.contributors_jenkins_io.id
+  default_tags                   = local.default_tags
 }
 output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {
   value = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -77,7 +77,7 @@ module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   active_directory_url           = "https://github.com/jenkins-infra/azure"
   service_principal_end_date     = "2024-06-20T23:00:00Z"
   file_share_resource_manager_id = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
-  storage_account_scope          = azurerm_storage_account.contributors_jenkins_io.id
+  storage_account_id             = azurerm_storage_account.contributors_jenkins_io.id
   default_tags                   = local.default_tags
 }
 output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -82,7 +82,7 @@ module "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   active_directory_url           = "https://github.com/jenkins-infra/azure"
   service_principal_end_date     = "2024-06-20T19:00:00Z"
   file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io.resource_manager_id
-  storage_account_scope          = azurerm_storage_account.updates_jenkins_io.id
+  storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }
 output "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -77,12 +77,13 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
 module "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn               = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer"
-  active_directory_owners    = [data.azuread_service_principal.terraform_production.id]
-  active_directory_url       = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date = "2024-06-20T19:00:00Z"
-  file_share_id              = azurerm_storage_share.updates_jenkins_io.resource_manager_id
-  default_tags               = local.default_tags
+  service_fqdn                   = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-06-20T19:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io.resource_manager_id
+  storage_account_scope          = azurerm_storage_account.updates_jenkins_io.id
+  default_tags                   = local.default_tags
 }
 output "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {
   value = module.trusted_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id


### PR DESCRIPTION
This PR sets the new fileshare writer module input variable `storage_account_id`, and rename `file_share_id` to `file_share_resource_manager_id`.

Review without whitespaces changes: https://github.com/jenkins-infra/azure/pull/618/files?diff=unified&w=1

Follow-up of:
- https://github.com/jenkins-infra/shared-tools/pull/143

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1942141701