### PR TITLE
chore: bump Terraform to 1.9.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.6, <1.7"
+  required_version = ">= 1.9, <1.10"
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4164

This PR bumps Terraform to 1.9.x and shared tools to their latest version