### PR TITLE
chore(updatecli) track enddate for updatecli azure SP

### DIFF
--- a/updatecli/updatecli.d/updatecli-end-dates.yaml.tpl
+++ b/updatecli/updatecli.d/updatecli-end-dates.yaml.tpl
@@ -1,0 +1,75 @@
+{{ range $key, $val := .updatecli_end_dates }}
+{{ $hclFile := printf "%s%s" $key ".tf" }}
+{{ $hclKey := "module.controller_service_principal_end_date" }}
+{{ if (and $val $val.custom_hcl_key) }}
+  {{ $hclKey = $val.custom_hcl_key }}
+{{ end }}
+---
+# yamllint disable rule:line-length
+name: "Generate new end date for the {{ $key }} Azure AD Application password"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ $.github.user }}"
+      email: "{{ $.github.email }}"
+      owner: "{{ $.github.owner }}"
+      repository: "{{ $.github.repository }}"
+      token: "{{ requiredEnv $.github.token }}"
+      username: "{{ $.github.username }}"
+      branch: "{{ $.github.branch }}"
+
+sources:
+  currentEndDate:
+    name: Get current `end_date` date
+    kind: hcl
+    spec:
+      file: {{ $hclFile }}
+      path: {{ $hclKey }}
+  nextEndDate:
+    name: Prepare next `end_date` date within 3 months
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/dateadd.sh
+      environments:
+        - name: PATH
+
+conditions:
+  checkIfEndDateSoonExpired:
+    kind: shell
+    sourceid: currentEndDate
+    spec:
+      # Current end_date date value passed as argument
+      command: bash ./updatecli/scripts/datediff.sh
+      environments:
+        - name: PATH
+
+targets:
+  updateNextEndDate:
+    name: Update Terraform file `{{ $key }}.tf` with new expiration date
+    kind: hcl
+    sourceid: nextEndDate
+    spec:
+      file: {{ $hclFile }}
+      path: {{ $hclKey }}
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: 'Azure AD Application password for updatecli in `{{ $key }}` expires on `{{ source "currentEndDate" }}`'
+      description: |
+        This PR updates the Azure AD application password used in `{{ $key }}` for updatecli.
+
+        The current end date is set to `{{ source "currentEndDate" }}`.
+
+{{ $val.doc_how_to_get_credential | indent 8 }}
+
+      labels:
+        - azure-ad-application
+        - end-dates
+        - {{ $key }}
+{{ end }}

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -116,3 +116,20 @@ end_dates:
         > You'll have to update the sops secrets `./secrets/config/geoipdata/staging-secrets.yaml`
         >
         > This credential value can be retrieved in the Terraform state from `module.cronjob_geoip_data_staging_fileshare_serviceprincipal_writer.azuread_application_password.fileshare_serviceprincipal_writer`.
+updatecli_end_dates:
+  infra.ci.jenkins.io:
+    custom_hcl_key: resource.azuread_application_password.updatecli_infra_ci_jenkins_io.end_date
+    doc_how_to_get_credential: |
+      > [!IMPORTANT]
+      >
+      > ⚠️ Merging this PR will prevent updatecli to use `az` until the credential is updated on the controller.
+
+      You'll have to update the credential on infra.ci.jenkins.io's encrypted secrets:
+
+      - Update the secret value in jenkins-infra/chart-secrets (or kubernetes-management/secrets), add, commit and push the change
+      - Trigger a build of the `kubernetes-management` job on infra.ci.jenkins.io to ensure secret value is updated in Kubernetes secrets
+      - Finally, trigger a reload from jcasc or a controller restart (pod delete, or rollout) to make sure secrets are used to update the Jenkins credential.
+      - test by replaying a build on main `https://infra.ci.jenkins.io/job/updatecli/job/packer-images/job/main/` and check the logs for an azure check (⚠️ do not rely on green result)
+
+      The new password value, once the PR is merged and deployed, can be retrieved from the Terraform state,
+      by searching for `azuread_application_password.updatecli_infra_ci_jenkins_io.value`.


### PR DESCRIPTION
add a manifest to track expiration date for the azure SP used by updatecli: https://github.com/jenkins-infra/azure/blob/254bf2f183987146fc6c5fd487cbda765ccc786d/infra.ci.jenkins.io.tf#L421