### PR TITLE
feat(updates.jenkins.io) add outputs and missing Azure SP to allow using new credentials

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,36 +7,55 @@ resource "local_file" "jenkins_infra_data_report" {
       "service_hostname" = azurerm_redis_cache.public_redis.hostname,
       "service_port"     = azurerm_redis_cache.public_redis.port,
     },
+    "updates.jenkins.io" = {
+      "content" = {
+        "share_name" = azurerm_storage_share.updates_jenkins_io.name,
+        "share_uri"  = "/",
+      },
+      # TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
+      "redirections" = {
+        "share_name" = azurerm_storage_share.updates_jenkins_io_httpd.name,
+        "share_uri"  = "/",
+      },
+      "redirections-unsecured" = {
+        "share_name" = azurerm_storage_share.updates_jenkins_io_redirects.name
+        "share_uri"  = "/unsecured/",
+      },
+      "redirections-secured" = {
+        "share_name" = azurerm_storage_share.updates_jenkins_io_redirects.name
+        "share_uri"  = "/secured/",
+      },
+    },
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure.json"
+}
+output "jenkins_infra_data_report" {
+  value = local_file.jenkins_infra_data_report.content
 }
 
 ## The script <https://github.com/jenkins-infra/charts-secrets/blob/main/config/trusted.ci.jenkins.io/get-uc-sync-zip-credential.sh>
 ## requires the following output for generating trusted.ci.jenkins.io's Update Center ZIP credentials
 ## used by https://github.com/jenkins-infra/update-center2 and https://github.com/jenkins-infra/crawler
-# From updates.jenkins.io.tf #
-output "updates_jenkins_io_storage_account_name" {
-  value = azurerm_storage_account.updates_jenkins_io.name
-}
-output "updates_jenkins_io_content_fileshare_name" {
-  value = azurerm_storage_share.updates_jenkins_io.name
-}
-output "updates_jenkins_io_redirections_fileshare_name" {
-  value = azurerm_storage_share.updates_jenkins_io_redirects.name
-}
-# From trusted.ci.jenkins.io.tf #
-output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_application_client_id" {
-  value = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
-}
-output "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer_application_client_secret" {
+output "trusted_ci_jenkins_io_updatesjenkinsio_credentials" {
   sensitive = true
-  value     = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
+  value = jsonencode({
+    "storage_name" = azurerm_storage_account.updates_jenkins_io.name,
+    "content" = {
+      "azure_client_id"       = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id,
+      "azure_client_password" = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password,
+    },
+    # TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
+    "redirections" = {
+      "azure_client_id"       = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id,
+      "azure_client_password" = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password,
+    },
+    "redirections-unsecured" = {
+      "azure_client_id"       = module.trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id,
+      "azure_client_password" = module.trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password,
+    },
+    "redirections-secured" = {
+      "azure_client_id"       = module.trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id,
+      "azure_client_password" = module.trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password,
+    },
+  })
 }
-output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_application_client_id" {
-  value = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
-}
-output "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer_application_client_secret" {
-  sensitive = true
-  value     = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
-}
-## End

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -85,7 +85,7 @@ module "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer" {
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }
-# Required to allow azcopy sync of updates.jenkins.io File Share (redirections) with the permanent agent
+# TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
 module "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
@@ -94,6 +94,18 @@ module "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_write
   active_directory_url           = "https://github.com/jenkins-infra/azure"
   service_principal_end_date     = "2024-12-18T00:00:00Z"
   file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io_httpd.resource_manager_id
+  storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
+  default_tags                   = local.default_tags
+}
+# Required to allow azcopy sync of updates.jenkins.io File Share (redirections) with the permanent agent
+module "trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer" {
+  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+
+  service_fqdn                   = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer-redirects"
+  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
+  active_directory_url           = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date     = "2024-12-18T00:00:00Z"
+  file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io_redirects.resource_manager_id
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

This PR adds a missing Azure SP to allow trusted.ci to write data into the new `redirects` UC file share and sets up outputs to ease the credential ZIP script generation.