### PR TITLE
bump (privatek8s): patch kubernetes to 1.26.12

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -39,7 +39,7 @@ locals {
   admin_username = "jenkins-infra-team"
 
   kubernetes_versions = {
-    "privatek8s" = "1.26.6"
+    "privatek8s" = "1.26.12"
     "publick8s"  = "1.26.6"
   }
 }


### PR DESCRIPTION
as per https://github.com/jenkins-infra/azure/pull/634 and https://github.com/jenkins-infra/azure/pull/635

need to upgrade to the latest patch version