### PR TITLE
chore(updatecli): add current end date to PR titles

### DIFF
--- a/updatecli/updatecli.d/ci.sp.endate.yaml
+++ b/updatecli/updatecli.d/ci.sp.endate.yaml
@@ -1,3 +1,5 @@
+---
+# yamllint disable rule:line-length
 name: "Generate new end date for ci.jenkins.io controller service principal"
 
 scms:
@@ -13,14 +15,14 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  currentExpiry:
-    name: Get current `expiry` date
+  currentEndDate:
+    name: Get current `end_date` date
     kind: terraform/file #  as per updatecli/updatecli#1859 need to use terraform/file findsubmatch for now
     spec:
       file: ci.jenkins.io.tf
       path: 'module.controller_service_principal_end_date'
-  nextExpiry:
-    name: Prepare next `expiry` date within 3 months
+  nextEndDate:
+    name: Prepare next `end_date` date within 3 months
     kind: shell
     spec:
       command: bash ./updatecli/scripts/dateadd.sh
@@ -28,23 +30,24 @@ sources:
         - name: PATH
 
 conditions:
-  checkIfExpirySoonExpired:
+  checkIfEndDateSoonExpired:
     kind: shell
-    sourceid: currentExpiry
+    sourceid: currentEndDate
     spec:
-      command: bash ./updatecli/scripts/datediff.sh # current expiry date value passed as argument
+      # Current end_date date value passed as argument
+      command: bash ./updatecli/scripts/datediff.sh
       environments:
         - name: PATH
 
 targets:
-  updateNextExpiry:
+  updateNextEndDate:
     name: Update Terraform file `ci.jenkins.io.tf` with new expiration date for controller_service_principal_end_date
     kind: file
-    sourceid: nextExpiry
+    sourceid: nextEndDate
     spec:
       file: ci.jenkins.io.tf
       matchpattern: (controller_service_principal_end_date.*=.*\")(.*)(\".*)
-      replacepattern: ${1}{{ source "nextExpiry" }}"
+      replacepattern: ${1}{{ source "nextEndDate" }}"
     scmid: default
 
 actions:
@@ -52,7 +55,12 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate a new Azure Service Principal password with expiration date {{ source "nextExpiry" }} on `ci.jenkins.io`
-      description: "Generate a new password for the Azure Service Principal `ci.jenkins.io`. See https://github.com/jenkins-infra/helpdesk/issues/4052#issuecomment-2072867491 for details"
+      title: "Extend Azure Service Principal password on `ci.jenkins.io` (current end date: {{ source \"currentEndDate\" }})"
+      description: |
+        Generate a new password for the Azure Service Principal `ci.jenkins.io`.
+
+        See https://github.com/jenkins-infra/helpdesk/issues/4052#issuecomment-2072867491 for details.
       labels:
         - terraform
+        - end-dates
+        - ci.jenkins.io

--- a/updatecli/updatecli.d/ci.sp.endate.yaml
+++ b/updatecli/updatecli.d/ci.sp.endate.yaml
@@ -55,7 +55,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: "Extend Azure Service Principal password on `ci.jenkins.io` (current end date: {{ source \"currentEndDate\" }})"
+      title: 'Extend Azure Service Principal password on `ci.jenkins.io` (current end date: {{ source "currentEndDate" }})'
       description: |
         Generate a new password for the Azure Service Principal `ci.jenkins.io`.
 

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
@@ -1,5 +1,6 @@
 {{ range $key, $val := .end_dates.infra_ci_jenkins_io }}
 ---
+# yamllint disable rule:line-length
 name: "Generate new end date for {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io"
 
 scms:
@@ -48,7 +49,7 @@ conditions:
 
 targets:
   updateNextEndDate:
-    name: new end date `{{ source "shortNextEndDate" }}` for `{{ $val.service }}` File Share service principal writer on `infra.ci.jenkins.io`
+    name: New end date `{{ source "shortNextEndDate" }}` for `{{ $val.service }}` File Share service principal writer on `infra.ci.jenkins.io`
     kind: yaml
     sourceid: nextEndDate
     spec:
@@ -61,7 +62,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: New end date `{{ source "shortNextEndDate" }}` for `{{ $val.service }}` File Share service principal writer on `infra.ci.jenkins.io`
+      title: "New end date for `{{ $val.service }}` File Share service principal writer on `infra.ci.jenkins.io` (current: {{ source \"currentEndDate\" }})"
       description: |
         This PR updates the end date of {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io.
 
@@ -76,7 +77,7 @@ actions:
         If you don't, the build of {{ $val.service }} on infra.ci.jenkins.io won't be able to update the website content anymore.
       labels:
         - terraform
-        - {{ $val.service }}
+        - "{{ $val.service }}"
         - end-dates
         - infra.ci.jenkins.io
 {{ end }}

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
@@ -62,7 +62,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: "New end date for `{{ $val.service }}` File Share service principal writer on `infra.ci.jenkins.io` (current: {{ source \"currentEndDate\" }})"
+      title: 'New end date for `{{ $val.service }}` File Share service principal writer on `infra.ci.jenkins.io` (current: {{ source "currentEndDate" }})'
       description: |
         This PR updates the end date of {{ $val.service }} File Share service principal writer on infra.ci.jenkins.io.
 

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.tpl
@@ -49,7 +49,7 @@ conditions:
 
 targets:
   updateNextEndDate:
-    name: "New end date for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io` (current: {{ source \"currentEndDate\" }})"
+    name: 'New end date for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io` (current: {{ source "currentEndDate" }})'
     kind: yaml
     sourceid: nextEndDate
     spec:

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.tpl
@@ -62,7 +62,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: "New end date for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io` (current: {{ source \"currentEndDate\" }})"
+      title: 'New end date for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io` (current: {{ source "currentEndDate" }})'
       description: |
         This PR updates the end date of {{ $val.service }} File Share service principal writer used in trusted.ci.jenkins.io.
 

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_trusted.ci.jenkins.io.tf.tpl
@@ -1,5 +1,6 @@
 {{ range $key, $val := .end_dates.trusted_ci_jenkins_io }}
 ---
+# yamllint disable rule:line-length
 name: "Generate new end date for {{ $val.service }} File Share service principal writer on trusted.ci.jenkins.io"
 
 scms:
@@ -48,7 +49,7 @@ conditions:
 
 targets:
   updateNextEndDate:
-    name: new end date `{{ source "shortNextEndDate" }}` for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io`
+    name: "New end date for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io` (current: {{ source \"currentEndDate\" }})"
     kind: yaml
     sourceid: nextEndDate
     spec:
@@ -61,7 +62,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: New end date `{{ source "shortNextEndDate" }}` for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io`
+      title: "New end date for `{{ $val.service }}` File Share service principal writer on `trusted.ci.jenkins.io` (current: {{ source \"currentEndDate\" }})"
       description: |
         This PR updates the end date of {{ $val.service }} File Share service principal writer used in trusted.ci.jenkins.io.
 
@@ -75,7 +76,7 @@ actions:
         If you don't, {{ $val.service }} File Share won't be updated by trusted.ci.jenkins.io jobs anymore.
       labels:
         - terraform
-        - {{ $val.service }}
+        - "{{ $val.service }}"
         - end-dates
         - trusted.ci.jenkins.io
 {{ end }}

--- a/updatecli/updatecli.d/infra.ci.sp.endate.yaml
+++ b/updatecli/updatecli.d/infra.ci.sp.endate.yaml
@@ -54,7 +54,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: "Extend Azure AD Application password on `infra.ci.jenkins.io` (current end date: {{ source \"currentEndDate\" }})"
+      title: 'Extend Azure AD Application password on `infra.ci.jenkins.io` (current end date: {{ source "currentEndDate" }})'
       description: |
         This PR generates a new Azure AD application password with a new end date for the `infra.ci.jenkins.io` controller (to allow spawning Azure VM agents).
         Once this PR is merged and deployed with success by Terraform (on infra.ci.jenkins.io), you can retrieve the new password value from the Terraform state with `terraform show -json` then searching for the new password in `values.value` of the `resource.azuread_application_password.infra_ci_jenkins_io` section (do NOT save it anywhere!) and (manually) update the infra.ci.jenkins.io credential named `azure-jenkins-sponsorship-credentials` through the Jenkins UI.

--- a/updatecli/updatecli.d/infra.ci.sp.endate.yaml
+++ b/updatecli/updatecli.d/infra.ci.sp.endate.yaml
@@ -1,3 +1,5 @@
+---
+# yamllint disable rule:line-length
 name: "Generate new end date for the infra.ci.jenkins.io controller Azure AD Application password"
 
 scms:
@@ -13,14 +15,14 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  currentExpiry:
-    name: Get current `expiry` date
+  currentEndDate:
+    name: Get current `end_date` date
     kind: hcl
     spec:
       file: infra.ci.jenkins.io.tf
       path: resource.azuread_application_password.infra_ci_jenkins_io.end_date
-  nextExpiry:
-    name: Prepare next `expiry` date within 3 months
+  nextEndDate:
+    name: Prepare next `end_date` date within 3 months
     kind: shell
     spec:
       command: bash ./updatecli/scripts/dateadd.sh
@@ -28,19 +30,20 @@ sources:
         - name: PATH
 
 conditions:
-  checkIfExpirySoonExpired:
+  checkIfEndDateSoonExpired:
     kind: shell
-    sourceid: currentExpiry
+    sourceid: currentEndDate
     spec:
-      command: bash ./updatecli/scripts/datediff.sh # current expiry date value passed as argument
+      # Current end_date date value passed as argument
+      command: bash ./updatecli/scripts/datediff.sh
       environments:
         - name: PATH
 
 targets:
-  updateNextExpiry:
+  updateNextEndDate:
     name: Update Terraform file `infra.ci.jenkins.io.tf` with new expiration date for controller_service_principal_end_date
     kind: hcl
-    sourceid: nextExpiry
+    sourceid: nextEndDate
     spec:
       file: infra.ci.jenkins.io.tf
       path: resource.azuread_application_password.infra_ci_jenkins_io.end_date
@@ -51,10 +54,12 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate a new Azure AD Application password with expiration date {{ source "nextExpiry" }} on `infra.ci.jenkins.io`
+      title: "Extend Azure AD Application password on `infra.ci.jenkins.io` (current end date: {{ source \"currentEndDate\" }})"
       description: |
         This PR generates a new Azure AD application password with a new end date for the `infra.ci.jenkins.io` controller (to allow spawning Azure VM agents).
         Once this PR is merged and deployed with success by Terraform (on infra.ci.jenkins.io), you can retrieve the new password value from the Terraform state with `terraform show -json` then searching for the new password in `values.value` of the `resource.azuread_application_password.infra_ci_jenkins_io` section (do NOT save it anywhere!) and (manually) update the infra.ci.jenkins.io credential named `azure-jenkins-sponsorship-credentials` through the Jenkins UI.
         Finally, verify both Azure Credential and Azure VM clouds by checking that a click on the "Verify <...>" buttons returns a success, then restart the controller to ensure that the old credential is not kept in cache.
       labels:
         - terraform
+        - end-dates
+        - infra.ci.jenkins.io

--- a/updatecli/updatecli.d/trusted.ci.sp.endate.yaml
+++ b/updatecli/updatecli.d/trusted.ci.sp.endate.yaml
@@ -1,3 +1,5 @@
+---
+# yamllint disable rule:line-length
 name: "Generate new end date for the trusted.ci.jenkins.io controller Azure AD Application password"
 
 scms:
@@ -13,14 +15,14 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  currentExpiry:
-    name: Get current `expiry` date
-    kind: terraform/file #  as per updatecli/updatecli#1859 need to use terraform/file findsubmatch for now
+  currentEndDate:
+    name: Get current `end_date` date
+    kind: terraform/file  # As per updatecli/updatecli#1859 need to use terraform/file findsubmatch for now
     spec:
       file: trusted.ci.jenkins.io.tf
       path: 'module.controller_service_principal_end_date'
-  nextExpiry:
-    name: Prepare next `expiry` date within 3 months
+  nextEndDate:
+    name: Prepare next `end_date` date within 3 months
     kind: shell
     spec:
       command: bash ./updatecli/scripts/dateadd.sh
@@ -28,23 +30,24 @@ sources:
         - name: PATH
 
 conditions:
-  checkIfExpirySoonExpired:
+  checkIfEndDateSoonExpired:
     kind: shell
-    sourceid: currentExpiry
+    sourceid: currentEndDate
     spec:
-      command: bash ./updatecli/scripts/datediff.sh # current expiry date value passed as argument
+      # Current end_date date value passed as argument
+      command: bash ./updatecli/scripts/datediff.sh
       environments:
         - name: PATH
 
 targets:
-  updateNextExpiry:
+  updateNextEndDate:
     name: Update Terraform file `trusted.ci.jenkins.io.tf` with new expiration date for controller_service_principal_end_date
     kind: file
-    sourceid: nextExpiry
+    sourceid: nextEndDate
     spec:
       file: trusted.ci.jenkins.io.tf
       matchpattern: (controller_service_principal_end_date.*=.*\")(.*)(\".*)
-      replacepattern: ${1}{{ source "nextExpiry" }}"
+      replacepattern: ${1}{{ source "nextEndDate" }}"
     scmid: default
 
 actions:
@@ -52,10 +55,12 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate a new Azure AD Application password with expiration date {{ source "nextExpiry" }} on `trusted.ci.jenkins.io`
+      title: "Extend Azure AD Application password on `trusted.ci.jenkins.io` (current end date: {{ source \"currentEndDate\" }})"
       description: |
         This PR generates a new Azure AD application password with a new end date for the `trusted.ci.jenkins.io` controller (to allow spawning Azure VM agents).
         Once this PR is merged and deployed with success by Terraform (on infra.ci.jenkins.io), you can retrieve the new password value from the Terraform state with `terraform show -json` then searching for the new password in `values.value` of the `module.trusted_ci_jenkins_io.azuread_application_password.controller` section (do NOT save it anywhere!) and (manually) update the trusted.ci.jenkins.io credential named `azure-jenkins-sponsorship-credentials` through the Jenkins UI.
         Finally, verify both Azure Credential and Azure VM clouds by checking that a click on the "Verify <...>" buttons returns a success, then restart the controller to ensure that the old credential is not kept in cache.
       labels:
         - terraform
+        - end-dates
+        - trusted.ci.jenkins.io

--- a/updatecli/updatecli.d/trusted.ci.sp.endate.yaml
+++ b/updatecli/updatecli.d/trusted.ci.sp.endate.yaml
@@ -55,7 +55,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: "Extend Azure AD Application password on `trusted.ci.jenkins.io` (current end date: {{ source \"currentEndDate\" }})"
+      title: 'Extend Azure AD Application password on `trusted.ci.jenkins.io` (current end date: {{ source "currentEndDate" }})'
       description: |
         This PR generates a new Azure AD application password with a new end date for the `trusted.ci.jenkins.io` controller (to allow spawning Azure VM agents).
         Once this PR is merged and deployed with success by Terraform (on infra.ci.jenkins.io), you can retrieve the new password value from the Terraform state with `terraform show -json` then searching for the new password in `values.value` of the `module.trusted_ci_jenkins_io.azuread_application_password.controller` section (do NOT save it anywhere!) and (manually) update the trusted.ci.jenkins.io credential named `azure-jenkins-sponsorship-credentials` through the Jenkins UI.


### PR DESCRIPTION
This PR adds current end date to PR titles.

It also renames the templates as .tpl instead of .yaml, replaces "ExpiryDate" by "EndDate", ignores yamllint "line too long" rule, adds labels and lints the manifests.