### PR TITLE
feat(infra.ci.jenkins.io) allow WinRM from agents to anywhere

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -225,7 +225,10 @@ resource "azurerm_network_security_rule" "allow_outbound_winrm_http_from_infraci
   source_port_range           = "*"
   destination_port_range      = "5985"
   source_address_prefix       = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
-  destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
+  ## Restriction to only Azure private subnet
+  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
+  ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
+  destination_address_prefix = "*"
   resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }
@@ -240,7 +243,10 @@ resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infrac
   source_port_range           = "*"
   destination_port_range      = "5986"
   source_address_prefix       = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
-  destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
+  ## Restriction to only Azure private subnet
+  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
+  ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
+  destination_address_prefix = "*"
   resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/packer-images/pull/1611#issuecomment-2552011686

This PR allows WinRM outbound to *any* internet IP, as we can't determine in advance the public IPs of packer images in EC2.