### PR TITLE
feat(weekly.ci) add role definition and assignment for new disk access

### DIFF
--- a/weekly.ci.jenkins.io.tf
+++ b/weekly.ci.jenkins.io.tf
@@ -53,3 +53,18 @@ resource "kubernetes_persistent_volume_claim" "jenkins_weekly_data" {
     }
   }
 }
+
+# Required to allow the weekly controller to read the disk
+resource "azurerm_role_definition" "weekly_ci_jenkins_io_controller_disk_reader" {
+  name     = "ReadWeeklyCIDisk"
+  scope    = azurerm_resource_group.weekly_ci_controller.id
+
+  permissions {
+    actions = ["Microsoft.Compute/disks/read"]
+  }
+}
+resource "azurerm_role_assignment" "weekly_ci_jenkins_io_allow_azurerm" {
+  scope                 = azurerm_resource_group.weekly_ci_controller.id
+  role_definition_name  = "ReadWeeklyCIDisk"
+  principal_id          = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
+}

--- a/weekly.ci.jenkins.io.tf
+++ b/weekly.ci.jenkins.io.tf
@@ -56,15 +56,15 @@ resource "kubernetes_persistent_volume_claim" "jenkins_weekly_data" {
 
 # Required to allow the weekly controller to read the disk
 resource "azurerm_role_definition" "weekly_ci_jenkins_io_controller_disk_reader" {
-  name     = "ReadWeeklyCIDisk"
-  scope    = azurerm_resource_group.weekly_ci_controller.id
+  name  = "ReadWeeklyCIDisk"
+  scope = azurerm_resource_group.weekly_ci_controller.id
 
   permissions {
     actions = ["Microsoft.Compute/disks/read"]
   }
 }
 resource "azurerm_role_assignment" "weekly_ci_jenkins_io_allow_azurerm" {
-  scope                 = azurerm_resource_group.weekly_ci_controller.id
-  role_definition_name  = "ReadWeeklyCIDisk"
-  principal_id          = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
+  scope              = azurerm_resource_group.weekly_ci_controller.id
+  role_definition_id = azurerm_role_definition.weekly_ci_jenkins_io_controller_disk_reader.role_definition_id
+  principal_id       = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
 }


### PR DESCRIPTION
following #700 and as per https://github.com/jenkins-infra/helpdesk/issues/4044
this PR will allow a pod to access the new PV/PVC/DISK and handle the data migration.

this PR was tested locally, it failed when using both ID and name for the role assignment/role definition, it failed with only the id with `Error: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidRoleDefinitionId" Message="The role definition ID '5a60a9a4-88e7-d46c-6311-6aa2bba1581c|' is not valid."`

but succeeded with only the `role_definition_name` ...
