### PR TITLE
fix(outputs) ensure outputs required by trusted.ci.jenkins.io are defined

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,3 +10,33 @@ resource "local_file" "jenkins_infra_data_report" {
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure.json"
 }
+
+## The script <https://github.com/jenkins-infra/charts-secrets/blob/main/config/trusted.ci.jenkins.io/get-uc-sync-zip-credential.sh>
+## requires the following output for generating trusted.ci.jenkins.io's Update Center ZIP credentials
+## used by https://github.com/jenkins-infra/update-center2 and https://github.com/jenkins-infra/crawler
+# From updates.jenkins.io.tf #
+output "updates_jenkins_io_storage_account_name" {
+  value = azurerm_storage_account.updates_jenkins_io.name
+}
+output "updates_jenkins_io_content_fileshare_name" {
+  value = azurerm_storage_share.updates_jenkins_io.name
+}
+output "updates_jenkins_io_redirections_fileshare_name" {
+  value = azurerm_storage_share.updates_jenkins_io_redirects.name
+}
+# From trusted.ci.jenkins.io.tf #
+output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_application_client_secret" {
+  sensitive = true
+  value     = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
+}
+output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_application_client_secret" {
+  sensitive = true
+  value     = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
+}
+## End

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -40,18 +40,10 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
   }
 }
 
-output "updates_jenkins_io_storage_account_name" {
-  value = azurerm_storage_account.updates_jenkins_io.name
-}
-
 resource "azurerm_storage_share" "updates_jenkins_io" {
   name                 = "updates-jenkins-io"
   storage_account_name = azurerm_storage_account.updates_jenkins_io.name
   quota                = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
-}
-
-output "updates_jenkins_io_content_fileshare_name" {
-  value = azurerm_storage_share.updates_jenkins_io.name
 }
 
 # TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
@@ -64,10 +56,6 @@ resource "azurerm_storage_share" "updates_jenkins_io_redirects" {
   name                 = "updates-jenkins-io-redirects"
   storage_account_name = azurerm_storage_account.updates_jenkins_io.name
   quota                = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
-}
-
-output "updates_jenkins_io_redirections_fileshare_name" {
-  value = azurerm_storage_share.updates_jenkins_io_redirects.name
 }
 
 ## Kubernetes Resources (static provision of persistent volumes)


### PR DESCRIPTION
Fixup of #838 and #839

We need to keep some outputs. This PR either move them or add them back but in the `outputs.tf` file which is the Terraform convention.

Note: adding a comment explaining which script is using them.