### PR TITLE
chore(publick8s): enable autoscaling for the system pool

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -84,8 +84,9 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     os_disk_type         = "Ephemeral"
     os_disk_size_gb      = 50
     orchestrator_version = local.kubernetes_versions["publick8s"]
-    enable_auto_scaling  = false
-    node_count           = 2
+    enable_auto_scaling  = true
+    min_count            = 2
+    max_count            = 4
     vnet_subnet_id       = data.azurerm_subnet.publick8s_tier.id
     tags                 = local.default_tags
     zones                = local.publick8s_compute_zones


### PR DESCRIPTION
as we are planning to upgrade to kubernetes 1.28 https://github.com/jenkins-infra/helpdesk/issues/4144, adding the autoscaling may speed up the upgrade, cijioagent1 wasn't with autoscale on the system pool and took 32mn to upgrade (most of it for the 3 nodes system pool).