### PR TITLE
hotfix(updates.jenkins.io) migrate CNAME DNS records to azure-net

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -64,25 +64,6 @@ output "updates_jenkins_io_redirections_fileshare_name" {
   value = azurerm_storage_share.updates_jenkins_io_httpd.name
 }
 
-# Azure service CNAME records
-resource "azurerm_dns_cname_record" "azure_updates_jenkins_io" {
-  name                = "azure.updates"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  record              = azurerm_dns_a_record.public_publick8s.fqdn
-  tags                = local.default_tags
-}
-
-resource "azurerm_dns_cname_record" "mirrors_updates_jenkins_io" {
-  name                = "mirrors.updates"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  record              = azurerm_dns_a_record.public_publick8s.fqdn
-  tags                = local.default_tags
-}
-
 ## NS records for each CloudFlare zone defined in https://github.com/jenkins-infra/cloudflare/blob/main/updates.jenkins.io.tf
 # West Europe
 resource "azurerm_dns_ns_record" "updates_jenkins_io_cloudflare_zone_westeurope" {


### PR DESCRIPTION
As these names are sensitive and should be managed in the same way as other publick8s records.

We initially set them here during the new Update Center experiment but the Update Center initial brownout (see https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2330934069) showed us that care is needed now that we promote these service to production grade.

- Terraform job is disabled: no checks
- Ran the following command to remove the elements from the state (as it's now managed in azure-net since <>):

  ```
  terraform state rm azurerm_dns_cname_record.azure_updates_jenkins_io
  terraform state rm azurerm_dns_cname_record.mirrors_updates_jenkins_io
  ```
  - Note: we did not try using https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources as it's new to us and DNS are too sensitive to "try" a new thing on it
- The local `terraform plan` says: `No changes. Your infrastructure matches the configuration.`