### PR TITLE
chore(updates.jenkins.io) fix failing tests by cleaning up (already) imported resource

### DIFF
--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -70,11 +70,7 @@ output "updates_jenkins_io_redirections_fileshare_name" {
   value = azurerm_storage_share.updates_jenkins_io_redirects.name
 }
 
-## Kubernetes Resources (statci provision of persistent volumes)
-import {
-  to = kubernetes_namespace.updates_jenkins_io
-  id = "updates-jenkins-io"
-}
+## Kubernetes Resources (static provision of persistent volumes)
 resource "kubernetes_namespace" "updates_jenkins_io" {
   provider = kubernetes.publick8s
 


### PR DESCRIPTION
The hotfix commit https://github.com/jenkins-infra/azure/commit/62f7910ae5f53d398d4d9455cb32f8af73bb1e7e added a forgotten `import { }` block as a fixup #840.
It fixed the production but the staging is now failing due to this block (as there are NO Kubernetes namespace reachable in the staging).

This PR cleans up the code by removing the `import {}` which fixes the staging build