### PR TITLE
chore(updatecli): track trusted.ci.jenkins.io.tf File Share service principal writer end-dates

### DIFF
--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.yaml
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.yaml
@@ -1,0 +1,83 @@
+{{ $github := .github }}
+{{ range $key, $val := .end_dates.infra_ci_jenkins_io }}
+---
+name: "Generate new end date for {{ $val.service }} File Share service principal writer"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ $github.user }}"
+      email: "{{ $github.email }}"
+      owner: "{{ $github.owner }}"
+      repository: "{{ $github.repository }}"
+      token: "{{ requiredEnv $github.token }}"
+      username: "{{ $github.username }}"
+      branch: "{{ $github.branch }}"
+
+sources:
+  currentEndDate:
+    name: Get current `end_date` date
+    kind: yaml
+    spec:
+      file: updatecli/values.yaml
+      key: $.end_dates.infra_ci_jenkins_io.{{ $key }}.end_date
+  nextEndDate:
+    name: Prepare next `end_date` date within 3 months
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/dateadd.sh
+      environments:
+        - name: PATH
+  shortNextEndDate:
+    name: Short next `end_date` date within 3 months
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/dateadd.sh | cut -c -10
+      environments:
+        - name: PATH
+
+conditions:
+  checkIfEndDateSoonExpired:
+    kind: shell
+    sourceid: currentEndDate
+    spec:
+      # Current end_date date value passed as argument
+      command: bash ./updatecli/scripts/datediff.sh
+      environments:
+        - name: PATH
+
+targets:
+  updateNextEndDate:
+    name: generate new end date {{ source "shortNextEndDate" }} for {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io
+    kind: yaml
+    sourceid: nextEndDate
+    spec:
+      file: updatecli/values.yaml
+      key: $.end_dates.infra_ci_jenkins_io.{{ $key }}.end_date
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Generate new end date {{ source "shortNextEndDate" }} for {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io
+      description: |
+        This PR updates the end date of {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io.
+
+        The current end date is set to `{{ $val.end_date }}`.
+
+        After merging this PR, a new password will be generated.
+        
+        > [!IMPORTANT]
+        > You'll have to ensure that `{{ $val.secret }}` is updated with this new password
+        > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.
+        
+        If you don't, the build of {{ $val.service }} on infra.ci.jenkins.io won't be able to update the website content anymore.
+      labels:
+        - terraform
+        - {{ $val.service }}
+        - end-dates
+        - infra.ci.jenkins.io
+{{ end }}

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.yaml
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.yaml
@@ -1,5 +1,5 @@
 {{ $github := .github }}
-{{ range $key, $val := .end_dates }}
+{{ range $key, $val := .end_dates.trusted_ci_jenkins_io }}
 ---
 name: "Generate new end date for {{ $val.service }} File Share service principal writer"
 
@@ -21,7 +21,7 @@ sources:
     kind: yaml
     spec:
       file: updatecli/values.yaml
-      key: $.end_dates.{{ $key }}.end_date
+      key: $.end_dates.trusted_ci_jenkins_io.{{ $key }}.end_date
   nextEndDate:
     name: Prepare next `end_date` date within 3 months
     kind: shell
@@ -49,12 +49,12 @@ conditions:
 
 targets:
   updateNextEndDate:
-    name: generate new end date {{ source "shortNextEndDate" }} for {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io
+    name: generate new end date {{ source "shortNextEndDate" }} for {{ $val.service }} File Share service principal writer on trusted.ci.jenkins.io
     kind: yaml
     sourceid: nextEndDate
     spec:
       file: updatecli/values.yaml
-      key: $.end_dates.{{ $key }}.end_date
+      key: $.end_dates.trusted_ci_jenkins_io.{{ $key }}.end_date
     scmid: default
 
 actions:
@@ -62,21 +62,25 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate new end date {{ source "shortNextEndDate" }} for {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io
+      title: Generate new end date {{ source "shortNextEndDate" }} for {{ $val.service }} File Share service principal writer on trusted.ci.jenkins.io
       description: |
-        This PR updates the end date of {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io.
+        This PR updates the end date of {{ $val.service }} File Share service principal writer used in trusted.ci.jenkins.io.
 
-        The current end date is set to {{ $val.end_date }}.
+        The current end date is set to `{{ $val.end_date }}`.
 
         After merging this PR, a new password will be generated.
         
-        > [!IMPORTANT]  
-        > You'll have to ensure that `{{ $val.secret }}` is updated with this new password
-        > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.
+        > [!IMPORTANT]
+        > You'll have to ensure that `{{ $val.secret }}` is updated with this new password!
         
-        If you don't, the build of {{ $val.service }} on infra.ci.jenkins.io won't be able to update the website content anymore.
+        If you don't, {{ $val.service }} File Share won't be updated by trusted.ci.jenkins.io jobs anymore.
+        
+        > [!NOTE]
+        > This message is a work in progress that needs to be improved
+        > Check https://github.com/jenkins-infra/helpdesk/issues/4148 for the next steps.
       labels:
         - terraform
         - {{ $val.service }}
         - end-dates
+        - trusted.ci.jenkins.io
 {{ end }}


### PR DESCRIPTION
This PR adds a manifest to track the File Share service principal writer end dates defined in trusted.ci.jenkins.io.tf file.

Follow-up of:
- #748

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4148#issuecomment-2185911564