### PR TITLE
hotfix(infraci.jenkins.io-kubernetes-sponsored-agents) set min size to 1 for ARM64 node pool to avoid slow auto-scaling

### DIFF
--- a/infraci.jenkins.io-kubernetes-sponsored-agents.tf
+++ b/infraci.jenkins.io-kubernetes-sponsored-agents.tf
@@ -113,7 +113,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_agents_1_sponsorshi
   orchestrator_version  = local.kubernetes_versions["infracijenkinsio_agents_1"]
   kubernetes_cluster_id = azurerm_kubernetes_cluster.infracijenkinsio_agents_1.id
   enable_auto_scaling   = true
-  min_count             = 0
+  min_count             = 1 # Azure autoscaler with ARM64 is really slow when starting from zero nodes.
   max_count             = 20
   zones                 = local.infracijenkinsio_agents_1_compute_zones # need to be on zone 1 for arm availability
   vnet_subnet_id        = data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3923