### PR TITLE
feat(mirrors.updates.jio): remove old redis and fmt

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ resource "local_file" "jenkins_infra_data_report" {
     },
     "public_redis" = {
       "service_hostname" = azurerm_redis_cache.public_redis.hostname,
-      "service_port" = azurerm_redis_cache.public_redis.port,
+      "service_port"     = azurerm_redis_cache.public_redis.port,
     },
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure.json"

--- a/public-redis.tf
+++ b/public-redis.tf
@@ -25,7 +25,7 @@ resource "azurerm_redis_cache" "public_redis" {
 resource "azurerm_private_dns_zone" "public_redis" {
   # Conventional and static name required by Azure (otherwise automatic record creation does not work)
   # https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
-  name     = "privatelink.redis.cache.windows.net"
+  name = "privatelink.redis.cache.windows.net"
 
   # Private DNS zone name is static: we can only have one per RG
   resource_group_name = data.azurerm_subnet.publick8s_tier.resource_group_name

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -64,29 +64,6 @@ output "updates_jenkins_io_redirections_fileshare_name" {
   value = azurerm_storage_share.updates_jenkins_io_httpd.name
 }
 
-# Redis database
-resource "azurerm_redis_cache" "updates_jenkins_io" {
-  name                = "updates-jenkins-io"
-  location            = azurerm_resource_group.updates_jenkins_io.location
-  resource_group_name = azurerm_resource_group.updates_jenkins_io.name
-  capacity            = 1
-  family              = "C"        # Basic/Standard SKU family
-  sku_name            = "Standard" # A replicated cache in a two node Primary/Secondary configuration managed by Microsoft, with a high availability SLA.
-  enable_non_ssl_port = true
-  minimum_tls_version = "1.2"
-
-  tags = local.default_tags
-}
-
-output "updates_jenkins_io_redis_hostname" {
-  value = azurerm_redis_cache.updates_jenkins_io.hostname
-}
-
-output "updates_jenkins_io_redis_primary_access_key" {
-  sensitive = true
-  value     = azurerm_redis_cache.updates_jenkins_io.primary_access_key
-}
-
 # Azure service CNAME records
 resource "azurerm_dns_cname_record" "azure_updates_jenkins_io" {
   name                = "azure.updates"


### PR DESCRIPTION
Cleanup old redis instance since #811 is in used by https://github.com/jenkins-infra/kubernetes-management/pull/5642

Related to https://github.com/jenkins-infra/helpdesk/issues/4259