### PR TITLE
feat(infracijioagents1): Upgrade cluster to kub 1.29.8

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -45,7 +45,7 @@ locals {
 
   kubernetes_versions = {
     "cijenkinsio_agents_1"      = "1.28.9"
-    "infracijenkinsio_agents_1" = "1.28.9"
+    "infracijenkinsio_agents_1" = "1.29.8"
     "privatek8s"                = "1.28.9"
     "publick8s"                 = "1.28.9"
   }


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4161#issuecomment-2299149540:

Upgrading the infracijenkinsio_agents_1 kubernetes cluster and node pools to kub 1.28.9.

We can proceed to check the terraform plan