### PR TITLE
chore(privatek8s) ignore changes for `upgrade_settings` to avoid never-ending updated attribute

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -150,7 +150,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracipool" {
   ]
 
   lifecycle {
-    ignore_changes = [node_count]
+    ignore_changes = [
+      node_count,       # Due to autoscaling
+      upgrade_settings, # https://github.com/hashicorp/terraform-provider-azurerm/issues/24020#issuecomment-2158404079
+    ]
   }
 
   tags = local.default_tags
@@ -182,7 +185,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "infraciarm64" {
     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule",
   ]
   lifecycle {
-    ignore_changes = [node_count]
+    ignore_changes = [
+      node_count,       # Due to autoscaling
+      upgrade_settings, # https://github.com/hashicorp/terraform-provider-azurerm/issues/24020#issuecomment-2158404079
+    ]
   }
 
   tags = local.default_tags


### PR DESCRIPTION
Follow up of #727 , #730 and #731

This fixes the never-ending changed attribute `upgrade_settings {}` for the 2 Spot node pools on `privatek8s`.

It follows the tip found in https://github.com/hashicorp/terraform-provider-azurerm/issues/24020#issuecomment-2158404079 to avoid having all of our plans trying to change the 2 node pools.