### PR TITLE
hotfix: use the new SP name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Service Principal ID used by the CI to authenticate terraform against the Azure API
 # Defined in the (private) repository jenkins-infra/terraform-states (in ./azure/main.tf)
 data "azuread_service_principal" "terraform_production" {
-  display_name = "terraform-production"
+  display_name = "terraform-azure-production"
 }
 
 # Data source used to retrieve the subscription id


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4045#issuecomment-2059732162, the [name of the Azure SP used by Terraform in production for the `azure`project changed](https://github.com/jenkins-infra/terraform-states/commit/bbab9fe5e97ce12d1bdcc9be5581941515e7dbe1)  


This PR updates the code to maps this change