### PR TITLE
feat(contributors) allow infra.ci VM agents to access storage account 

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -19,8 +19,12 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
     ip_rules = flatten(concat(
       [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
     ))
-    virtual_network_subnet_ids = [data.azurerm_subnet.privatek8s_tier.id, data.azurerm_subnet.publick8s_tier.id]
-    bypass                     = ["AzureServices"]
+    virtual_network_subnet_ids = [
+      data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
+      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
+    ]
+    bypass = ["AzureServices"]
   }
 
   tags = local.default_tags

--- a/plugins.jenkins.io.tf
+++ b/plugins.jenkins.io.tf
@@ -24,7 +24,7 @@ resource "azurerm_storage_account" "plugins_jenkins_io" {
     )
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_tier.id, # required for management from infra.ci (terraform)
+      data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
     ]
     bypass = ["Metrics", "Logging", "AzureServices"]


### PR DESCRIPTION
Since https://github.com/jenkins-infra/contributor-spotlight/pull/108, the deployment of contributors.jenkins.io fails with an `AuthorizationFailure` (HTTP/403) error from `azcopy`.

This PR applies the same fix as #647 but for contributors.jenkins.io by allowing the infra.ci VM agents to reach the storage account.

Related to the following IM request: https://matrix.to/#/!JLUOInpEYmxJIYXlzs:matrix.org/$7fA7k79pIcRfhFIJOLTS88apzvjt-IYlsBmyBN_43ac?via=g4v.dev&via=gitter.im&via=matrix.org (incoming helpdesk issue to track)