### PR TITLE
chore: remove service principal id and password outputs and rename application ones

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -69,10 +69,6 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_subnet_privat
 }
 
 # Required to allow azcopy sync of contributors.jenkins.io File Share
-moved {
-  from = module.infra_ci_jenkins_io_fileshare_serviceprincipal_writer
-  to   = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer
-}
 module "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
@@ -103,10 +99,6 @@ output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_sp_passw
 }
 
 # Required to allow azcopy sync of docs.jenkins.io File Share
-moved {
-  from = module.infraci_docs_jenkins_io_fileshare_serviceprincipal_writer
-  to   = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer
-}
 module "infraci_docsjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
@@ -137,10 +129,6 @@ output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_sp_password" {
 }
 
 # Required to allow azcopy sync of stats.jenkins.io File Share
-moved {
-  from = module.infraci_stats_jenkins_io_fileshare_serviceprincipal_writer
-  to   = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer
-}
 module "infraci_statsjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -80,22 +80,12 @@ module "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer" {
   storage_account_id             = azurerm_storage_account.contributors_jenkins_io.id
   default_tags                   = local.default_tags
 }
-output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_id" {
-  value = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id
-}
-output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_password" {
-  sensitive = true
-  value     = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
-}
 output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_sp_id" {
-  value = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_id
-}
-output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_sp_password" {
+output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
-  value     = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
+  value     = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
 
 # Required to allow azcopy sync of docs.jenkins.io File Share
@@ -110,22 +100,12 @@ module "infraci_docsjenkinsio_fileshare_serviceprincipal_writer" {
   storage_account_id             = azurerm_storage_account.docs_jenkins_io.id
   default_tags                   = local.default_tags
 }
-output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_id" {
-  value = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id
-}
-output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_password" {
-  sensitive = true
-  value     = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
-}
 output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_sp_id" {
-  value = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_id
-}
-output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_sp_password" {
+output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
-  value     = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
+  value     = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
 
 # Required to allow azcopy sync of stats.jenkins.io File Share
@@ -140,22 +120,12 @@ module "infraci_statsjenkinsio_fileshare_serviceprincipal_writer" {
   storage_account_id             = azurerm_storage_account.stats_jenkins_io.id
   default_tags                   = local.default_tags
 }
-output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_id" {
-  value = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_id
-}
-output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_password" {
-  sensitive = true
-  value     = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
-}
 output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_sp_id" {
-  value = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_id
-}
-output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_sp_password" {
+output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
-  value     = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_sp_password
+  value     = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
 
 locals {
@@ -271,7 +241,7 @@ module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
 output "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer_password" {
+output "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
-  value     = module.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+  value     = module.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -74,10 +74,6 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
 }
 
 # Required to allow azcopy sync of updates.jenkins.io File Share (content) with the permanent agent
-moved {
-  from = module.trusted_ci_jenkins_io_fileshare_serviceprincipal_writer
-  to   = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer
-}
 module "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
@@ -97,10 +93,6 @@ output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_cli
   value     = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
 }
 # Required to allow azcopy sync of updates.jenkins.io File Share (redirections) with the permanent agent
-moved {
-  from = module.trustedci_updates_jenkins_io_httpd_fileshare_serviceprincipal_writer
-  to   = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer
-}
 module "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -85,12 +85,12 @@ module "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer" {
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }
-output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_client_id" {
+output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_client_secret" {
+output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_application_client_secret" {
   sensitive = true
-  value     = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+  value     = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
 # Required to allow azcopy sync of updates.jenkins.io File Share (redirections) with the permanent agent
 module "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer" {
@@ -104,12 +104,12 @@ module "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_write
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }
-output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_client_id" {
+output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_client_secret" {
+output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_application_client_secret" {
   sensitive = true
-  value     = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+  value     = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
 
 # Required to allow azcopy sync of jenkins.io File Share
@@ -127,9 +127,9 @@ module "trustedci_jenkinsio_fileshare_serviceprincipal_writer" {
 output "trustedci_jenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.trustedci_jenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "trustedci_jenkinsio_fileshare_serviceprincipal_writer_password" {
+output "trustedci_jenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
-  value     = module.trustedci_jenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+  value     = module.trustedci_jenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
 
 # Required to allow azcopy sync of javadoc.jenkins.io File Share
@@ -147,9 +147,9 @@ module "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer" {
 output "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
 }
-output "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer_password" {
+output "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
-  value     = module.trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_password
+  value     = module.trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
 
 ## Sponsorship subscription specific resources for controller


### PR DESCRIPTION
This PR removes service principal id and password outputs and rename application ones to be more descriptive about the fact they concern the application client id and the application client password, not the service principal.

It also removes the `moved` blocks introduced in #754 as these renaming are now in terraform state.

Follow-up of:
- https://github.com/jenkins-infra/shared-tools/pull/150
- #754

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4149