### PR TITLE
chore(updates.jenkins.io): allow trusted.ci.jenkins.io to interract with updates-jenkins-io-httpd File Share

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -85,12 +85,30 @@ module "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }
+module "trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+
+  service_fqdn                   = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-06-20T19:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io_httpd.resource_manager_id
+  storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
+  default_tags                   = local.default_tags
+}
 output "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer_id" {
   value = module.trusted_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id
 }
 output "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer_password" {
   sensitive = true
   value     = module.trusted_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+}
+output "trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer_id" {
+  value = module.trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id
+}
+output "trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer_password" {
+  sensitive = true
+  value     = module.trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
 }
 
 # Required to allow azcopy sync of jenkins.io File Share


### PR DESCRIPTION
This PR allows trusted.ci.jenkins.io to interract with updates-jenkins-io-httpd File Share.

Follow-up of:
- #676

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2075477428