### PR TITLE
cleanup: tune setup of AKS PV disks

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -262,9 +262,7 @@ resource "azurerm_managed_disk" "jenkins_infra_data" {
   storage_account_type = "StandardSSD_ZRS"
   create_option        = "Empty"
   disk_size_gb         = 64
-  tags = {
-    environment = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins.name
-  }
+  tags                 = local.default_tags
 }
 
 resource "kubernetes_persistent_volume" "jenkins_infra_data" {
@@ -306,7 +304,7 @@ resource "kubernetes_persistent_volume_claim" "jenkins_infra_data" {
   }
 }
 
-# Required to allow the release controller to read the disk
+# Required to allow AKS CSI driver to access the Azure disk
 resource "azurerm_role_definition" "infra_ci_jenkins_io_controller_disk_reader" {
   name  = "ReadinfraCIDisk"
   scope = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins.id

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -236,7 +236,11 @@ resource "kubernetes_storage_class" "managed_csi_standard_ZRS_retain_public" {
   allow_volume_expansion = true
 }
 
-resource "kubernetes_storage_class" "statically_provisionned" {
+moved {
+  from = kubernetes_storage_class.statically_provisionned
+  to   = kubernetes_storage_class.statically_provisionned_publick8s
+}
+resource "kubernetes_storage_class" "statically_provisionned_publick8s" {
   metadata {
     name = "statically-provisionned"
   }

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -10,9 +10,7 @@ resource "azurerm_managed_disk" "jenkins_release_data" {
   storage_account_type = "StandardSSD_ZRS"
   create_option        = "Empty"
   disk_size_gb         = 64
-  tags = {
-    environment = azurerm_resource_group.release_ci_controller.name
-  }
+  tags                 = local.default_tags
 }
 
 resource "kubernetes_persistent_volume" "jenkins_release_data" {
@@ -54,7 +52,7 @@ resource "kubernetes_persistent_volume_claim" "jenkins_release_data" {
   }
 }
 
-# Required to allow the release controller to read the disk
+# Required to allow AKS CSI driver to access the Azure disk
 resource "azurerm_role_definition" "release_ci_jenkins_io_controller_disk_reader" {
   name  = "ReadreleaseCIDisk"
   scope = azurerm_resource_group.release_ci_controller.id


### PR DESCRIPTION
- Use proper tags for resource groups
- Reword comment around disk permissions to give the real target (CSI driver, not the controller pods)
- Rename the publick8s static storage class to avoid confusion
- Update the shared tools to latest version