### PR TITLE
feat(ci.jenkins.io) create resource to ensure an internal LB can be setup to reach ACP in the ci.jenkins.io-agents1 cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tfplan
 # sensitive files from terraform outputs
 .env*
 *.zip
+jenkins-infra-data-reports

--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -168,6 +168,15 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
   tags = local.default_tags
 }
 
+# Allow AKS to manipulate LBs, PLS and join subnets - https://learn.microsoft.com/en-us/azure/aks/internal-lb?tabs=set-service-annotations#use-private-networks (see Note)
+resource "azurerm_role_assignment" "cijio_agents_networkcontributor_vnet" {
+  provider                         = azurerm.jenkins-sponsorship
+  scope                            = data.azurerm_virtual_network.public_jenkins_sponsorship.id
+  role_definition_name             = "Network Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.cijenkinsio_agents_1.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}
+
 # Configure the jenkins-infra/kubernetes-management admin service account
 module "cijenkinsio_agents_1_admin_sa" {
   providers = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,8 @@
+resource "local_file" "jenkins_infra_data_report" {
+  content = jsonencode({
+    "artifact-caching-proxy.privatelink.azurecr.io" = {
+      "service_ip" = azurerm_private_dns_a_record.artifact_caching_proxy,
+    },
+  })
+  filename = "${path.module}/jenkins-infra-data-reports/azure-net.json"
+}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2278334260

This PR introduces the following changes to allow ci.jenkins.io VM agents to access the private ACP in the `ci.jenkins.io-agents1` AKS cluster (instead of the azure.repo.jenkins.io ACP in the `publick8s` cluster):

- Allow the AKS cluster identity to manage Network on the whole Vnet (as per the Azure documentation - see comment)
  - Required to create LB and NIC in both subnets. We could restrict a bit more but wouldn't protect us.
- Create private DNS records in the private DNS zone of the ci.jenkins.io vnet to point to thge internal ACP LB.
  - Note: I moved the 2 existing DNS record close to this one. Only visual.
- Add NSG in/out rules in the ci.jenkibns.io ephemeral (VM- agents subnet to allow HTTP request on the port `8080` of the internal ACP loadbalancer
- Update shared tools
  - Usual "keep up to date"
- Generate an infra report for reports.jenkins.io to export the private IP. It will allow us to automate the Kubernetes Service LB annotations


----

Testing: I applied these changes manually and verified it's working by creating an additional LB with the YAML below on the AKS cluster.
Then I was able to emit curl request to ACP using the DNS on the port `8080` \o/

Finally: clean up all of these (both Terraform and AKS) resources.