### PR TITLE
fix(publick8s) allow cluster to manage network of public IPs

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -196,6 +196,13 @@ resource "azurerm_role_assignment" "publick8s_ipv6_networkcontributor" {
   skip_service_principal_aad_check = true
 }
 
+resource "azurerm_role_assignment" "public_ips_networkcontributor" {
+  scope                            = azurerm_resource_group.prod_public_ips.id
+  role_definition_name             = "Network Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}
+
 resource "kubernetes_storage_class" "managed_csi_premium_retain_public" {
   metadata {
     name = "managed-csi-premium-retain"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4206

This PR allows the cluster to fully manages IPs in this RG.

