### PR TITLE
chore(updatecli): provide a manifest to track geoip fileshare enddates

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -216,37 +216,37 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents
 
 # Allow infra.ci VM agents to reach packer VMs with WinRM (HTTP without TLS)
 resource "azurerm_network_security_rule" "allow_outbound_winrm_http_from_infraci_agents_to_packer_vms" {
-  provider                    = azurerm.jenkins-sponsorship
-  name                        = "allow-outbound-winrm-http-from-infraci-agents-to-packer-vms"
-  priority                    = 4081
-  direction                   = "Outbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "5985"
-  source_address_prefix       = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
+  provider               = azurerm.jenkins-sponsorship
+  name                   = "allow-outbound-winrm-http-from-infraci-agents-to-packer-vms"
+  priority               = 4081
+  direction              = "Outbound"
+  access                 = "Allow"
+  protocol               = "Tcp"
+  source_port_range      = "*"
+  destination_port_range = "5985"
+  source_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
   ## Restriction to only Azure private subnet
   # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
   ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
-  destination_address_prefix = "*"
+  destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }
 # Allow infra.ci VM agents to reach packer VMs with WinRM (HTTPS)
 resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infraci_agents_to_packer_vms" {
-  provider                    = azurerm.jenkins-sponsorship
-  name                        = "allow-outbound-winrm-https-from-infraci-agents-to-packer-vms"
-  priority                    = 4082
-  direction                   = "Outbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "5986"
-  source_address_prefix       = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
+  provider               = azurerm.jenkins-sponsorship
+  name                   = "allow-outbound-winrm-https-from-infraci-agents-to-packer-vms"
+  priority               = 4082
+  direction              = "Outbound"
+  access                 = "Allow"
+  protocol               = "Tcp"
+  source_port_range      = "*"
+  destination_port_range = "5986"
+  source_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
   ## Restriction to only Azure private subnet
   # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
   ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
-  destination_address_prefix = "*"
+  destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_publick8s.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_publick8s.tf.tpl
@@ -1,0 +1,71 @@
+{{ range $key, $val := .end_dates.publick8s }}
+---
+# yamllint disable rule:line-length
+name: "Generate new end date for {{ $val.service }} File Share service principal writer on publick8s"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ $.github.user }}"
+      email: "{{ $.github.email }}"
+      owner: "{{ $.github.owner }}"
+      repository: "{{ $.github.repository }}"
+      token: "{{ requiredEnv $.github.token }}"
+      username: "{{ $.github.username }}"
+      branch: "{{ $.github.branch }}"
+
+sources:
+  currentEndDate:
+    name: Get current `end_date` date
+    kind: hcl
+    spec:
+      file: publick8s.tf
+      path: module.{{ $key }}.service_principal_end_date
+  nextEndDate:
+    name: Prepare next `end_date` date within 3 months
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/dateadd.sh
+      environments:
+        - name: PATH
+
+conditions:
+  checkIfEndDateSoonExpired:
+    kind: shell
+    sourceid: currentEndDate
+    spec:
+      # Current end_date date value passed as argument
+      command: bash ./updatecli/scripts/datediff.sh
+      environments:
+        - name: PATH
+
+targets:
+  updateNextEndDate:
+    name: 'New end date for `{{ $val.service }}` File Share service principal writer on `publick8s` (current: {{ source "currentEndDate" }})'
+    kind: hcl
+    sourceid: nextEndDate
+    spec:
+      file: publick8s.tf
+      path: module.{{ $key }}.service_principal_end_date
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: 'Azure File Share Principal `{{ $val.service }}` on `publick8s` expires on `{{ source "currentEndDate" }}`'
+      description: |
+        This PR updates the end date of {{ $val.service }} File Share service principal writer used in publick8s for geoip.
+
+        The current end date is set to `{{ source "currentEndDate" }}`.
+
+{{ $val.doc_how_to_get_credential | indent 8 }}
+
+      labels:
+        - terraform
+        - "{{ $val.service }}"
+        - end-dates
+        - publick8s
+{{ end }}

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -88,13 +88,31 @@ end_dates:
         > ⚠️ Merging this PR will prevent the "jenkins.io" deployment job to succeed and update the www.jenkins.io website.
         > You'll have to update the top-level credential `trustedci_jenkinsio_fileshare_serviceprincipal_writer` on trusted.ci.jenkins.io UI.
         >
-        > This credential value can be retrieved in the Terraform state from `module.trustedci_jenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password`.
+        > This credential value can be retrieved in the Terraform state from `module.trustedci_jenkinsio_fileshare_serviceprincipal_writer.azuread_application.fileshare_serviceprincipal_writer_application_client_password`.
     trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer:
       service: "javadoc.jenkins.io"
       doc_how_to_get_credential: |
         > [!IMPORTANT]
         >
-        > ⚠️ Merging this PR will prevent the "jenkins.io" deployment job to succeed and update the www.jenkins.io website.
+        > ⚠️ Merging this PR will prevent the "javadoc.jenkins.io" deployment job to succeed and update the www.jenkins.io website.
         > You'll have to update the top-level credential `trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer` on trusted.ci.jenkins.io UI.
         >
-        > This credential value can be retrieved in the Terraform state from `module.trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password`.
+        > This credential value can be retrieved in the Terraform state from `module.trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer.azuread_application.fileshare_serviceprincipal_writer_application_client_password`.
+  publick8s:
+    cronjob_geoip_data_fileshare_serviceprincipal_writer:
+      service: "geoip"
+      doc_how_to_get_credential: |
+        > [!IMPORTANT]
+        >
+        > ⚠️ Merging this PR will prevent the "geoip kubernetes cronjob" to succeed and update the mirrorbits geoip databases.
+        > You'll have to update the sops secrets `./secrets/config/geoipdata/secrets.yaml`
+        >
+        > This credential value can be retrieved in the Terraform state from `module.cronjob_geoip_data_fileshare_serviceprincipal_writer.azuread_application.fileshare_serviceprincipal_writer_application_client_password`.
+    cronjob_geoip_data_staging_fileshare_serviceprincipal_writer:
+      service: "geoip_staging"
+      doc_how_to_get_credential: |
+        > this is for the staging environment
+        > ⚠️ Merging this PR will prevent the "geoip kubernetes cronjob" to succeed and update the mirrorbits geoip databases.
+        > You'll have to update the sops secrets `./secrets/config/geoipdata/secrets.yaml`
+        >
+        > This credential value can be retrieved in the Terraform state from `module.cronjob_geoip_data_fileshare_serviceprincipal_writer.azuread_application.fileshare_serviceprincipal_writer_application_client_password`.


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4486
provide an updatecli manifest to track geoip expiration for the fileshare

(add a few corrections in docs and fmt)