### PR TITLE
fix(db,updates.jio) correct and document network accesses to allow terraform from admin machines through VPN (instead of SSH tunnels)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,10 @@ In order to use this repository to provision the Jenkins infrastructure on azure
 git submodule update --init --recursive
 ----
 
+* Routing to database (private endpoints and private DNSes):
+** VPN access is required with routing to the database subnets set up to your user
+** As there are no public DNS, set up your local `/etc/hosts` (check the `providers.tf` for details)
+
 == HowTo
 
 === Provision

--- a/mysql-public-db.tf
+++ b/mysql-public-db.tf
@@ -1,3 +1,13 @@
+# NOTE: managing DB resources requires routes to database (private endpoints and private DNSes):
+# * Either:
+# ** VPN access is required with routing to the database subnets set up to your user,
+# ** OR running terraform in a subnet with a private endpoint access/routing to the DB subnet
+# * Also, as there are no public DNS, either:
+# ** Set up your local `/etc/hosts` (check the `providers.tf` for details),
+# ** OR have your subnet set up to use the private DNS records
+######
+# Dedicated subnet is reserved as "delegated" for the mysql server on the public network
+# Defined in https://github.com/jenkins-infra/azure-net/blob/main/vnets.tf
 data "azurerm_subnet" "public_db_vnet_mysql_tier" {
   name                 = "${data.azurerm_virtual_network.public_db.name}-mysql-tier"
   virtual_network_name = data.azurerm_virtual_network.public_db.name

--- a/postgres-public-db.tf
+++ b/postgres-public-db.tf
@@ -1,3 +1,12 @@
+# NOTE: managing DB resources requires routes to database (private endpoints and private DNSes):
+# * Either:
+# ** VPN access is required with routing to the database subnets set up to your user,
+# ** OR running terraform in a subnet with a private endpoint access/routing to the DB subnet
+# * Also, as there are no public DNS, either:
+# ** Set up your local `/etc/hosts` (check the `providers.tf` for details),
+# ** OR have your subnet set up to use the private DNS records
+
+######
 # Dedicated subnet is reserved as "delegated" for the pgsql server on the public network
 # Ref. https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking
 # Defined in https://github.com/jenkins-infra/azure-net/blob/main/vnets.tf

--- a/providers.tf
+++ b/providers.tf
@@ -45,12 +45,9 @@ provider "kubernetes" {
 
 provider "postgresql" {
   /**
-  Important: terraform must be allowed to reach this instance through the network. Check the followings:
-  - If running in Jenkins, ensure that the subnet of the agents is peered to the subnet of this postgreSQL instance
-    * Don't forget to also check the network security group rules
-  - If running locally, ensure that:
-    * your /etc/hosts defines an entry with <azurerm_postgresql_flexible_server.public.fqdn> to 127.0.0.1
-    * you've opened an SSH tunnel such as `ssh -L 5432:<azurerm_postgresql_flexible_server.public.fqdn>:5432` through a machine of the private network
+  Reaching this DB requires:
+  - VPN access (with proper routing)
+  - The following line added in your `/etc/hosts` as there are no public DNS: `10.253.0.4      public-db.postgres.database.azure.com`
   **/
   host      = azurerm_postgresql_flexible_server.public_db.fqdn
   username  = local.public_db_pgsql_admin_login
@@ -60,12 +57,9 @@ provider "postgresql" {
 
 provider "mysql" {
   /**
-  Important: terraform must be allowed to reach this instance through the network. Check the followings:
-  - If running in Jenkins, ensure that the subnet of the agents is peered to the subnet of this mysql instance
-    * Don't forget to also check the network security group rules
-  - If running locally, ensure that:
-    * your /etc/hosts defines an entry with <azurerm_mysql_flexible_server.public.fqdn> to 127.0.0.1
-    * you've opened an SSH tunnel such as `ssh -L 3306:<azurerm_mysql_flexible_server.public.fqdn>:3306` through a machine of the private network
+  Reaching this DB requires:
+  - VPN access (with proper routing)
+  - The following line added in your `/etc/hosts` as there are no public DNS: `10.253.0.4      public-db.postgres.database.azure.com`
   **/
   endpoint = "${azurerm_mysql_flexible_server.public_db_mysql.fqdn}:3306"
   username = local.public_db_mysql_admin_login

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -24,7 +24,11 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
   # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"
   network_rules {
     default_action = "Deny"
-
+    ip_rules = flatten(
+      concat(
+        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
+      )
+    )
     # Only NFS share means only private network access - https://learn.microsoft.com/en-us/azure/storage/files/files-nfs-protocol#security-and-networking
     virtual_network_subnet_ids = [
       data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,


### PR DESCRIPTION
Following work and discoveries by @smerle33 in https://github.com/jenkins-infra/docker-openvpn/pull/375 and https://github.com/jenkins-infra/docker-openvpn/pull/376

This PR corrects and documents the required accesses to allow us running `terraform plan` (before sending PRs) and `terraform apply` (hotfix/emergencies) from our admin machines.

- DBs routing is now fixed and using the VPN: documenting that `/etc/hosts` need to be updated (instead of using SSH tunnels) or using private subnets (infra.ci agents)
- Adding back the Update Center storage account IP restriction to the admin public IPs to avoid errors