### PR TITLE
fixup(jenkins.io): set File Share size to 100Gio (minimum when using Premium)

### DIFF
--- a/jenkins.io.tf
+++ b/jenkins.io.tf
@@ -37,5 +37,5 @@ resource "azurerm_storage_account" "jenkins_io" {
 resource "azurerm_storage_share" "jenkins_io" {
   name                 = "jenkins-io"
   storage_account_name = azurerm_storage_account.jenkins_io.name
-  quota                = 5 # Used capacity end of February 2024: 380Mio
+  quota                = 100 # Minimum size when using a Premium storage account
 }


### PR DESCRIPTION
This PR sets `jenkins-io` file share size to 100Gio, the minimum size when using a Premium storage account.

According to https://azure.microsoft.com/en-us/pricing/details/storage/files/#pricing, this means a cost of $20/month ($0.20 * 100Gio)

<img width="1270" alt="image" src="https://github.com/jenkins-infra/azure/assets/91831478/81f0fea5-8c0e-4288-bbf2-8ee0cb085968">

Fixup of:
- #623 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414
