### PR TITLE
feat!(publick8s/updates.jenkins.io) switch Storage Account to Premium to decrease costs (BREAKING)

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -6,12 +6,16 @@ resource "azurerm_resource_group" "updates_jenkins_io" {
 }
 
 resource "azurerm_storage_account" "updates_jenkins_io" {
-  name                     = "updatesjenkinsio"
-  resource_group_name      = azurerm_resource_group.updates_jenkins_io.name
-  location                 = azurerm_resource_group.updates_jenkins_io.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  min_tls_version          = "TLS1_2" # default value, needed for tfsec
+  name                = "updatesjenkinsio"
+  resource_group_name = azurerm_resource_group.updates_jenkins_io.name
+  location            = azurerm_resource_group.updates_jenkins_io.location
+
+  account_tier                      = "Premium"
+  account_kind                      = "FileStorage"
+  access_tier                       = "Hot"
+  account_replication_type          = "ZRS"
+  min_tls_version                   = "TLS1_2" # default value, needed for tfsec
+  infrastructure_encryption_enabled = true
 
   tags = local.default_tags
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2090967319

This PR switches to a `Premium` storage account kind for updates.jenkins.io to remove costs related to file storage transactions. The storage costs will increase from $0.09 to $0.50 which is ... affordable... to say the least (compared to the expected decrease of ~$320 transaction cost).


Note:
- The update center job is not trying to update storage
- Services azure.updates.jenkins.io and mirrors.updates.jenkins.io have been uninstalled