### PR TITLE
feat(private) add a storage class for ZRS volumes

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -275,6 +275,19 @@ resource "kubernetes_storage_class" "azurefile_csi_premium_retain" {
   provider      = kubernetes.privatek8s
 }
 
+resource "kubernetes_storage_class" "managed_csi_premium_ZRS_retain_public_private" {
+  metadata {
+    name = "managed-csi-premium-zrs-retain"
+  }
+  storage_provisioner = "disk.csi.azure.com"
+  reclaim_policy      = "Retain"
+  parameters = {
+    skuname = "Premium_ZRS"
+  }
+  provider               = kubernetes.publick8s
+  allow_volume_expansion = true
+}
+
 # Used later by the load balancer deployed on the cluster, see https://github.com/jenkins-infra/kubernetes-management/config/privatek8s.yaml
 resource "azurerm_public_ip" "public_privatek8s" {
   name                = "public-privatek8s"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-2036372624
create a new storage class on private to be used for ZRS multizone volumes, we need the volume to be accessible from both eastus2-1 for the arm64 nodes and eastus2-3 for our intel/amd nodes