### PR TITLE
chore: move `trusted.ci.jenkins.io.tf` service principal writer end dates to `updatecli/values.yaml`

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -75,7 +75,7 @@ module "infra_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.end_date
+  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infra_ci_jenkins_io_fileshare_serviceprincipal_writer.end_date
   file_share_resource_manager_id = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.contributors_jenkins_io.id
   default_tags                   = local.default_tags
@@ -105,7 +105,7 @@ module "infraci_docs_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.end_date
+  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer.end_date
   file_share_resource_manager_id = azurerm_storage_share.docs_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.docs_jenkins_io.id
   default_tags                   = local.default_tags
@@ -135,7 +135,7 @@ module "infraci_stats_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer.end_date
+  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer.end_date
   file_share_resource_manager_id = azurerm_storage_share.stats_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.stats_jenkins_io.id
   default_tags                   = local.default_tags
@@ -263,7 +263,7 @@ module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "infraci-pluginsjenkinsio-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.end_date
   file_share_resource_manager_id = azurerm_storage_share.plugins_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.plugins_jenkins_io.id
   default_tags                   = local.default_tags

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -80,7 +80,7 @@ module "trusted_ci_jenkins_io_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-06-20T19:00:00Z"
+  service_principal_end_date     = local.end_dates.trusted_ci_jenkins_io.trusted_ci_jenkins_io_fileshare_serviceprincipal_writer.end_date
   file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
@@ -91,7 +91,7 @@ module "trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer-httpd"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-06-20T19:00:00Z"
+  service_principal_end_date     = local.end_dates.trusted_ci_jenkins_io.trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer.end_date
   file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io_httpd.resource_manager_id
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
@@ -118,7 +118,7 @@ module "trustedci_jenkinsio_fileshare_serviceprincipal_writer" {
   service_fqdn                   = "trustedci-jenkinsio-fileshare_serviceprincipal_writer"
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-07-23T00:00:00Z"
+  service_principal_end_date     = local.end_dates.trusted_ci_jenkins_io.trustedci_jenkinsio_fileshare_serviceprincipal_writer.end_date
   file_share_resource_manager_id = azurerm_storage_share.jenkins_io.resource_manager_id
   storage_account_id             = azurerm_storage_account.jenkins_io.id
   default_tags                   = local.default_tags

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -8,19 +8,37 @@ github:
 
 # Also used by terraform in locals.tf
 end_dates:
-  infra_ci_jenkins_io_fileshare_serviceprincipal_writer:
-    end_date: "2024-06-20T23:00:00Z"
-    service: "contributors.jenkins.io"
-    secret: "CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
-  infraci_docs_jenkins_io_fileshare_serviceprincipal_writer:
-    end_date: "2024-08-07T23:00:00Z"
-    service: "docs.jenkins.io"
-    secret: "DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
-  infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer:
-    end_date: "2024-07-27T00:00:00Z"
-    service: "plugins.jenkins.io"
-    secret: "INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_PASSWORD"
-  infraci_stats_jenkins_io_fileshare_serviceprincipal_writer:
-    end_date: "2024-09-19T23:00:00Z"
-    service: "stats.jenkins.io"
-    secret: "STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+  infra_ci_jenkins_io:
+    infra_ci_jenkins_io_fileshare_serviceprincipal_writer:
+      end_date: "2024-06-20T23:00:00Z"
+      service: "contributors.jenkins.io"
+      secret: "CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+    infraci_docs_jenkins_io_fileshare_serviceprincipal_writer:
+      end_date: "2024-08-07T23:00:00Z"
+      service: "docs.jenkins.io"
+      secret: "DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+    infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer:
+      end_date: "2024-07-27T00:00:00Z"
+      service: "plugins.jenkins.io"
+      secret: "INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_PASSWORD"
+    infraci_stats_jenkins_io_fileshare_serviceprincipal_writer:
+      end_date: "2024-09-19T23:00:00Z"
+      service: "stats.jenkins.io"
+      secret: "STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+  trusted_ci_jenkins_io:
+    trusted_ci_jenkins_io_fileshare_serviceprincipal_writer:
+      end_date: "2024-06-20T19:00:00Z"
+      service: "updates.jenkins.io"
+      secret: "TODO: to be identified, related to updates.jenkins.io"
+    trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer:
+      end_date: "2024-06-20T19:00:00Z"
+      service: "updates.jenkins.io (httpd)"
+      secret: "TODO: to be identified, related to updates.jenkins.io (httpd)"
+    trustedci_jenkinsio_fileshare_serviceprincipal_writer:
+      end_date: "2024-07-23T00:00:00Z"
+      service: "jenkins.io"
+      secret: "TODO: to be identified, related to jenkins.io"
+    trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer:
+      end_date: "2024-07-28T00:00:00Z"
+      service: "javadoc.jenkins.io"
+      secret: "TODO: to be identified, related to javadoc.jenkins.io"


### PR DESCRIPTION
This PR moves `trusted.ci.jenkins.io.tf` service principal writer end dates to `updatecli/values.yaml`.

A dedicated updatecli manifest will be added in a follow-up pull request so it can be properly validated. (Will adapt the existing manifest at the same time)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4148#issuecomment-2185911564