### PR TITLE
feat(javadoc.jenkins.io): new storage

### DIFF
--- a/javadoc.jenkins.io.tf
+++ b/javadoc.jenkins.io.tf
@@ -1,0 +1,41 @@
+resource "azurerm_resource_group" "javadoc_jenkins_io" {
+  name     = "javadocjenkinsio"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "javadoc_jenkins_io" {
+  name                              = "javadocjenkinsio"
+  resource_group_name               = azurerm_resource_group.javadoc_jenkins_io.name
+  location                          = azurerm_resource_group.javadoc_jenkins_io.location
+  account_tier                      = "Premium"
+  account_kind                      = "FileStorage"
+  access_tier                       = "Hot"
+  account_replication_type          = "ZRS"
+  min_tls_version                   = "TLS1_2" # default value, needed for tfsec
+  infrastructure_encryption_enabled = true
+
+  # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"
+  network_rules {
+    default_action = "Deny"
+    ip_rules = flatten(
+      concat(
+        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
+      )
+    )
+    virtual_network_subnet_ids = [
+      data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_tier.id, # required for management from infra.ci (terraform)
+      data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,
+      data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id,
+    ]
+    bypass = ["Metrics", "Logging", "AzureServices"]
+  }
+
+  tags = local.default_tags
+}
+
+resource "azurerm_storage_share" "javadoc_jenkins_io" {
+  name                 = "javadoc-jenkins-io"
+  storage_account_name = azurerm_storage_account.javadoc_jenkins_io.name
+  quota                = 100 # Minimum size when using a Premium storage account
+}

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -113,6 +113,26 @@ output "trustedci_jenkinsio_fileshare_serviceprincipal_writer_password" {
   value     = module.trustedci_jenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
 }
 
+# Required to allow azcopy sync of javadoc.jenkins.io File Share
+module "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+
+  service_fqdn                   = "trustedci-javadocjenkinsio-fileshare_serviceprincipal_writer"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-07-28T00:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.javadoc_jenkins_io.resource_manager_id
+  storage_account_id             = azurerm_storage_account.javadoc_jenkins_io.id
+  default_tags                   = local.default_tags
+}
+output "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer_password" {
+  sensitive = true
+  value     = module.trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+}
+
 ## Sponsorship subscription specific resources for controller
 resource "azurerm_resource_group" "trusted_ci_jenkins_io_controller_jenkins_sponsorship" {
   provider = azurerm.jenkins-sponsorship


### PR DESCRIPTION
This PR creates a Premium Storage Account, a File Share and a Service Principal attached to trusted.ci.jenkins.io (from where the publication of javadoc.jenkins.io is executed)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1966067802