### PR TITLE
feat(updates.jenkins.io) define statically provisioned PVCs for mirrorbits data and geoipdata

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,22 +9,25 @@ resource "local_file" "jenkins_infra_data_report" {
     },
     "updates.jenkins.io" = {
       "content" = {
-        "share_name" = azurerm_storage_share.updates_jenkins_io.name,
+        "share_name" = azurerm_storage_share.updates_jenkins_io_content.name,
         "share_uri"  = "/",
-      },
-      # TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
-      "redirections" = {
-        "share_name" = azurerm_storage_share.updates_jenkins_io_httpd.name,
-        "share_uri"  = "/",
+        "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_content.metadata[0].name,
       },
       "redirections-unsecured" = {
         "share_name" = azurerm_storage_share.updates_jenkins_io_redirects.name
         "share_uri"  = "/unsecured/",
+        "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_redirects.metadata[0].name,
       },
       "redirections-secured" = {
         "share_name" = azurerm_storage_share.updates_jenkins_io_redirects.name
         "share_uri"  = "/secured/",
+        "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_redirects.metadata[0].name,
       },
+      "geoip_data" = {
+        "share_name" = azurerm_storage_share.geoip_data.name
+        "share_uri"  = "/",
+        "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_geoipdata.metadata[0].name,
+      }
     },
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure.json"

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -81,7 +81,7 @@ module "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer" {
   active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
   active_directory_url           = "https://github.com/jenkins-infra/azure"
   service_principal_end_date     = "2024-12-18T00:00:00Z"
-  file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io.resource_manager_id
+  file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io_content.resource_manager_id
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }


### PR DESCRIPTION
Since https://github.com/jenkins-infra/helm-charts/pull/1339, we can specify existing PVC for mirrorbits usage.

This PR defines statically provisioned (with the new typo-less storage class) volumes for the mirrorbits and geoip datas for (mirrors.)updates.jenkins.io.

It will allows us to have less setup and config in kubernetes management while keeping persistent volume under terraform control