### PR TITLE
chore(infra.ci.jenkins.io) move end date for the Azure client password used by Azure VM agents plugin

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -44,7 +44,7 @@ resource "azuread_service_principal" "infra_ci_jenkins_io" {
 resource "azuread_application_password" "infra_ci_jenkins_io" {
   application_id = azuread_application.infra_ci_jenkins_io.id
   display_name   = "infra.ci.jenkins.io-tf-managed"
-  end_date       = "2024-06-30T00:00:00Z"
+  end_date       = local.end_dates.infra_ci_jenkins_io.azurevms_agents_client_secret.end_date
 }
 # Allow Service Principal to manage AzureRM resources inside the agents resource groups
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_azurerm" {

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -24,6 +24,10 @@ end_dates:
       end_date: "2024-09-19T23:00:00Z"
       service: "stats.jenkins.io"
       secret: "STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+    azurevms_agents_client_secret:
+      end_date: "2024-06-30T00:00:00Z"
+      service: "infra.ci.jenkins.io Azure VM agents"
+      secret: "JENKINSINFRA_AZURE_CLIENT_SECRET_VALUE"
   trusted_ci_jenkins_io:
     trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer:
       end_date: 2024-09-22T00:00:00Z


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4154

This PR moves the end date definition to the YAML file used by `updatecli` to track dates.

- Local tests shows there are no changes in Terraform plan: let's see what the CI checks tells us
- Bumped the shared tools to ensure we have the latest version all the time
- Naming: I used `azurevms_agents_client_secret` in the YAML file:
  - The prefix `infraci_` does not make sense as this key is under the `infra.ci.jenkins.io` key
  - There are no corresponding environment variable that would fit the other keys naming convention: most probably because we started by this one, and then the resource sets grew over the initial naming.