### PR TITLE
feat(infra.ci.jenkins.io) updatecli azure SP rotation

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -418,7 +418,7 @@ resource "azuread_service_principal" "updatecli_infra_ci_jenkins_io" {
 resource "azuread_application_password" "updatecli_infra_ci_jenkins_io" {
   application_id = azuread_application.updatecli_infra_ci_jenkins_io.id
   display_name   = "updatecli_infra.ci.jenkins.io-tf-managed"
-  end_date       = "2025-01-18T00:00:00Z"
+  end_date       = "2025-04-18T00:00:00Z"
 }
 
 resource "azurerm_role_definition" "vm_images_reader" {


### PR DESCRIPTION
the SP for updatecli on azure has expired, this PR manually renew the SP.

nice to have an updatecli 

Plan: 2 to add, 0 to change, 1 to destroy. (1 add/1 destroy = report file)
```
-/+ resource "azuread_application_password" "updatecli_infra_ci_jenkins_io" {
      ~ end_date       = "2025-01-18T00:00:00Z" -> "2025-04-18T00:00:00Z" # forces replacement
```