### PR TITLE
feat(privatek8s): adding a large arm64 nodepool

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -169,6 +169,38 @@ resource "azurerm_kubernetes_cluster_node_pool" "infraciarm64" {
   tags = local.default_tags
 }
 
+resource "azurerm_kubernetes_cluster_node_pool" "infracilargearm64" {
+  name                  = "arm64large"
+  vm_size               = "Standard_D8pds_v5" # 8 vCPU, 32 GB RAM, local disk: 300 GB and 38000 IOPS
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 300 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)
+  orchestrator_version  = local.kubernetes_versions["privatek8s"]
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s.id
+  enable_auto_scaling   = true
+  min_count             = 0 # warning this can lead to error with spot instances, we acknowledge the risk of a 0 node nodepool occurance.
+  max_count             = 10
+  zones                 = [1]
+  vnet_subnet_id        = data.azurerm_subnet.privatek8s_tier.id
+
+  # Spot instances
+  priority        = "Spot"
+  eviction_policy = "Delete"
+  spot_max_price  = "-1" # in $, -1 = On demand pricing
+  # Note: label and taint added automatically when in "Spot" priority, putting it here to explicit them
+  node_labels = {
+    "kubernetes.azure.com/scalesetpriority" = "spot"
+  }
+  node_taints = [
+    "jenkins=infra.ci.jenkins.io:NoSchedule",
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule",
+  ]
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
 resource "azurerm_kubernetes_cluster_node_pool" "releasepool" {
   name                  = "releasepool"
   vm_size               = "Standard_D8s_v3" # 8 vCPU 32 GiB RAM


### PR DESCRIPTION
lets retry #633 now that the kubernetes is on 1.26.12

as per [jenkins-infra/jenkins.io#7027 (files)](https://github.com/jenkins-infra/jenkins.io/pull/7027/files#r1511135932)
and [jenkins-infra/kubernetes-management#5035 (files)](https://github.com/jenkins-infra/kubernetes-management/pull/5035/files)

need a bigger node for ARM64 for large pods

(we may need to add a taint and toleration to reserve those nodes for only large pods)

Prices for those large nodes are exactly double of the small ones (264,26$/month)