### PR TITLE
chore(updates.jenkins.io): add a dedicated File Share for httpd service

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -41,6 +41,12 @@ resource "azurerm_storage_share" "updates_jenkins_io" {
   quota                = 2 # updates.jenkins.io total size in /www/updates.jenkins.io: 400Mo (Mid 2023)
 }
 
+resource "azurerm_storage_share" "updates_jenkins_io_httpd" {
+  name                 = "updates-jenkins-io-httpd"
+  storage_account_name = azurerm_storage_account.updates_jenkins_io.name
+  quota                = 1
+}
+
 # Redis database
 resource "azurerm_redis_cache" "updates_jenkins_io" {
   name                = "updates-jenkins-io"


### PR DESCRIPTION
This PR adds a dedicated File Share for httpd.

This will allow us to mount the .htaccess file generated by https://github.com/jenkins-infra/update-center2/blob/master/site/generate-htaccess.sh and completed with https://github.com/jenkins-infra/update-center2/pull/776 only as volume for the `httpd` updates.jenkins.io service, and every other files except .htaccess as volume for the `mirrorbits` updates.jenkins.io service.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2075477428