### PR TITLE
hotfix(trusted.ci.jenkins.io): renew controller service principal

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -43,7 +43,7 @@ module "trusted_ci_jenkins_io" {
   controller_service_principal_ids = [
     data.azuread_service_principal.terraform_production.id,
   ]
-  controller_service_principal_end_date = "2024-03-08T19:40:35Z"
+  controller_service_principal_end_date = "2024-06-09T19:40:35Z"
   controller_packer_rg_ids = [
     azurerm_resource_group.packer_images["prod"].id
   ]


### PR DESCRIPTION
This PR renews trusted.ci.jenkins.io controller service principal so it can spawn azure VM agents again.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3982