### PR TITLE
cleanup(contributors.jenkins.io): remove `azurerm_storage_share.contributors_jenkins_io` output

### DIFF
--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -35,7 +35,3 @@ resource "azurerm_storage_share" "contributors_jenkins_io" {
   storage_account_name = azurerm_storage_account.contributors_jenkins_io.name
   quota                = 5
 }
-
-output "contributors_jenkins_io_share_url" {
-  value = azurerm_storage_share.contributors_jenkins_io.url
-}


### PR DESCRIPTION
This PR removes this output, superseded by the use of https://github.com/jenkins-infra/pipeline-library/blob/master/resources/get-fileshare-signed-url.sh to get the file share URL including a SAS token.

Verification procedure after merging this PR: ensure https://infra.ci.jenkins.io/job/website-jobs/job/contributor-spotlight/ job passes.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-2034806598