### PR TITLE
chore(outputs) export endpoints of publick8s and privatek8s

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -15,7 +15,7 @@ data "azurerm_subnet" "ci_jenkins_io_kubernetes_sponsorship" {
 #trivy:ignore:avd-azu-0040 # No need to enable oms_agent for Azure monitoring as we already have datadog
 resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
   provider = azurerm.jenkins-sponsorship
-  name     = "cijenkinsio-agents-1"
+  name     = local.aks_clusters["cijenkinsio_agents_1"].name
   sku_tier = "Standard"
   ## Private cluster requires network setup to allow API access from:
   # - infra.ci.jenkins.io agents (for both terraform job agents and kubernetes-management agents)
@@ -26,7 +26,7 @@ resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
   dns_prefix                          = "cijenkinsioagents1" # Avoid hyphens in this DNS host
   location                            = azurerm_resource_group.cijenkinsio_kubernetes_agents.location
   resource_group_name                 = azurerm_resource_group.cijenkinsio_kubernetes_agents.name
-  kubernetes_version                  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  kubernetes_version                  = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
   role_based_access_control_enabled   = true # default value but made explicit to please trivy
 
   image_cleaner_interval_hours = 48
@@ -55,7 +55,7 @@ resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
     os_sku               = "AzureLinux"
     os_disk_type         = "Ephemeral"
     os_disk_size_gb      = 75 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
-    orchestrator_version = local.kubernetes_versions["cijenkinsio_agents_1"]
+    orchestrator_version = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
     kubelet_disk_type    = "OS"
     auto_scaling_enabled = true
     min_count            = 2 # for best practices
@@ -80,7 +80,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_n2_applications" {
   os_disk_type          = "Ephemeral"
   os_sku                = "AzureLinux"
   os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  orchestrator_version  = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cijenkinsio_agents_1.id
   auto_scaling_enabled  = true
   min_count             = 1
@@ -114,7 +114,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_agents_1" {
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  orchestrator_version  = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cijenkinsio_agents_1.id
   auto_scaling_enabled  = true
   min_count             = 0
@@ -148,7 +148,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["cijenkinsio_agents_1"]
+  orchestrator_version  = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.cijenkinsio_agents_1.id
   auto_scaling_enabled  = true
   min_count             = 0

--- a/infraci.jenkins.io-kubernetes-sponsored-agents.tf
+++ b/infraci.jenkins.io-kubernetes-sponsored-agents.tf
@@ -15,7 +15,7 @@ data "azurerm_subnet" "infraci_jenkins_io_kubernetes_agent_sponsorship" {
 #trivy:ignore:avd-azu-0040 # No need to enable oms_agent for Azure monitoring as we already have datadog
 resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
   provider = azurerm.jenkins-sponsorship
-  name     = "infracijenkinsio-agents-1"
+  name     = local.aks_clusters["infracijenkinsio_agents_1"].name
   sku_tier = "Standard"
   ## Private cluster requires network setup to allow API access from:
   # - infra.ci.jenkins.io agents (for both terraform job agents and kubernetes-management agents)
@@ -25,7 +25,7 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
   dns_prefix                          = "infracijenkinsioagents1" # Avoid hyphens in this DNS host
   location                            = azurerm_resource_group.infracijio_kubernetes_agents_sponsorship.location
   resource_group_name                 = azurerm_resource_group.infracijio_kubernetes_agents_sponsorship.name
-  kubernetes_version                  = local.kubernetes_versions["infracijenkinsio_agents_1"]
+  kubernetes_version                  = local.aks_clusters["infracijenkinsio_agents_1"].kubernetes_version
   role_based_access_control_enabled   = true # default value but made explicit to please trivy
 
   image_cleaner_interval_hours = 48
@@ -54,7 +54,7 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
     os_sku               = "AzureLinux"
     os_disk_type         = "Ephemeral"
     os_disk_size_gb      = 75 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series (depends on the instance size)
-    orchestrator_version = local.kubernetes_versions["infracijenkinsio_agents_1"]
+    orchestrator_version = local.aks_clusters["infracijenkinsio_agents_1"].kubernetes_version
     kubelet_disk_type    = "OS"
     auto_scaling_enabled = true
     min_count            = 2 # for best practices
@@ -80,7 +80,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_agents_1_sponsorsh
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 300 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["infracijenkinsio_agents_1"]
+  orchestrator_version  = local.aks_clusters["infracijenkinsio_agents_1"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.infracijenkinsio_agents_1.id
   auto_scaling_enabled  = true
   min_count             = 0
@@ -115,7 +115,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_agents_1_sponsorshi
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dpdsv5-series?tabs=sizebasic (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["infracijenkinsio_agents_1"]
+  orchestrator_version  = local.aks_clusters["infracijenkinsio_agents_1"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.infracijenkinsio_agents_1.id
   auto_scaling_enabled  = true
   min_count             = 1 # Azure autoscaler with ARM64 is really slow when starting from zero nodes.

--- a/locals.tf
+++ b/locals.tf
@@ -45,11 +45,23 @@ locals {
 
   admin_username = "jenkins-infra-team"
 
-  kubernetes_versions = {
-    "cijenkinsio_agents_1"      = "1.29.11"
-    "infracijenkinsio_agents_1" = "1.29.11"
-    "privatek8s"                = "1.29.11"
-    "publick8s"                 = "1.29.11"
+  aks_clusters = {
+    "cijenkinsio_agents_1" = {
+      name               = "cijenkinsio-agents-1",
+      kubernetes_version = "1.29.11",
+    }
+    "infracijenkinsio_agents_1" = {
+      name               = "infracijenkinsio-agents-1",
+      kubernetes_version = "1.29.11",
+    }
+    "privatek8s" = {
+      name               = "privatek8s-${random_pet.suffix_privatek8s.id}",
+      kubernetes_version = "1.29.11",
+    }
+    "publick8s" = {
+      name               = "publick8s-${random_pet.suffix_publick8s.id}",
+      kubernetes_version = "1.29.11",
+    }
   }
 
   ci_jenkins_io_fqdn                 = "ci.jenkins.io"

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,12 @@ resource "local_file" "jenkins_infra_data_report" {
         "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_geoipdata.metadata[0].name,
       }
     },
+    "publick8s" = {
+      hostname = data.azurerm_kubernetes_cluster.publick8s.fqdn,
+    },
+    "privatek8s" = {
+      hostname = data.azurerm_kubernetes_cluster.privatek8s.fqdn,
+    },
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure.json"
 }

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -25,11 +25,11 @@ data "azurerm_subnet" "public_vnet_data_tier" {
 
 #trivy:ignore:azure-container-logging #trivy:ignore:azure-container-limit-authorized-ips
 resource "azurerm_kubernetes_cluster" "publick8s" {
-  name                              = "publick8s-${random_pet.suffix_publick8s.id}"
+  name                              = local.aks_clusters["publick8s"].name
   location                          = azurerm_resource_group.publick8s.location
   resource_group_name               = azurerm_resource_group.publick8s.name
-  kubernetes_version                = local.kubernetes_versions["publick8s"]
-  dns_prefix                        = "publick8s-${random_pet.suffix_publick8s.id}"
+  kubernetes_version                = local.aks_clusters["publick8s"].kubernetes_version
+  dns_prefix                        = local.aks_clusters["publick8s"].name
   role_based_access_control_enabled = true # default value but made explicit to please trivy
   api_server_access_profile {
     authorized_ip_ranges = setunion(
@@ -85,7 +85,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     kubelet_disk_type    = "OS"
     os_disk_type         = "Ephemeral"
     os_disk_size_gb      = 50
-    orchestrator_version = local.kubernetes_versions["publick8s"]
+    orchestrator_version = local.aks_clusters["publick8s"].kubernetes_version
     auto_scaling_enabled = true
     min_count            = 2
     max_count            = 4
@@ -101,12 +101,10 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
   tags = local.default_tags
 }
 
-
 data "azurerm_kubernetes_cluster" "publick8s" {
-  name                = "publick8s-${random_pet.suffix_publick8s.id}"
+  name                = local.aks_clusters["publick8s"].name
   resource_group_name = azurerm_resource_group.publick8s.name
 }
-
 
 resource "azurerm_kubernetes_cluster_node_pool" "x86small" {
   name    = "x86small"
@@ -116,7 +114,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "x86small" {
   }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 100 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["publick8s"]
+  orchestrator_version  = local.aks_clusters["publick8s"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.publick8s.id
   auto_scaling_enabled  = true
   min_count             = 0
@@ -139,7 +137,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "arm64small2" {
   }
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 150 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)
-  orchestrator_version  = local.kubernetes_versions["publick8s"]
+  orchestrator_version  = local.aks_clusters["publick8s"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.publick8s.id
   auto_scaling_enabled  = true
   min_count             = 0


### PR DESCRIPTION
This PR adds the hostname of the 2 "legacy" clusters (`publick8s` and `privatek8s`) to the infra report.

The goal is to allow Puppet and OpenVPN to access these information to keep the routing (to control planes through VPN).