### PR TITLE
feat: add a new AKS cluster for ci.jenkins.io agents

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -1,0 +1,172 @@
+resource "azurerm_resource_group" "cijenkinsio_kubernetes_agents" {
+  provider = azurerm.jenkins-sponsorship
+  name     = "cijenkinsio-kubernetes-agents"
+  location = var.location
+  tags     = local.default_tags
+
+}
+
+data "azurerm_subnet" "ci_jenkins_io_kubernetes_sponsorship" {
+  provider             = azurerm.jenkins-sponsorship
+  name                 = "${data.azurerm_virtual_network.public_jenkins_sponsorship.name}-ci_jenkins_io_kubernetes"
+  resource_group_name  = data.azurerm_resource_group.public_jenkins_sponsorship.name
+  virtual_network_name = data.azurerm_virtual_network.public_jenkins_sponsorship.name
+}
+
+#trivy:ignore:avd-azu-0040 # No need to enable oms_agent for Azure monitoring as we already have datadog
+resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
+  provider = azurerm.jenkins-sponsorship
+  name     = "cijenkinsio-agents-1"
+  ## Private cluster requires network setup to allow API access from:
+  # - infra.ci.jenkins.io agents (for both terraform job agents and kubernetes-management agents)
+  # - ci.jenkins.io controller to allow spawning agents (nominal usage)
+  # - private.vpn.jenkins.io to allow admin management (either Azure UI or kube tools from admin machines)
+  private_cluster_enabled             = true
+  private_cluster_public_fqdn_enabled = true
+  dns_prefix                          = "cijenkinsioagents1" # Avoid hyphens in this DNS host
+  location                            = azurerm_resource_group.cijenkinsio_kubernetes_agents.location
+  resource_group_name                 = azurerm_resource_group.cijenkinsio_kubernetes_agents.name
+  kubernetes_version                  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  role_based_access_control_enabled   = true # default value but made explicit to please trivy
+
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    network_policy      = "azure"
+    outbound_type       = "userAssignedNATGateway"
+    load_balancer_sku   = "standard" # Required to customize the outbound type
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  default_node_pool {
+    name                         = "systempool1"
+    only_critical_addons_enabled = true                # This property is the only valid way to add the "CriticalAddonsOnly=true:NoSchedule" taint to the default node pool
+    vm_size                      = "Standard_D4pds_v5" # At least 4 vCPUS/4 Gb as per AKS best practises
+    os_sku                       = "AzureLinux"
+    os_disk_type                 = "Ephemeral"
+    os_disk_size_gb              = 150 # Ref. Cache storage size athttps://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
+    orchestrator_version         = local.kubernetes_versions["cijenkinsio_agents_1"]
+    kubelet_disk_type            = "OS"
+    enable_auto_scaling          = false
+    node_count                   = 3 # 3 nodes for HA as per AKS best practises
+    vnet_subnet_id               = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
+    tags                         = local.default_tags
+    zones                        = local.cijenkinsio_agents_1_compute_zones
+  }
+
+  tags = local.default_tags
+}
+
+# Node pool to host "jenkins-infra" applications required on this cluster such as ACP or datadog's cluster-agent, e.g. "Not agent, neither AKS System tools"
+resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_n2_applications" {
+  provider              = azurerm.jenkins-sponsorship
+  name                  = "la64n2app"
+  vm_size               = "Standard_D4pds_v5"
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
+  orchestrator_version  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.cijenkinsio_agents_1.id
+  enable_auto_scaling   = true
+  min_count             = 1
+  max_count             = 3 # 2 nodes always up for HA, a 3rd one is allowed for surge upgrades
+  zones                 = local.cijenkinsio_agents_1_compute_zones
+  vnet_subnet_id        = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
+
+  node_labels = {
+    "jenkins" = "ci.jenkins.io"
+    "role"    = "applications"
+  }
+  node_taints = [
+    "ci.jenkins.io/applications=true:NoSchedule",
+  ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+# Node pool to host ci.jenkins.io agents for usual builds
+resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_agents_1" {
+  provider              = azurerm.jenkins-sponsorship
+  name                  = "lx86n3agt1"
+  vm_size               = "Standard_D16ads_v5"
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
+  orchestrator_version  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.cijenkinsio_agents_1.id
+  enable_auto_scaling   = true
+  min_count             = 0
+  max_count             = 50 # 4 pods per nodes, max 200 nodes
+  zones                 = local.cijenkinsio_agents_1_compute_zones
+  vnet_subnet_id        = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
+
+  node_labels = {
+    "jenkins" = "ci.jenkins.io"
+    "role"    = "jenkins-agents"
+  }
+  node_taints = [
+    "ci.jenkins.io/agents=true:NoSchedule",
+  ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+# Node pool to host ci.jenkins.io agents for BOM builds
+resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
+  provider              = azurerm.jenkins-sponsorship
+  name                  = "lx86n3bom1"
+  vm_size               = "Standard_D16ads_v5"
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
+  orchestrator_version  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.cijenkinsio_agents_1.id
+  enable_auto_scaling   = true
+  min_count             = 0
+  max_count             = 50
+  zones                 = local.cijenkinsio_agents_1_compute_zones
+  vnet_subnet_id        = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
+
+  node_labels = {
+    "jenkins" = "ci.jenkins.io"
+    "role"    = "jenkins-agents"
+  }
+  node_taints = [
+    "ci.jenkins.io/agents=true:NoSchedule",
+    "ci.jenkins.io/bom=true:NoSchedule",
+  ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+# Configure the jenkins-infra/kubernetes-management admin service account
+module "cijenkinsio_agents_1_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.cijenkinsio_agents_1
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = azurerm_kubernetes_cluster.cijenkinsio_agents_1.name
+  cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.host
+  cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
+}
+
+output "kubeconfig_cijenkinsio_agents_1" {
+  sensitive = true
+  value     = module.cijenkinsio_agents_1_admin_sa.kubeconfig
+}
+
+output "cijenkinsio_agents_1_kube_config_command" {
+  value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.cijenkinsio_agents_1.name} --resource-group ${azurerm_kubernetes_cluster.cijenkinsio_agents_1.resource_group_name}"
+}

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -87,7 +87,7 @@ module "ci_jenkins_io_kubernetes_agents_jenkins_sponsorship_1" {
   providers = {
     azurerm = azurerm.jenkins-sponsorship
   }
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-kubernetes-agents"
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-inbound-agents"
 
   service_fqdn                      = local.ci_jenkins_io_fqdn
   kubernetes_agents_network_rg_name = data.azurerm_resource_group.public_jenkins_sponsorship.name

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -83,6 +83,57 @@ module "ci_jenkins_io_aci_agents_sponsorship" {
   controller_service_principal_id = module.ci_jenkins_io_sponsorship.controller_service_principal_id
 }
 
+module "ci_jenkins_io_kubernetes_agents_jenkins_sponsorship_1" {
+  providers = {
+    azurerm = azurerm.jenkins-sponsorship
+  }
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-kubernetes-agents"
+
+  service_fqdn                      = local.ci_jenkins_io_fqdn
+  kubernetes_agents_network_rg_name = data.azurerm_resource_group.public_jenkins_sponsorship.name
+  kubernetes_agents_network_name    = data.azurerm_virtual_network.public_jenkins_sponsorship.name
+  kubernetes_agents_subnet_name     = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.name
+
+  controller_rg_name = module.ci_jenkins_io_sponsorship.controller_resourcegroup_name
+  controller_ips = compact([
+    module.ci_jenkins_io_sponsorship.controller_private_ipv4,
+    module.ci_jenkins_io_sponsorship.controller_public_ipv4
+  ])
+  default_tags = local.default_tags
+}
+
+## Allow ci.jenkins.io to reach the private AKS cluster API (outbound in controller NSG and inbound in cluster subnet)
+resource "azurerm_network_security_rule" "allow_outbound_https_from_cijio_to_cijenkinsio_agents_1_api" {
+  provider               = azurerm.jenkins-sponsorship
+  name                   = "allow-out-https-from-cijio-to-cijenkinsio_agents-1-api"
+  priority               = 4000
+  direction              = "Outbound"
+  access                 = "Allow"
+  protocol               = "Tcp"
+  source_port_range      = "*"
+  destination_port_range = "443"
+  source_address_prefix  = module.ci_jenkins_io_sponsorship.controller_private_ipv4 # Only private IPv4
+  # All IPs has the endpoint NIC may change inside this subnet
+  destination_address_prefixes = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.address_prefixes
+  resource_group_name          = module.ci_jenkins_io_sponsorship.controller_resourcegroup_name
+  network_security_group_name  = module.ci_jenkins_io_sponsorship.controller_nsg_name
+}
+resource "azurerm_network_security_rule" "allow_inbound_https_from_cijio_to_cijenkinsio_agents_1_api" {
+  provider               = azurerm.jenkins-sponsorship
+  name                   = "allow-in-https-from-cijio-to-cijenkinsio_agents-1-api"
+  priority               = 4000
+  direction              = "Inbound"
+  access                 = "Allow"
+  protocol               = "Tcp"
+  source_port_range      = "*"
+  destination_port_range = "443"
+  source_address_prefix  = module.ci_jenkins_io_sponsorship.controller_private_ipv4 # Only private IPv4
+  # All IPs has the endpoint NIC may change inside this subnet
+  destination_address_prefixes = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.address_prefixes
+  resource_group_name          = data.azurerm_resource_group.public_jenkins_sponsorship.name # Passed to module.ci_jenkins_io_kubernetes_agents_jenkins_sponsorship_1
+  network_security_group_name  = module.ci_jenkins_io_kubernetes_agents_jenkins_sponsorship_1.kubernetes_agents_nsg_name
+}
+
 ## Service DNS records
 resource "azurerm_dns_cname_record" "ci_jenkins_io" {
   name                = trimsuffix(trimsuffix(local.ci_jenkins_io_fqdn, data.azurerm_dns_zone.jenkinsio.name), ".")

--- a/locals.tf
+++ b/locals.tf
@@ -43,7 +43,8 @@ locals {
   admin_username = "jenkins-infra-team"
 
   kubernetes_versions = {
-    "privatek8s" = "1.27.9"
-    "publick8s"  = "1.27.9"
+    "privatek8s"           = "1.27.9"
+    "publick8s"            = "1.27.9"
+    "cijenkinsio_agents_1" = "1.27.9"
   }
 }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -40,7 +40,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
   resource_group_name               = azurerm_resource_group.privatek8s.name
   kubernetes_version                = local.kubernetes_versions["privatek8s"]
   dns_prefix                        = "privatek8s-${random_pet.suffix_privatek8s.id}"
-  role_based_access_control_enabled = true # default value, added to please tfsec
+  role_based_access_control_enabled = true # default value but made explicit to please trivy
 
   api_server_access_profile {
     authorized_ip_ranges = setunion(

--- a/providers.tf
+++ b/providers.tf
@@ -27,6 +27,14 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate)
 }
 
+provider "kubernetes" {
+  alias                  = "cijenkinsio_agents_1"
+  host                   = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.host
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate)
+}
+
 provider "postgresql" {
   /**
   Important: terraform must be allowed to reach this instance through the network. Check the followings:

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -24,7 +24,8 @@ data "azurerm_subnet" "public_vnet_data_tier" {
 }
 
 locals {
-  publick8s_compute_zones = [3]
+  publick8s_compute_zones            = [3]
+  cijenkinsio_agents_1_compute_zones = [1]
 }
 
 #trivy:ignore:azure-container-logging #trivy:ignore:azure-container-limit-authorized-ips
@@ -34,7 +35,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   resource_group_name               = azurerm_resource_group.publick8s.name
   kubernetes_version                = local.kubernetes_versions["publick8s"]
   dns_prefix                        = "publick8s-${random_pet.suffix_publick8s.id}"
-  role_based_access_control_enabled = true # default value, added to please tfsec
+  role_based_access_control_enabled = true # default value but made explicit to please trivy
   api_server_access_profile {
     authorized_ip_ranges = setunion(
       # admins


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954

Blocked by https://github.com/jenkins-infra/shared-tools/pull/146

This PR introduces a new AKS cluster to host ci.jenkins.io container agents workload with the [specified](https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2095952884) attributes:

- [Private cluster](https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2096296286) (e.g. API not exposed except internally) which means we need cluster to reach it => it might need subsequent PRs to fine-tune the infra.ci.jenkins.io agent network accesses.
- Outbound with NAT gateway and no ingress (as per https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2096296286)
- Initial set of node pools with the [proposed sizings](https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2096407507)

Notes:

- Allowing ci.jenkins.io to reach the AKS API of this cluster requires a few additional NSGs rules specified in the `ci.jenkins.io.tf` file
- The PR https://github.com/jenkins-infra/shared-tools/pull/146 is needed so we can set up NSG rules to restrict the agents in and out network requests.