### PR TITLE
feat(publick8s) allow cluster to manage private data dtier subnet to allow creating internal LB

### DIFF
--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -252,7 +252,7 @@ resource "azurerm_role_assignment" "datatier_networkcontributor" {
   skip_service_principal_aad_check = true
 }
 
-# Allow cluster to manage LBs in the data-tier subnet (internal LBs)
+# Allow cluster to manage private IP
 resource "azurerm_role_assignment" "publicip_networkcontributor" {
   scope                            = azurerm_public_ip.public_privatek8s.id
   role_definition_name             = "Network Contributor"

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -164,9 +164,17 @@ resource "azurerm_role_assignment" "publick8s_networkcontributor" {
   skip_service_principal_aad_check = true
 }
 
+## TODO: remove once private ingress moved to private vnet
 # Allow cluster to manage LBs in the public-vnet-data-tier subnet (internal LBs)
 resource "azurerm_role_assignment" "public_vnet_data_tier_networkcontributor" {
   scope                            = data.azurerm_subnet.public_vnet_data_tier.id
+  role_definition_name             = "Network Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}
+# Allow cluster to manage LBs in the private-vnet-data-tier subnet (internal LBs)
+resource "azurerm_role_assignment" "private_vnet_data_tier_networkcontributor" {
+  scope                            = data.azurerm_subnet.private_vnet_data_tier.id
   role_definition_name             = "Network Contributor"
   principal_id                     = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
   skip_service_principal_aad_check = true


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2294769030,

it appeared that we want the `publick8s` cluster to manage LB in the private data subnet of the **private** network as the private ingress is only expected to be accessed through the private VPN.

It also allows trusted.ci to access it (through the vnet peering trusted -> private).