### PR TITLE
hotfix(reports) remove the custom domain associated to the storage account

### DIFF
--- a/reports.jenkins.io.tf
+++ b/reports.jenkins.io.tf
@@ -18,11 +18,6 @@ resource "azurerm_storage_account" "prodjenkinsreports" {
   https_traffic_only_enabled = true
   min_tls_version            = "TLS1_2"
 
-  custom_domain {
-    name          = "reports.jenkins.io"
-    use_subdomain = false
-  }
-
   tags = {
     scope = "terraform-managed"
   }


### PR DESCRIPTION
Hot fixup of 

Fix the error:

```
performing Create: unexpected status 409 (409 Conflict) with error: StorageDomainNameCouldNotVerify: The custom domain name could not be verified. CNAME mapping from reports.jenkins.io to any of prodjenkinsreports.blob.core.windows.net,prodjenkinsreports.z20.web.core.windows.net does not exist.
```