### PR TITLE
feat: create a service principal to interact with `stats-jenkins-io` File Share

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -128,6 +128,36 @@ output "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer_sp_password" {
   value     = module.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
 }
 
+# Required to allow azcopy sync of stats.jenkins.io File Share
+module "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+
+  service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-09-19T23:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.stats_jenkins_io.resource_manager_id
+  storage_account_id             = azurerm_storage_account.stats_jenkins_io.id
+  default_tags                   = local.default_tags
+}
+output "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer_id" {
+  value = module.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id
+}
+output "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer_password" {
+  sensitive = true
+  value     = module.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+}
+output "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer_sp_id" {
+  value = module.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_id
+}
+output "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer_sp_password" {
+  sensitive = true
+  value     = module.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
+}
+
 locals {
   infra_ci_jenkins_io_fqdn                        = "infra.ci.jenkins.io"
   infra_ci_jenkins_io_service_short_name          = trimprefix(trimprefix(local.infra_ci_jenkins_io_fqdn, "jenkins.io"), ".")


### PR DESCRIPTION
This PR creates a service principal to interact with `stats-jenkins-io` File Share expiring in 3 months.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401