### PR TITLE
feat(cloudflare): add cname for the eastamerica bucket

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -104,3 +104,13 @@ resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zone_westeurope"
   records = ["jaxson.ns.cloudflare.com", "mira.ns.cloudflare.com"]
   tags    = local.default_tags
 }
+# East US
+resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zone_eastamerica" {
+  name                = "eastamerica.cloudflare"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  # Should correspond to the "zones_name_servers" output defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
+  records = ["jaxson.ns.cloudflare.com", "mira.ns.cloudflare.com"]
+  tags    = local.default_tags
+}


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2134643950

adding a cname `eastamerica.cloudflare.jenkins.io` to be used within mirrorbits for updatecenter (updates-jenkins-io-mirrorbits)

