### PR TITLE
chore(weekly.ci) make resource dependencies explicit by avoiding locals

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -62,8 +62,5 @@ locals {
 
   publick8s_compute_zones = [3]
 
-  weekly_ci_disk_size    = 8
-  weekly_ci_access_modes = ["ReadWriteOnce"]
-
   end_dates = yamldecode(data.local_file.locals_yaml.content).end_dates
 }

--- a/weekly.ci.jenkins.io.tf
+++ b/weekly.ci.jenkins.io.tf
@@ -9,7 +9,7 @@ resource "azurerm_managed_disk" "jenkins_weekly_data" {
   resource_group_name  = azurerm_resource_group.weekly_ci_controller.name
   storage_account_type = "StandardSSD_ZRS"
   create_option        = "Empty"
-  disk_size_gb         = local.weekly_ci_disk_size
+  disk_size_gb         = 8
   tags = {
     environment = azurerm_resource_group.weekly_ci_controller.name
   }
@@ -22,9 +22,9 @@ resource "kubernetes_persistent_volume" "jenkins_weekly_data" {
   }
   spec {
     capacity = {
-      storage = local.weekly_ci_disk_size
+      storage = azurerm_managed_disk.jenkins_weekly_data.disk_size_gb
     }
-    access_modes                     = local.weekly_ci_access_modes
+    access_modes                     = ["ReadWriteOnce"]
     persistent_volume_reclaim_policy = "Retain"
     storage_class_name               = kubernetes_storage_class.statically_provisionned.id
     persistent_volume_source {
@@ -43,12 +43,12 @@ resource "kubernetes_persistent_volume_claim" "jenkins_weekly_data" {
     namespace = "jenkins-weekly"
   }
   spec {
-    access_modes       = local.weekly_ci_access_modes
+    access_modes       = kubernetes_persistent_volume.jenkins_weekly_data.spec[0].access_modes
     volume_name        = kubernetes_persistent_volume.jenkins_weekly_data.metadata.0.name
     storage_class_name = kubernetes_storage_class.statically_provisionned.id
     resources {
       requests = {
-        storage = local.weekly_ci_disk_size
+        storage = azurerm_managed_disk.jenkins_weekly_data.disk_size_gb
       }
     }
   }


### PR DESCRIPTION
We have the following rule of thumb in the Jenkins Infra terraform projects: "If a value is duplicated then factorize it as a local". It's a rule of thumb which has been carefully followed which is good 👍 

However in this particular case (weekly.ci persistent resources), the values duplication factorized into a local has an unexpected side-effect: it hides a dependency chain between resources.

This PR fixes it by making the dependency between resources (PVC -> PV -> disk) explicit.
Positive side-effect: it removes the local so the specific values sides within the scope of the weekly.ci.jenkins.io TF file.


We expect no changes in this PR (for the Terraform plan).