### PR TITLE
feat(infracijenkinsio_agents_1): upgrade to kubernetes 1.28

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -47,7 +47,7 @@ locals {
 
   kubernetes_versions = {
     "cijenkinsio_agents_1"      = "1.27.9"
-    "infracijenkinsio_agents_1" = "1.27.9"
+    "infracijenkinsio_agents_1" = "1.28.9"
     "privatek8s"                = "1.27.9"
     "publick8s"                 = "1.27.9"
   }


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2178169723

upgrading the infracijenkinsio_agents_1 kubernetes cluster and node pools to 1.28.9

Plan: 0 to add, 3 to change, 0 to destroy.