### PR TITLE
chore(updatecli): track all File Share service principal writer `end_date`s

### DIFF
--- a/updatecli/updatecli.d/fs-sp-writer-end-dates.yaml
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates.yaml
@@ -1,0 +1,73 @@
+{{ $github := .github }}
+{{ range $key, $val := .end_dates }}
+---
+name: "Generate new end date for {{ $val.concern }} File Share service principal writer"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ $github.user }}"
+      email: "{{ $github.email }}"
+      owner: "{{ $github.owner }}"
+      repository: "{{ $github.repository }}"
+      token: "{{ requiredEnv $github.token }}"
+      username: "{{ $github.username }}"
+      branch: "{{ $github.branch }}"
+
+sources:
+  currentEndDate:
+    name: Get current `end_date` date
+    kind: yaml
+    spec:
+      file: updatecli/values.yaml
+      key: $.end_dates.{{ $key }}.end_date
+  nextEndDate:
+    name: Prepare next `end_date` date within 3 months
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/dateadd.sh
+      environments:
+        - name: PATH
+
+conditions:
+  checkIfEndDateSoonExpired:
+    kind: shell
+    sourceid: currentEndDate
+    spec:
+      # Current end_date date value passed as argument
+      command: bash ./updatecli/scripts/datediff.sh
+      environments:
+        - name: PATH
+
+targets:
+  updateNextEndDate:
+    name: generate new end date {{ source "nextEndDate" }} for {{ $val.concern }} File Share service principal writer on infra.ci.jenkins.io
+    kind: yaml
+    sourceid: nextEndDate
+    spec:
+      file: updatecli/values.yaml
+      key: $.end_dates.{{ $key }}.end_date
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Generate new end date {{ source "nextEndDate" }} for {{ $val.concern }} File Share service principal writer on infra.ci.jenkins.io
+      description: |
+        This PR updates the end date of {{ $val.concern }} File Share service principal writer on infra.ci.jenkins.io.
+
+        After merging this PR, a new password will be generated.
+        
+        > [!IMPORTANT]  
+        > You'll have to ensure that `STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET` is updated with this new password
+        > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.
+        
+        If you don't, the build of {{ $val.concern }} on infra.ci.jenkins.io won't be able to update the website content anymore.
+      labels:
+        - terraform
+        - {{ $val.concern }}
+        - end-dates
+{{ end }}


### PR DESCRIPTION
This PR adds a generic File Share service principal writer end dates manifest.

PR body with stats.jenkins.io as example:

> ![image](https://github.com/jenkins-infra/azure/assets/91831478/31935fd7-13c2-4675-8813-d9b3c8682b54)

Follow-up of:
- #741
- #737
