### PR TITLE
fix(infra.ci.jenkins.io) update NSG to allow arm64 controller to reach agents (new subnet)

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -140,7 +140,7 @@ module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
   ephemeral_agents_network_name    = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.virtual_network_name
   ephemeral_agents_subnet_name     = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.name
   controller_rg_name               = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
-  controller_ips                   = data.azurerm_subnet.privatek8s_tier.address_prefixes # Pod IPs: controller IP may change in the pods IP subnet
+  controller_ips                   = data.azurerm_subnet.privatek8s_infra_ci_controller_tier.address_prefixes # Pod IPs: controller IP may change in the pods IP subnet
   controller_service_principal_id  = azuread_service_principal.infra_ci_jenkins_io.id
   default_tags                     = local.default_tags
   storage_account_name             = "infraciagentssub" # Max 24 chars


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3823

This PR follows up https://github.com/jenkins-infra/kubernetes-management/pull/5126

It fixes the failure to spin up VM agents since the `arm64` migration: as the infra.ci.jenkins.io controller was moved to a new subnet in https://github.com/jenkins-infra/azure/pull/658