### PR TITLE
feat: create a service principal to interact with `docs-jenkins-io` File Share

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -98,6 +98,36 @@ output "infra_ci_jenkins_io_fileshare_serviceprincipal_writer_sp_password" {
   value     = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
 }
 
+# Required to allow azcopy sync of docs.jenkins.io File Share
+module "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+
+  service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-08-07T23:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.docs_jenkins_io.resource_manager_id
+  storage_account_id             = azurerm_storage_account.docs_jenkins_io.id
+  default_tags                   = local.default_tags
+}
+output "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer_id" {
+  value = module.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id
+}
+output "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer_password" {
+  sensitive = true
+  value     = module.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+}
+output "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer_sp_id" {
+  value = module.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_id
+}
+output "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer_sp_password" {
+  sensitive = true
+  value     = module.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
+}
+
 locals {
   infra_ci_jenkins_io_fqdn                        = "infra.ci.jenkins.io"
   infra_ci_jenkins_io_service_short_name          = trimprefix(trimprefix(local.infra_ci_jenkins_io_fqdn, "jenkins.io"), ".")


### PR DESCRIPTION
This PR creates a service principal to interact with `docs-jenkins-io` File Share expiring in 3 months.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3885#issuecomment-2090052823