### PR TITLE
chore(trusted.ci): remove SAS token

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,9 +20,9 @@ resource "azurerm_resource_group" "prod_public_ips" {
 }
 
 output "jenkins_tenant_id" {
-  value = azurerm_subscription.jenkins.tenant_id
+  value = data.azurerm_subscription.jenkins.tenant_id
 }
 
 output "jenkins_subscription_id" {
-  value = azurerm_subscription.jenkins.subscription_id
+  value = data.azurerm_subscription.jenkins.subscription_id
 }

--- a/main.tf
+++ b/main.tf
@@ -18,3 +18,11 @@ resource "azurerm_resource_group" "prod_public_ips" {
   location = var.location
   tags     = local.default_tags
 }
+
+output "jenkins_tenant_id" {
+  value = azurerm_subscription.jenkins.tenant_id
+}
+
+output "jenkins_subscription_id" {
+  value = azurerm_subscription.jenkins.subscription_id
+}

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -41,50 +41,6 @@ resource "azurerm_storage_share" "updates_jenkins_io" {
   quota                = 2 # updates.jenkins.io total size in /www/updates.jenkins.io: 400Mo (Mid 2023)
 }
 
-data "azurerm_storage_account_sas" "updates_jenkins_io" {
-  connection_string = azurerm_storage_account.updates_jenkins_io.primary_connection_string
-  signed_version    = "2022-11-02"
-
-  resource_types {
-    service   = true # Ex: list Share
-    container = true # Ex: list Files and Directories
-    object    = true # Ex: create File
-  }
-
-  services {
-    blob  = false
-    queue = false
-    table = false
-    file  = true
-  }
-
-  start  = "2024-01-01T00:00:00Z"
-  expiry = "2024-03-01T00:00:00Z"
-
-  # https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas#file-service
-  permissions {
-    read    = true
-    write   = true
-    delete  = true
-    list    = true
-    add     = false
-    create  = true
-    update  = false
-    process = false
-    tag     = false
-    filter  = false
-  }
-}
-
-output "updates_jenkins_io_share_url" {
-  value = azurerm_storage_share.updates_jenkins_io.url
-}
-
-output "updates_jenkins_io_sas_query_string" {
-  sensitive = true
-  value     = data.azurerm_storage_account_sas.updates_jenkins_io.sas
-}
-
 # Redis database
 resource "azurerm_redis_cache" "updates_jenkins_io" {
   name                = "updates-jenkins-io"


### PR DESCRIPTION
This PR removes the SAS token as we'll use a service principal to generate a short lived SAS token instead, already added in https://github.com/jenkins-infra/azure/pull/618

This PR also adds the `jenkins` subscription_id and tenant_id so we can retrieve them to create the service principal credentials.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1952035761