### PR TITLE
chore(AKS clusters) explicit upgrade_settings.max_surge to default Azure value for all nodepools to avoid permanent update

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -46,16 +46,19 @@ resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
     name                         = "systempool1"
     only_critical_addons_enabled = true                # This property is the only valid way to add the "CriticalAddonsOnly=true:NoSchedule" taint to the default node pool
     vm_size                      = "Standard_D4pds_v5" # At least 4 vCPUS/4 Gb as per AKS best practises
-    os_sku                       = "AzureLinux"
-    os_disk_type                 = "Ephemeral"
-    os_disk_size_gb              = 150 # Ref. Cache storage size athttps://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
-    orchestrator_version         = local.kubernetes_versions["cijenkinsio_agents_1"]
-    kubelet_disk_type            = "OS"
-    enable_auto_scaling          = false
-    node_count                   = 3 # 3 nodes for HA as per AKS best practises
-    vnet_subnet_id               = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
-    tags                         = local.default_tags
-    zones                        = local.cijenkinsio_agents_1_compute_zones
+    upgrade_settings {
+      max_surge = "10%"
+    }
+    os_sku               = "AzureLinux"
+    os_disk_type         = "Ephemeral"
+    os_disk_size_gb      = 150 # Ref. Cache storage size athttps://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
+    orchestrator_version = local.kubernetes_versions["cijenkinsio_agents_1"]
+    kubelet_disk_type    = "OS"
+    enable_auto_scaling  = false
+    node_count           = 3 # 3 nodes for HA as per AKS best practises
+    vnet_subnet_id       = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
+    tags                 = local.default_tags
+    zones                = local.cijenkinsio_agents_1_compute_zones
   }
 
   tags = local.default_tags
@@ -63,9 +66,12 @@ resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
 
 # Node pool to host "jenkins-infra" applications required on this cluster such as ACP or datadog's cluster-agent, e.g. "Not agent, neither AKS System tools"
 resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_n2_applications" {
-  provider              = azurerm.jenkins-sponsorship
-  name                  = "la64n2app"
-  vm_size               = "Standard_D4pds_v5"
+  provider = azurerm.jenkins-sponsorship
+  name     = "la64n2app"
+  vm_size  = "Standard_D4pds_v5"
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_sku                = "AzureLinux"
   os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
@@ -94,9 +100,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_n2_applications" {
 
 # Node pool to host ci.jenkins.io agents for usual builds
 resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_agents_1" {
-  provider              = azurerm.jenkins-sponsorship
-  name                  = "lx86n3agt1"
-  vm_size               = "Standard_D16ads_v5"
+  provider = azurerm.jenkins-sponsorship
+  name     = "lx86n3agt1"
+  vm_size  = "Standard_D16ads_v5"
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
@@ -125,9 +134,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_agents_1" {
 
 # Node pool to host ci.jenkins.io agents for BOM builds
 resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
-  provider              = azurerm.jenkins-sponsorship
-  name                  = "lx86n3bom1"
-  vm_size               = "Standard_D16ads_v5"
+  provider = azurerm.jenkins-sponsorship
+  name     = "lx86n3bom1"
+  vm_size  = "Standard_D16ads_v5"
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)

--- a/infraci.jenkins.io-kubernetes-sponsored-agents.tf
+++ b/infraci.jenkins.io-kubernetes-sponsored-agents.tf
@@ -45,16 +45,19 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
     name                         = "systempool1"
     only_critical_addons_enabled = true                # This property is the only valid way to add the "CriticalAddonsOnly=true:NoSchedule" taint to the default node pool
     vm_size                      = "Standard_D4pds_v5" # At least 4 vCPUS/4 Gb as per AKS best practises
-    os_sku                       = "AzureLinux"
-    os_disk_type                 = "Ephemeral"
-    os_disk_size_gb              = 150 # Ref. Cache storage size athttps://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
-    orchestrator_version         = local.kubernetes_versions["infracijenkinsio_agents_1"]
-    kubelet_disk_type            = "OS"
-    enable_auto_scaling          = false
-    node_count                   = 3 # 3 nodes for HA as per AKS best practises
-    vnet_subnet_id               = data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id
-    tags                         = local.default_tags
-    zones                        = local.infracijenkinsio_agents_1_compute_zones
+    upgrade_settings = {
+      max_surge = "10%"
+    }
+    os_sku               = "AzureLinux"
+    os_disk_type         = "Ephemeral"
+    os_disk_size_gb      = 150 # Ref. Cache storage size athttps://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
+    orchestrator_version = local.kubernetes_versions["infracijenkinsio_agents_1"]
+    kubelet_disk_type    = "OS"
+    enable_auto_scaling  = false
+    node_count           = 3 # 3 nodes for HA as per AKS best practises
+    vnet_subnet_id       = data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id
+    tags                 = local.default_tags
+    zones                = local.infracijenkinsio_agents_1_compute_zones
   }
 
   tags = local.default_tags
@@ -63,9 +66,12 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
 # Node pool to host infra.ci.jenkins.io x86_64 agents
 # number of pods per node calculated with https://github.com/jenkins-infra/kubernetes-management/blob/9c14f72867170e9755f3434fb6f6dd3a8606686a/config/jenkins_infra.ci.jenkins.io.yaml#L137-L208
 resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_agents_1_sponsorship" {
-  provider              = azurerm.jenkins-sponsorship
-  name                  = "lx86n14agt1"
-  vm_size               = "Standard_D8ads_v5" # https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series Standard_D8ads_v5 	8vcpu 	32Go 	300ssd
+  provider = azurerm.jenkins-sponsorship
+  name     = "lx86n14agt1"
+  vm_size  = "Standard_D8ads_v5" # https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series Standard_D8ads_v5 	8vcpu 	32Go 	300ssd
+  upgrade_settings = {
+    max_surge = "10%"
+  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 300 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series (depends on the instance size)
@@ -95,9 +101,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_agents_1_sponsorsh
 # # Node pool to host infra.ci.jenkins.io
 # number of pods per node calculated with https://github.com/jenkins-infra/kubernetes-management/blob/9c14f72867170e9755f3434fb6f6dd3a8606686a/config/jenkins_infra.ci.jenkins.io.yaml#L137-L208
 resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_agents_1_sponsorship" {
-  provider              = azurerm.jenkins-sponsorship
-  name                  = "la64n14agt1"
-  vm_size               = "Standard_D8pds_v5" # https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series 	8vcpu 	32Go 	300ssd
+  provider = azurerm.jenkins-sponsorship
+  name     = "la64n14agt1"
+  vm_size  = "Standard_D8pds_v5" # https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series 	8vcpu 	32Go 	300ssd
+  upgrade_settings = {
+    max_surge = "10%"
+  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 300 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)

--- a/infraci.jenkins.io-kubernetes-sponsored-agents.tf
+++ b/infraci.jenkins.io-kubernetes-sponsored-agents.tf
@@ -45,7 +45,7 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
     name                         = "systempool1"
     only_critical_addons_enabled = true                # This property is the only valid way to add the "CriticalAddonsOnly=true:NoSchedule" taint to the default node pool
     vm_size                      = "Standard_D4pds_v5" # At least 4 vCPUS/4 Gb as per AKS best practises
-    upgrade_settings = {
+    upgrade_settings {
       max_surge = "10%"
     }
     os_sku               = "AzureLinux"
@@ -69,7 +69,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_agents_1_sponsorsh
   provider = azurerm.jenkins-sponsorship
   name     = "lx86n14agt1"
   vm_size  = "Standard_D8ads_v5" # https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series Standard_D8ads_v5 	8vcpu 	32Go 	300ssd
-  upgrade_settings = {
+  upgrade_settings {
     max_surge = "10%"
   }
   os_sku                = "AzureLinux"
@@ -104,7 +104,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_agents_1_sponsorshi
   provider = azurerm.jenkins-sponsorship
   name     = "la64n14agt1"
   vm_size  = "Standard_D8pds_v5" # https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series 	8vcpu 	32Go 	300ssd
-  upgrade_settings = {
+  upgrade_settings {
     max_surge = "10%"
   }
   os_sku                = "AzureLinux"

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -71,8 +71,11 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
   }
 
   default_node_pool {
-    name                 = "syspool"
-    vm_size              = "Standard_D2as_v4"
+    name    = "syspool"
+    vm_size = "Standard_D2as_v4"
+    upgrade_settings {
+      max_surge = "10%"
+    }
     os_sku               = "Ubuntu"
     os_disk_type         = "Ephemeral"
     os_disk_size_gb      = 50 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dav4-dasv4-series#dasv4-series (depends on the instance size)
@@ -98,8 +101,11 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
-  name                  = "linuxpool"
-  vm_size               = "Standard_D4s_v3"
+  name    = "linuxpool"
+  vm_size = "Standard_D4s_v3"
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 100 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
   orchestrator_version  = local.kubernetes_versions["privatek8s"]
@@ -118,8 +124,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "linuxpool" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
-  name                  = "infracipool"
-  vm_size               = "Standard_D8s_v3"
+  name    = "infracipool"
+  vm_size = "Standard_D8s_v3"
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 200 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
   orchestrator_version  = local.kubernetes_versions["privatek8s"]
@@ -151,8 +160,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "infraciarm64" {
-  name                  = "arm64small"
-  vm_size               = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  name    = "arm64small"
+  vm_size = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)
   orchestrator_version  = local.kubernetes_versions["privatek8s"]
@@ -184,8 +196,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "infraciarm64" {
 
 # nodepool dedicated for the infra.ci.jenkins.io controller
 resource "azurerm_kubernetes_cluster_node_pool" "infraci_controller" {
-  name                  = "infracictrl"
-  vm_size               = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  name    = "infracictrl"
+  vm_size = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)
@@ -210,8 +225,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "infraci_controller" {
 
 # nodepool dedicated for the release.ci.jenkins.io controller
 resource "azurerm_kubernetes_cluster_node_pool" "releaseci_controller" {
-  name                  = "releacictrl"
-  vm_size               = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  name    = "releacictrl"
+  vm_size = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)
@@ -234,8 +252,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "releaseci_controller" {
   tags = local.default_tags
 }
 resource "azurerm_kubernetes_cluster_node_pool" "releasepool" {
-  name                  = "releasepool"
-  vm_size               = "Standard_D8s_v3" # 8 vCPU 32 GiB RAM
+  name    = "releasepool"
+  vm_size = "Standard_D8s_v3" # 8 vCPU 32 GiB RAM
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 200 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
   orchestrator_version  = local.kubernetes_versions["privatek8s"]
@@ -257,8 +278,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "releasepool" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "windows2019pool" {
-  name                  = "w2019"
-  vm_size               = "Standard_D4s_v3" # 4 vCPU 16 GiB RAM
+  name    = "w2019"
+  vm_size = "Standard_D4s_v3" # 4 vCPU 16 GiB RAM
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 100 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
   orchestrator_version  = local.kubernetes_versions["privatek8s"]

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -76,15 +76,18 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     name                         = "systempool3"
     only_critical_addons_enabled = true               # This property is the only valid way to add the "CriticalAddonsOnly=true:NoSchedule" taint to the default node pool
     vm_size                      = "Standard_D2as_v4" # 2 vCPU, 8 GB RAM, 16 GB disk, 4000 IOPS
-    kubelet_disk_type            = "OS"
-    os_disk_type                 = "Ephemeral"
-    os_disk_size_gb              = 50
-    orchestrator_version         = local.kubernetes_versions["publick8s"]
-    enable_auto_scaling          = false
-    node_count                   = 2
-    vnet_subnet_id               = data.azurerm_subnet.publick8s_tier.id
-    tags                         = local.default_tags
-    zones                        = local.publick8s_compute_zones
+    upgrade_settings {
+      max_surge = "10%"
+    }
+    kubelet_disk_type    = "OS"
+    os_disk_type         = "Ephemeral"
+    os_disk_size_gb      = 50
+    orchestrator_version = local.kubernetes_versions["publick8s"]
+    enable_auto_scaling  = false
+    node_count           = 2
+    vnet_subnet_id       = data.azurerm_subnet.publick8s_tier.id
+    tags                 = local.default_tags
+    zones                = local.publick8s_compute_zones
   }
 
   identity {
@@ -102,8 +105,11 @@ data "azurerm_kubernetes_cluster" "publick8s" {
 
 
 resource "azurerm_kubernetes_cluster_node_pool" "x86small" {
-  name                  = "x86small"
-  vm_size               = "Standard_D4s_v3" # 4 vCPU, 16 GB RAM, 32 GB disk, 8 000 IOPS
+  name    = "x86small"
+  vm_size = "Standard_D4s_v3" # 4 vCPU, 16 GB RAM, 32 GB disk, 8 000 IOPS
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 100 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
   orchestrator_version  = local.kubernetes_versions["publick8s"]
@@ -122,8 +128,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "x86small" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "arm64small2" {
-  name                  = "arm64small2"
-  vm_size               = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  name    = "arm64small2"
+  vm_size = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS
+  upgrade_settings {
+    max_surge = "10%"
+  }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)
   orchestrator_version  = local.kubernetes_versions["publick8s"]


### PR DESCRIPTION
as per 
- https://github.com/hashicorp/terraform-provider-azurerm/issues/24020

we are having the same repetitive update on azure, so setting the default should avoir permanent update override