### PR TITLE
feat(privatek8s): bump kubernetes to 1.27.9 for privatek8s

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -43,7 +43,7 @@ locals {
   admin_username = "jenkins-infra-team"
 
   kubernetes_versions = {
-    "privatek8s" = "1.26.12"
+    "privatek8s" = "1.27.9"
     "publick8s"  = "1.26.6"
   }
 }


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3948#issuecomment-1991178802

bump kubernetes to 1.27