### PR TITLE
feat(privatek8s): upgrade to kubernetes 1.28

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -49,7 +49,7 @@ locals {
   kubernetes_versions = {
     "cijenkinsio_agents_1"      = "1.28.9"
     "infracijenkinsio_agents_1" = "1.28.9"
-    "privatek8s"                = "1.27.9"
+    "privatek8s"                = "1.28.9"
     "publick8s"                 = "1.27.9"
   }
 


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2190936375

upgrading the privatek8s kubernetes cluster and node pools to 1.28.9