### PR TITLE
hotfix(infra.ci.jenkins.io-agents1) use a supported version of AKS

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -45,7 +45,7 @@ locals {
 
   kubernetes_versions = {
     "cijenkinsio_agents_1"      = "1.28.9"
-    "infracijenkinsio_agents_1" = "1.29.8"
+    "infracijenkinsio_agents_1" = "1.29.7"
     "privatek8s"                = "1.28.9"
     "publick8s"                 = "1.28.9"
   }


### PR DESCRIPTION
Fixup of #806 

cc @jayfranco999 : we went a bit too quickly to set the version: `kubectl` (client side) is 1.29.8 which is the latest available 👍 
But the server side on AKS is not always the latest: Let's use https://github.com/Azure/AKS/releases in the future to validate prior to opening the PR ;)
