### PR TITLE
chore(updatecli): track `infraci_stats_jenkins_io_fileshare_serviceprincipal_writer` end date

### DIFF
--- a/updatecli/updatecli.d/stats.jenkins.io.sp.endate.yaml
+++ b/updatecli/updatecli.d/stats.jenkins.io.sp.endate.yaml
@@ -53,10 +53,15 @@ actions:
     spec:
       title: Generate new end date {{ source "nextExpiry" }} for stats.jenkins.io File Share service principal writer on infra.ci.jenkins.io
       description: |
-        Generate a new password for stats.jenkins.io File Share service principal on infra.ci.jenkins.io.
+        This PR updates the end date of stats.jenkins.io File Share service principal writer on infra.ci.jenkins.io.
+
+        After merging this PR, a new password will be generated.
         
-        Ref:
-        - https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401
+        > [!IMPORTANT]  
+        > You'll have to ensure that `STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET` is updated with this new password
+        > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.
+        
+        If you don't, the build of stats.jenkins.io on infra.ci.jenkins.io won't be able to update the website content anymore.
       labels:
         - terraform
         - stats.jenkins.io

--- a/updatecli/updatecli.d/stats.jenkins.io.sp.endate.yaml
+++ b/updatecli/updatecli.d/stats.jenkins.io.sp.endate.yaml
@@ -1,0 +1,63 @@
+name: "Generate new end date for stats.jenkins.io File Share service principal writer"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  currentExpiry:
+    name: Get current `end_date` date
+    kind: yaml
+    spec:
+      file: locals.yaml
+      key: $.end_dates.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer
+  nextExpiry:
+    name: Prepare next `end_date` date within 3 months
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/dateadd.sh
+      environments:
+        - name: PATH
+
+conditions:
+  checkIfExpirySoonExpired:
+    kind: shell
+    sourceid: currentExpiry
+    spec:
+      command: bash ./updatecli/scripts/datediff.sh # current end_date date value passed as argument
+      environments:
+        - name: PATH
+
+targets:
+  updateNextExpiry:
+    name: generate new end date {{ source "nextExpiry" }} for stats.jenkins.io File Share service principal writer on infra.ci.jenkins.io
+    kind: yaml
+    sourceid: nextExpiry
+    spec:
+      file: locals.yaml
+      key: $.end_dates.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Generate new end date {{ source "nextExpiry" }} for stats.jenkins.io File Share service principal writer on infra.ci.jenkins.io
+      description: |
+        Generate a new password for stats.jenkins.io File Share service principal on infra.ci.jenkins.io.
+        
+        Ref:
+        - https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401
+      labels:
+        - terraform
+        - stats.jenkins.io
+        - end-dates


### PR DESCRIPTION
This PR adds an updatecli manifest to track `infraci_stats_jenkins_io_fileshare_serviceprincipal_writer` end date.

Proposed PR body:

> ![image](https://github.com/jenkins-infra/azure/assets/91831478/ad015472-2440-466d-b565-0a5c57950010)

Test:
<details><summary>updatecli diff --values updatecli/values.yaml --config updatecli/updatecli.d/stats.jenkins.io.sp.endate.yaml</summary>

```console
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/stats.jenkins.io.sp.endate.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



##################################################################################
# GENERATE NEW END DATE FOR STATS.JENKINS.IO FILE SHARE SERVICE PRINCIPAL WRITER #
##################################################################################


SOURCES
=======

nextExpiry
----------
The shell 🐚 command "/bin/sh /var/folders/ly/77mv7l9968g068w9_fwzwggw0000gp/T/updatecli/bin/bd1b66faf6e39c527f085eea5b269bba76c890efa7550e4ca84317fcabb6e3f1.sh" ran successfully with the following output:
----
2024-09-18T00:00:00Z
----
✔ shell command executed successfully

currentExpiry
-------------
✔ value "\"2023-09-19T23:00:00Z\"" found for key "$.end_dates.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" in the yaml file "locals.yaml"


CONDITIONS:
===========

checkIfExpirySoonExpired
------------------------
The shell 🐚 command "/bin/sh /var/folders/ly/77mv7l9968g068w9_fwzwggw0000gp/T/updatecli/bin/56202140e385731a2fc616bc17989ad91eed830fd60ba795da3fdd132df9fd37.sh" ran successfully with the following output:
----
time for update
----
✔ shell condition of type "console/output", passing


TARGETS
========

updateNextExpiry
----------------

**Dry Run enabled**

⚠ - change detected:
        * key "$.end_dates.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" should be updated from "\"2024-09-19T23:00:00Z\"" to "2024-09-18T00:00:00Z", in file "locals.yaml"


ACTIONS
========


Generate new end date for stats.jenkins.io File Share service principal writer - default
----------------------------------------------------------------------------------------

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:



⚠ Generate new end date for stats.jenkins.io File Share service principal writer:
        Source:
                ✔ [currentExpiry] Get current `end_date` date
                ✔ [nextExpiry] Prepare next `end_date` date within 3 months
        Condition:
                ✔ [checkIfExpirySoonExpired] 
        Target:
                ⚠ [updateNextExpiry] generate new end date 2024-09-18T00:00:00Z for stats.jenkins.io File Share service principal writer on infra.ci.jenkins.io


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
 ```
 
 </details>
 
 Follow-up of:
- #734

Ref:
- https://github.com/jenkins-infra/azure/pull/733#discussion_r1646375931
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401
