### PR TITLE
feat(jenkins.io): new premium storage and infra.ci service principal writer

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -98,6 +98,26 @@ output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_sp_password" {
   value     = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
 }
 
+# Required to allow azcopy sync of jenkins.io File Share
+module "infraci_jenkinsio_fileshare_serviceprincipal_writer" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+
+  service_fqdn                   = "infraci-jenkinsio-fileshare_serviceprincipal_writer"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-07-23T00:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.jenkins_io.resource_manager_id
+  storage_account_id             = azurerm_storage_account.jenkins_io.id
+  default_tags                   = local.default_tags
+}
+output "infraci_jenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.infraci_jenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "infraci_jenkinsio_fileshare_serviceprincipal_writer_password" {
+  sensitive = true
+  value     = module.infraci_jenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+}
+
 locals {
   infra_ci_jenkins_io_fqdn                        = "infra.ci.jenkins.io"
   infra_ci_jenkins_io_service_short_name          = trimprefix(trimprefix(local.infra_ci_jenkins_io_fqdn, "jenkins.io"), ".")

--- a/jenkins.io.tf
+++ b/jenkins.io.tf
@@ -1,0 +1,20 @@
+resource "azurerm_resource_group" "jenkins_io" {
+  name     = "jenkinsio"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "jenkins_io" {
+  name                     = "jenkinsio"
+  resource_group_name      = azurerm_resource_group.jenkins_io.name
+  location                 = azurerm_resource_group.jenkins_io.location
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+
+  tags = local.default_tags
+}
+
+resource "azurerm_storage_share" "jenkins_io" {
+  name                 = "jenkins-io"
+  storage_account_name = azurerm_storage_account.contributors_jenkins_io.name
+  quota                = 5 # Used capacity end of February 2024: 380Mio
+}


### PR DESCRIPTION
This PR adds a new Premium storage account and file share for jenkins.io, and a service principal writer allowing infra.ci.jenkins.io to use azcopy and short lived SAS token to interact with it.

Looking at existing jenkins.io storage account, we noticed that most of its $70/month cost came from transactions.
Using a Premium storage account instead with no transaction cost should allow us to decrease the monthly charge.

Compared to the existing "prodjenkinsio" storage account, this PR sets the new storage account replication type from "GRS" to "LRS", sufficient for our use case.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414
