### PR TITLE
chore(updatecli) simplify manifests using gotemplates by using root scope to get top-level values

### DIFF
--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.yaml
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.yaml
@@ -1,4 +1,3 @@
-{{ $github := .github }}
 {{ range $key, $val := .end_dates.infra_ci_jenkins_io }}
 ---
 name: "Generate new end date for {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io"
@@ -7,13 +6,13 @@ scms:
   default:
     kind: github
     spec:
-      user: "{{ $github.user }}"
-      email: "{{ $github.email }}"
-      owner: "{{ $github.owner }}"
-      repository: "{{ $github.repository }}"
-      token: "{{ requiredEnv $github.token }}"
-      username: "{{ $github.username }}"
-      branch: "{{ $github.branch }}"
+      user: "{{ $.github.user }}"
+      email: "{{ $.github.email }}"
+      owner: "{{ $.github.owner }}"
+      repository: "{{ $.github.repository }}"
+      token: "{{ requiredEnv $.github.token }}"
+      username: "{{ $.github.username }}"
+      branch: "{{ $.github.branch }}"
 
 sources:
   currentEndDate:
@@ -69,11 +68,11 @@ actions:
         The current end date is set to `{{ $val.end_date }}`.
 
         After merging this PR, a new password will be generated.
-        
+
         > [!IMPORTANT]
         > You'll have to ensure that `{{ $val.secret }}` is updated with this new password
         > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.
-        
+
         If you don't, the build of {{ $val.service }} on infra.ci.jenkins.io won't be able to update the website content anymore.
       labels:
         - terraform

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.yaml
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.yaml
@@ -1,4 +1,3 @@
-{{ $github := .github }}
 {{ range $key, $val := .end_dates.trusted_ci_jenkins_io }}
 ---
 name: "Generate new end date for {{ $val.service }} File Share service principal writer on trusted.ci.jenkins.io"
@@ -7,13 +6,13 @@ scms:
   default:
     kind: github
     spec:
-      user: "{{ $github.user }}"
-      email: "{{ $github.email }}"
-      owner: "{{ $github.owner }}"
-      repository: "{{ $github.repository }}"
-      token: "{{ requiredEnv $github.token }}"
-      username: "{{ $github.username }}"
-      branch: "{{ $github.branch }}"
+      user: "{{ $.github.user }}"
+      email: "{{ $.github.email }}"
+      owner: "{{ $.github.owner }}"
+      repository: "{{ $.github.repository }}"
+      token: "{{ requiredEnv $.github.token }}"
+      username: "{{ $.github.username }}"
+      branch: "{{ $.github.branch }}"
 
 sources:
   currentEndDate:


### PR DESCRIPTION
This PR simplifies the Go template used in `updatecli` manifests to have less code, which follows the usual Go conventiojns to ensure any contributor with go background will be at ease. It also prevent potential bugs around variables scope re-entrance in `updatecli` and human mistake (overriding accidentally the `github` values).

Go template system (see https://pkg.go.dev/text/template#hdr-Variables) allows accessing the root context (e.g. the values passed to the template engine scoped at the top of the file) through the variable `$`.
