### PR TITLE
feat(ci.jenkins.io - aks-agents-1) create an admin SVCaccount to manage kubernetes resources

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -151,21 +151,20 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
   tags = local.default_tags
 }
 
-## TODO: uncomment once infra.ci routing is enabled
-# # Configure the jenkins-infra/kubernetes-management admin service account
-# module "cijenkinsio_agents_1_admin_sa" {
-#   providers = {
-#     kubernetes = kubernetes.cijenkinsio_agents_1
-#   }
-#   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
-#   cluster_name               = azurerm_kubernetes_cluster.cijenkinsio_agents_1.name
-#   cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.fqdn # Public FQDN is required to allow infra.ci agent to work as expected
-#   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
-# }
-# output "kubeconfig_cijenkinsio_agents_1" {
-#   sensitive = true
-#   value     = module.cijenkinsio_agents_1_admin_sa.kubeconfig
-# }
-# output "cijenkinsio_agents_1_kube_config_command" {
-#   value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.cijenkinsio_agents_1.name} --resource-group ${azurerm_kubernetes_cluster.cijenkinsio_agents_1.resource_group_name}"
-# }
+# Configure the jenkins-infra/kubernetes-management admin service account
+module "cijenkinsio_agents_1_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.cijenkinsio_agents_1
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = azurerm_kubernetes_cluster.cijenkinsio_agents_1.name
+  cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.fqdn # Public FQDN is required to allow infra.ci agent to work as expected
+  cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
+}
+output "kubeconfig_cijenkinsio_agents_1" {
+  sensitive = true
+  value     = module.cijenkinsio_agents_1_admin_sa.kubeconfig
+}
+output "cijenkinsio_agents_1_kube_config_command" {
+  value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.cijenkinsio_agents_1.name} --resource-group ${azurerm_kubernetes_cluster.cijenkinsio_agents_1.resource_group_name}"
+}

--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -158,7 +158,7 @@ module "cijenkinsio_agents_1_admin_sa" {
   }
   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
   cluster_name               = azurerm_kubernetes_cluster.cijenkinsio_agents_1.name
-  cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.fqdn # Public FQDN is required to allow infra.ci agent to work as expected
+  cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.fqdn
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
 }
 output "kubeconfig_cijenkinsio_agents_1" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2107226189

This PR adds managed resources to create a kubernetes cluster-admin account to be used by infra.ci.jenkins.io to run the jenkins-infra/kubernetes-management jobs on the new ci.jio agent 1 cluster.