### PR TITLE
chore(azurerm providers): specify subscriptions ID as `locals` and update shared tools

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,8 @@
 locals {
+
+  subscription_main      = "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+  subscription_sponsored = "1311c09f-aee0-4d6c-99a4-392c2b543204"
+
   public_db_pgsql_admin_login = "psqladmin${random_password.public_db_pgsql_admin_login.result}"
   public_db_mysql_admin_login = "mysqladmin${random_password.public_db_mysql_admin_login.result}"
 

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ data "azuread_service_principal" "terraform_production" {
 
 # Data source used to retrieve the subscription id
 data "azurerm_subscription" "jenkins" {
+  subscription_id = local.subscription_main
 }
 
 module "jenkins_infra_shared_data" {

--- a/providers.tf
+++ b/providers.tf
@@ -1,11 +1,12 @@
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
+  subscription_id            = local.subscription_main
   skip_provider_registration = "true"
   features {}
 }
 provider "azurerm" {
   alias                      = "jenkins-sponsorship"
-  subscription_id            = "1311c09f-aee0-4d6c-99a4-392c2b543204"
+  subscription_id            = local.subscription_sponsored
   skip_provider_registration = "true"
   features {}
 }


### PR DESCRIPTION
(edited) This PR ensures that terraform ignores any local `az` CLI subscription custom setup and uses raw values instead