### PR TITLE
feat(infra.ci.jenkins.io) rotate Jenkins Azure VM Service Principal

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -44,7 +44,7 @@ resource "azuread_service_principal" "infra_ci_jenkins_io" {
 resource "azuread_application_password" "infra_ci_jenkins_io" {
   application_id = azuread_application.infra_ci_jenkins_io.id
   display_name   = "infra.ci.jenkins.io-tf-managed"
-  end_date       = "2024-03-22T00:00:00Z"
+  end_date       = "2024-06-30T00:00:00Z"
 }
 # Allow Service Principal to manage AzureRM resources inside the agents resource groups
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_azurerm" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4000

This PR changes the end date of this service principal used by infra.ci.jenkins.io to spin up Azure VM agents to rotate it (regular routine)