### PR TITLE
feat(privatek8s/publick8s): allow infracijenkinsioagents1 subnet to reach aks api

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -51,6 +51,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s" {
             [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
             # privatek8s outbound IPs (traffic routed through gateways or outbound LBs)
             module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],
+            module.jenkins_infra_shared_data.outbound_ips["infracijenkinsioagents1.jenkins.io"],
           )
         )
       ),

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -46,6 +46,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
             # trusted.ci subnet (UC agents need to execute mirrorbits scans)
             module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],
             module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"],
+            module.jenkins_infra_shared_data.outbound_ips["infracijenkinsioagents1.jenkins.io"],
           )
         )
       ),


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3923

we need to allow new agents from the cluster `infracijenkinsioagents1` to access aks api for privatek8s and publick8s.