### PR TITLE
fix(updates.jenkins.io) set FS to minimum size for each

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -42,13 +42,13 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
 resource "azurerm_storage_share" "updates_jenkins_io" {
   name                 = "updates-jenkins-io"
   storage_account_name = azurerm_storage_account.updates_jenkins_io.name
-  quota                = 2 # updates.jenkins.io total size in /www/updates.jenkins.io: 400Mo (Mid 2023)
+  quota                = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
 }
 
 resource "azurerm_storage_share" "updates_jenkins_io_httpd" {
   name                 = "updates-jenkins-io-httpd"
   storage_account_name = azurerm_storage_account.updates_jenkins_io.name
-  quota                = 1
+  quota                = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
 }
 
 # Redis database


### PR DESCRIPTION
Fixup of #682 which failed to deploy (HTTP/400 error) when creating the file shares.

As per https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method, the minimum size for a file share is 100 Gb.

The cost evaluation in https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2090967319 need to be re-evaluated:

- Transactions cost from ~$380 to $0 monthly
- Storage cost from $0.09 monthly to $32 (2 x 100 x 0,16).