### PR TITLE
fix(ci.jenkins.io-kubernetes-agents) use correct labels for the BOM node pool

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -137,7 +137,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
 
   node_labels = {
     "jenkins" = "ci.jenkins.io"
-    "role"    = "jenkins-agents"
+    "role"    = "jenkins-agents-bom"
   }
   node_taints = [
     "ci.jenkins.io/agents=true:NoSchedule",


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2114950444

This PR fixes the label `role` used by the BOM node pool on the `ci.jenkins.io-kubernetes-agents-1` cluster to ensure we can use a specific `nodeSelector` for the BOM container agents