### PR TITLE
Revert "New end date for `docs.jenkins.io` File Share service principal writer on `infra.ci.jenkins.io` (current: 2024-10-17T00:00:00Z)"

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -68,7 +68,7 @@ end_dates:
       service: "contributors.jenkins.io"
       secret: "CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
     infraci_docsjenkinsio_fileshare_serviceprincipal_writer:
-      end_date: 2025-01-09T00:00:00Z
+      end_date: 2024-10-17T00:00:00Z
       service: "docs.jenkins.io"
       secret: "DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
     infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer:


### PR DESCRIPTION
Reverts jenkins-infra/azure#851

until we have problems with arm node pool for infra.ci agents