### PR TITLE
chore(infracijioagent1/cijioagent1): enable autoscaling for the system pool

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -54,8 +54,9 @@ resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
     os_disk_size_gb      = 150 # Ref. Cache storage size athttps://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
     orchestrator_version = local.kubernetes_versions["cijenkinsio_agents_1"]
     kubelet_disk_type    = "OS"
-    enable_auto_scaling  = false
-    node_count           = 3 # 3 nodes for HA as per AKS best practises
+    enable_auto_scaling  = true
+    min_count            = 2 # for best practises
+    max_count            = 3 # for upgrade
     vnet_subnet_id       = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
     tags                 = local.default_tags
     zones                = local.cijenkinsio_agents_1_compute_zones

--- a/infraci.jenkins.io-kubernetes-sponsored-agents.tf
+++ b/infraci.jenkins.io-kubernetes-sponsored-agents.tf
@@ -53,8 +53,9 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
     os_disk_size_gb      = 150 # Ref. Cache storage size athttps://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
     orchestrator_version = local.kubernetes_versions["infracijenkinsio_agents_1"]
     kubelet_disk_type    = "OS"
-    enable_auto_scaling  = false
-    node_count           = 3 # 3 nodes for HA as per AKS best practises
+    enable_auto_scaling  = true
+    min_count            = 2 # for best practises
+    max_count            = 3 # for upgrade
     vnet_subnet_id       = data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id
     tags                 = local.default_tags
     zones                = local.infracijenkinsio_agents_1_compute_zones


### PR DESCRIPTION
during the upgrade to kubernetes 1.28 https://github.com/jenkins-infra/helpdesk/issues/4144, we saw a long time to upgrade system pool and this may be due to the fact that the system pools of those 2 clusters: `cijioagents1` and `infracijioagent1` are not on autoscale.
This may improve next upgrade.