### PR TITLE
fix(updates.jenkins.io) fix the geoip data PV setup to use correct RG and node secret

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -492,37 +492,37 @@ resource "azurerm_dns_a_record" "trusted_bounce" {
 ## Private endpoints
 ####################################################################################
 ## updates.jenkins.io's mirrorbits CLI Kubernetes Service (internal LB)
-data "azurerm_private_link_service" "updates_jenkins_io_cli" {
-  # https://github.com/jenkins-infra/kubernetes-management/blob/67e5741bf926c72c143604301132cbe6ada0bab8/config/updates.jenkins.io.yaml#L126
-  name                = "updates.jenkins.io-cli"
-  resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
-}
+# data "azurerm_private_link_service" "updates_jenkins_io_cli" {
+#   # https://github.com/jenkins-infra/kubernetes-management/blob/67e5741bf926c72c143604301132cbe6ada0bab8/config/updates.jenkins.io.yaml#L126
+#   name                = "updates.jenkins.io-cli"
+#   resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
+# }
 
-resource "azurerm_private_endpoint" "updates_jio_mirrorbits_cli_for_trustedci" {
-  name = "${data.azurerm_private_link_service.updates_jenkins_io_cli.name}-for-trustedci"
+# resource "azurerm_private_endpoint" "updates_jio_mirrorbits_cli_for_trustedci" {
+#   name = "${data.azurerm_private_link_service.updates_jenkins_io_cli.name}-for-trustedci"
 
-  location            = var.location
-  resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.resource_group_name
-  subnet_id           = data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.id
+#   location            = var.location
+#   resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.resource_group_name
+#   subnet_id           = data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.id
 
-  custom_network_interface_name = "${data.azurerm_private_link_service.updates_jenkins_io_cli.name}-for-trustedci-nic"
+#   custom_network_interface_name = "${data.azurerm_private_link_service.updates_jenkins_io_cli.name}-for-trustedci-nic"
 
-  private_service_connection {
-    name                           = "${data.azurerm_private_link_service.updates_jenkins_io_cli.name}-for-trustedci"
-    private_connection_resource_id = data.azurerm_private_link_service.updates_jenkins_io_cli.id
-    is_manual_connection           = false
-  }
-  private_dns_zone_group {
-    name                 = "trusted.ci.jenkins.io"
-    private_dns_zone_ids = [azurerm_private_dns_zone.trusted.id]
-  }
-  tags = local.default_tags
-}
+#   private_service_connection {
+#     name                           = "${data.azurerm_private_link_service.updates_jenkins_io_cli.name}-for-trustedci"
+#     private_connection_resource_id = data.azurerm_private_link_service.updates_jenkins_io_cli.id
+#     is_manual_connection           = false
+#   }
+#   private_dns_zone_group {
+#     name                 = "trusted.ci.jenkins.io"
+#     private_dns_zone_ids = [azurerm_private_dns_zone.trusted.id]
+#   }
+#   tags = local.default_tags
+# }
 
-resource "azurerm_private_dns_a_record" "updates_jio_mirrorbits_cli_for_trustedci" {
-  name                = "updates.jio-cli"
-  zone_name           = azurerm_private_dns_zone.trusted.name
-  resource_group_name = data.azurerm_resource_group.trusted_ci_jenkins_io.name
-  ttl                 = 60
-  records             = [azurerm_private_endpoint.updates_jio_mirrorbits_cli_for_trustedci.private_service_connection[0].private_ip_address]
-}
+# resource "azurerm_private_dns_a_record" "updates_jio_mirrorbits_cli_for_trustedci" {
+#   name                = "updates.jio-cli"
+#   zone_name           = azurerm_private_dns_zone.trusted.name
+#   resource_group_name = data.azurerm_resource_group.trusted_ci_jenkins_io.name
+#   ttl                 = 60
+#   records             = [azurerm_private_endpoint.updates_jio_mirrorbits_cli_for_trustedci.private_service_connection[0].private_ip_address]
+# }

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -195,12 +195,12 @@ resource "kubernetes_persistent_volume" "updates_jenkins_io_geoipdata" {
         volume_handle = "${kubernetes_secret.updates_jenkins_io_storage.metadata[0].namespace}-${azurerm_storage_share.geoip_data.name}"
         read_only     = true
         volume_attributes = {
-          resourceGroup = azurerm_resource_group.updates_jenkins_io.name
+          resourceGroup = azurerm_resource_group.publick8s.name
           shareName     = azurerm_storage_share.geoip_data.name
         }
         node_stage_secret_ref {
-          name      = kubernetes_secret.updates_jenkins_io_storage.metadata[0].name
-          namespace = kubernetes_secret.updates_jenkins_io_storage.metadata[0].namespace
+          name      = kubernetes_secret.geoip_data.metadata[0].name
+          namespace = kubernetes_secret.geoip_data.metadata[0].namespace
         }
       }
     }


### PR DESCRIPTION
The PR https://github.com/jenkins-infra/kubernetes-management/pull/5749 failed to deploy with the following error in the pod events (when CSI tried to mount the GeoIPdata volume):

```text
Please refer to http://aka.ms/filemounterror for possible causes and solutions for mount errors.
  Warning  FailedMount  18s (x5 over 4m27s)  kubelet  MountVolume.MountDevice failed for volume "updates-jenkins-io-geoip-data" : rpc error: code = Internal desc = volume(updates-jenkins-io-geoip-data) mount //updatesjenkinsio.file.core.windows.net/geoip-data on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/0b6c3f7f2c0a4af88a040c48736703c5803f01808f4814df3d538ac17fc590c0/globalmount failed with mount failed: exit status 32
Mounting command: mount
Mounting arguments: -t cifs -o ro,file_mode=0777,dir_mode=0777,actimeo=30,mfsymlinks,nosharesock,<masked> //updatesjenkinsio.file.core.windows.net/geoip-data /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/0b6c3f7f2c0a4af88a040c48736703c5803f01808f4814df3d538ac17fc590c0/globalmount
Output: mount error(2): No such file or directory
Refer to the mount.cifs(8) manual page (e.g. man mount.cifs) and kernel log messages (dmesg)
```

This PR is a fixup of #845 aims to fix this error by correcting the GeoIP data PV definition in updates.jenkins.io with:
- Proper resource group name (copy and paste error)
- Proper node secret references (copy and paste error)


Note: the commit is associated to "forgetting" the private endpoint resources:

```
$ terraform state rm azurerm_private_endpoint.updates_jio_mirrorbits_cli_for_trustedci
$ terraform state rm azurerm_private_dns_a_record.updates_jio_mirrorbits_cli_for_trustedci
```

until the PLS is re-created by kubernetes management