### PR TITLE
cleanup(updates.jenkins.io) remove deprecated httpd file share

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -47,11 +47,6 @@ output "trusted_ci_jenkins_io_updatesjenkinsio_credentials" {
       "azure_client_id"       = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id,
       "azure_client_password" = module.trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password,
     },
-    # TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
-    "redirections" = {
-      "azure_client_id"       = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id,
-      "azure_client_password" = module.trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password,
-    },
     "redirections-unsecured" = {
       "azure_client_id"       = module.trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id,
       "azure_client_password" = module.trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password,

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -85,18 +85,6 @@ module "trustedci_updatesjenkinsio_content_fileshare_serviceprincipal_writer" {
   storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
   default_tags                   = local.default_tags
 }
-# TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
-module "trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
-
-  service_fqdn                   = "${module.trusted_ci_jenkins_io.service_fqdn}-fileshare_serviceprincipal_writer-httpd"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2024-12-18T00:00:00Z"
-  file_share_resource_manager_id = azurerm_storage_share.updates_jenkins_io_httpd.resource_manager_id
-  storage_account_id             = azurerm_storage_account.updates_jenkins_io.id
-  default_tags                   = local.default_tags
-}
 # Required to allow azcopy sync of updates.jenkins.io File Share (redirections) with the permanent agent
 module "trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -92,7 +92,7 @@ end_dates:
         https://github.com/jenkins-infra/charts-secrets/blob/main/config/trusted.ci.jenkins.io/get-uc-sync-zip-credential.sh.
         > ⚠️ Make sure you can generate this ZIP file BEFORE merging the pull request here!
         > ⚠️ Check if you don't have other PR to related to the same ZIP credential to only generates the ZIP once.
-    trustedci_updatesjenkinsio_redirections_fileshare_serviceprincipal_writer:
+    trustedci_updatesjenkinsio_redirects_fileshare_serviceprincipal_writer:
       service: "updates.jenkins.io (redirections)"
       doc_how_to_get_credential: |
         > [!IMPORTANT]

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -39,20 +39,8 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
     bypass = ["Metrics", "Logging", "AzureServices"]
   }
 }
-
-moved {
-  from = azurerm_storage_share.updates_jenkins_io
-  to   = azurerm_storage_share.updates_jenkins_io_content
-}
 resource "azurerm_storage_share" "updates_jenkins_io_content" {
   name                 = "updates-jenkins-io"
-  storage_account_name = azurerm_storage_account.updates_jenkins_io.name
-  quota                = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
-}
-
-# TODO: remove once migration to 'updates_jenkins_io_redirect' is complete
-resource "azurerm_storage_share" "updates_jenkins_io_httpd" {
-  name                 = "updates-jenkins-io-httpd"
   storage_account_name = azurerm_storage_account.updates_jenkins_io.name
   quota                = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

This PR removes the (now) unused httpd file share and associated resources