### PR TITLE
feat(publick8s): upgrade to kubernetes 1.28

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -50,7 +50,7 @@ locals {
     "cijenkinsio_agents_1"      = "1.28.9"
     "infracijenkinsio_agents_1" = "1.28.9"
     "privatek8s"                = "1.28.9"
-    "publick8s"                 = "1.27.9"
+    "publick8s"                 = "1.28.9"
   }
 
   ci_jenkins_io_fqdn                 = "ci.jenkins.io"


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2196274746

upgrading the publick8s kubernetes cluster and node pools to 1.28.9