### PR TITLE
feat(ci.jenkins.io-agents1) set AKS SKU to `Standard` instead of `Free`

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -16,6 +16,7 @@ data "azurerm_subnet" "ci_jenkins_io_kubernetes_sponsorship" {
 resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
   provider = azurerm.jenkins-sponsorship
   name     = "cijenkinsio-agents-1"
+  sku_tier = "Standard"
   ## Private cluster requires network setup to allow API access from:
   # - infra.ci.jenkins.io agents (for both terraform job agents and kubernetes-management agents)
   # - ci.jenkins.io controller to allow spawning agents (nominal usage)


### PR DESCRIPTION
When a cluster has 10+ nodes, the following recommendation pops in Azure portal:

<img width="1548" alt="Capture d’écran 2024-06-06 à 14 09 43" src="https://github.com/jenkins-infra/azure/assets/1522731/0782b296-2137-419c-bb03-a1649e23d654">

This PR changes the SKU on this cluster to ensure better scheduling performances when BOM builds are running.
The cost can be ignored: it is in the subscription paid by sponsored credits