### PR TITLE
hotfix(infraci.jenkins.io-kubernetes-sponsored-agents) use new subnet (shorter) name

### DIFF
--- a/infraci.jenkins.io-kubernetes-sponsored-agents.tf
+++ b/infraci.jenkins.io-kubernetes-sponsored-agents.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "infracijio_kubernetes_agents_sponsorship" {
 
 data "azurerm_subnet" "infraci_jenkins_io_kubernetes_agent_sponsorship" {
   provider             = azurerm.jenkins-sponsorship
-  name                 = "${data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name}-infraci_jenkins_io_kubernetes-agent"
+  name                 = "${data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name}-kubernetes-agents"
   resource_group_name  = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.resource_group_name
   virtual_network_name = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name
 }


### PR DESCRIPTION
This PR aims to fix the error mentioned in https://github.com/jenkins-infra/azure/pull/715#issuecomment-2158850175

It updates the subnet name used for this cluster as a follow up of https://github.com/jenkins-infra/azure-net/pull/252