### PR TITLE
fix(trusted.ci/ephemeral-agents) add NSG rules to allow access the PE

### DIFF
--- a/modules/private-resources/outputs.tf
+++ b/modules/private-resources/outputs.tf
@@ -5,3 +5,7 @@ output "zone_name" {
 output "zone_id" {
   value = var.dns_zone_name == "" ? azurerm_private_dns_zone.dnszone[0].id : data.azurerm_private_dns_zone.existing_dnszone[0].id
 }
+
+output "endpoint_ip" {
+  value = azurerm_private_endpoint.pe.private_service_connection[0].private_ip_address
+}

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -333,12 +333,8 @@ resource "azurerm_network_security_rule" "allow_out_many_from_trusted_ephemeral_
     "3390", # mirrorbits CLI (content-secured)
     "3391", # mirrorbits CLI (content-unsecured)
   ]
-  source_address_prefixes = data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefixes
-  destination_address_prefixes = distinct(
-    flatten(
-      [for rs in azurerm_private_endpoint.dockerhub_mirror["trustedcijenkinsio"].private_dns_zone_configs.*.record_sets : rs.*.ip_addresses]
-    )
-  )
+  source_address_prefixes     = data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefixes
+  destination_address_prefix  = module.trustedci_ephemeral_agents_private_resources.endpoint_ip
   resource_group_name         = azurerm_resource_group.trusted_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4402#issuecomment-2506556409

The goal is to fix the error `ssh: connect to host updates.jenkins.io-data.trusted.ci.jenkins.io port 22: Connection timed out`