### PR TITLE
chore: move `infra.ci.jenkins.io.tf` service principal end dates to `local.tf`

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -75,7 +75,7 @@ module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates["infra_ci_jenkins_io_fileshare_serviceprincipal_writer"]
+  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io_fileshare_serviceprincipal_writer
   file_share_resource_manager_id = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.contributors_jenkins_io.id
   default_tags                   = local.default_tags
@@ -105,7 +105,7 @@ module "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates["infraci_docs_jenkins_io_fileshare_serviceprincipal_writer"]
+  service_principal_end_date     = local.end_dates.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer
   file_share_resource_manager_id = azurerm_storage_share.docs_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.docs_jenkins_io.id
   default_tags                   = local.default_tags
@@ -135,7 +135,7 @@ module "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates["infraci_stats_jenkins_io_fileshare_serviceprincipal_writer"]
+  service_principal_end_date     = local.end_dates.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer
   file_share_resource_manager_id = azurerm_storage_share.stats_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.stats_jenkins_io.id
   default_tags                   = local.default_tags
@@ -263,7 +263,7 @@ module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infraci-pluginsjenkinsio-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates["infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer"]
+  service_principal_end_date     = local.end_dates.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer
   file_share_resource_manager_id = azurerm_storage_share.plugins_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.plugins_jenkins_io.id
   default_tags                   = local.default_tags

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -75,7 +75,7 @@ module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-06-20T23:00:00Z"
+  service_principal_end_date     = local.end_dates["infra_ci_jenkins_io_fileshare_serviceprincipal_writer"]
   file_share_resource_manager_id = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.contributors_jenkins_io.id
   default_tags                   = local.default_tags
@@ -105,7 +105,7 @@ module "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-08-07T23:00:00Z"
+  service_principal_end_date     = local.end_dates["infraci_docs_jenkins_io_fileshare_serviceprincipal_writer"]
   file_share_resource_manager_id = azurerm_storage_share.docs_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.docs_jenkins_io.id
   default_tags                   = local.default_tags
@@ -135,7 +135,7 @@ module "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-09-19T23:00:00Z"
+  service_principal_end_date     = local.end_dates["infraci_stats_jenkins_io_fileshare_serviceprincipal_writer"]
   file_share_resource_manager_id = azurerm_storage_share.stats_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.stats_jenkins_io.id
   default_tags                   = local.default_tags
@@ -263,7 +263,7 @@ module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infraci-pluginsjenkinsio-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-07-27T00:00:00Z"
+  service_principal_end_date     = local.end_dates["infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer"]
   file_share_resource_manager_id = azurerm_storage_share.plugins_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.plugins_jenkins_io.id
   default_tags                   = local.default_tags

--- a/locals.tf
+++ b/locals.tf
@@ -59,4 +59,12 @@ locals {
 
   weekly_ci_disk_size    = 8
   weekly_ci_access_modes = ["ReadWriteOnce"]
+
+  # End dates regrouped here, easier to track with updatecli
+  end_dates = {
+    "infra_ci_jenkins_io_fileshare_serviceprincipal_writer"      = "2024-06-20T23:00:00Z"
+    "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer"  = "2024-08-07T23:00:00Z"
+    "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" = "2024-07-27T00:00:00Z"
+    "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" = "2024-09-19T23:00:00Z"
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,7 @@
+data "local_file" "locals_yaml" {
+  filename = "locals.yaml"
+}
+
 locals {
   subscription_main      = "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
   subscription_sponsored = "1311c09f-aee0-4d6c-99a4-392c2b543204"
@@ -60,11 +64,5 @@ locals {
   weekly_ci_disk_size    = 8
   weekly_ci_access_modes = ["ReadWriteOnce"]
 
-  # End dates regrouped here, easier to track with updatecli
-  end_dates = {
-    "infra_ci_jenkins_io_fileshare_serviceprincipal_writer"      = "2024-06-20T23:00:00Z"
-    "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer"  = "2024-08-07T23:00:00Z"
-    "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" = "2024-07-27T00:00:00Z"
-    "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" = "2024-09-19T23:00:00Z"
-  }
+  end_dates = yamldecode(data.local_file.locals_yaml.content).end_dates
 }

--- a/locals.yaml
+++ b/locals.yaml
@@ -1,0 +1,7 @@
+---
+# End dates regrouped here, easier to track with updatecli
+end_dates:
+  infra_ci_jenkins_io_fileshare_serviceprincipal_writer: "2024-06-20T23:00:00Z"
+  infraci_docs_jenkins_io_fileshare_serviceprincipal_writer: "2024-08-07T23:00:00Z"
+  infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer: "2024-07-27T00:00:00Z"
+  infraci_stats_jenkins_io_fileshare_serviceprincipal_writer: "2024-09-19T23:00:00Z"


### PR DESCRIPTION
This PR moves `infra.ci.jenkins.io.tf` service principal end dates to `local.tf` so they can more easily be tracked by updatecli.

In existing manifests tracking end dates, these dates aren't an issue as their name is unique in their file, ex:
https://github.com/jenkins-infra/azure/blob/23b9374f2346839182e8aac1f9628ab758664ceb/ci.jenkins.io.tf#L34C3-L34C40
Retrieved by
https://github.com/jenkins-infra/azure/blob/23b9374f2346839182e8aac1f9628ab758664ceb/updatecli/updatecli.d/ci.sp.endate.yaml#L16-L21

Unfortunately, adding a manifest to take care of https://github.com/jenkins-infra/azure/pull/733#discussion_r1646375931 isn't as easy as there are multiple `service_principal_end_date` in the infra.ci.jenkins.io.tf file.

Hence this PR to regroup them into a map in local.tf so they can be addressed individually without resorting to use the order of the SP declaration to get the correct index of all `service_principal_end_date`s, or a regexp on the complete file for retrieving
https://github.com/jenkins-infra/azure/blob/23b9374f2346839182e8aac1f9628ab758664ceb/infra.ci.jenkins.io.tf#L138

Another pull request will follow to add the corresponding updatecli manifest for `infraci_stats_jenkins_io_fileshare_serviceprincipal_writer`'s end date, and another for the others that aren't tracked at all yet.

Note: I named this map `end_dates` (short and not restricted to service principal dates) and chose the module names of services principal in `infra.ci.jenkins.io.tf` as keys as they're already unique and sufficiently descriptive, WDYT?

**EDIT:**
Using a YAML file to store end dates, converted to an object with `yamldecode` in local.tf as workaround since updatecli doesn't seem to be able to retrieve a nested value from a HCL file yet.

Ref:
- https://github.com/jenkins-infra/azure/pull/733#discussion_r1646375931
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401