### PR TITLE
 feat(ldap) provision statically the LDAP backup Azure File volume 

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -155,15 +155,15 @@ resource "azurerm_network_security_rule" "allow_outbound_https_from_cijio_to_cij
 
 ## Allow ci.jenkins.io to reach aws.ci.jenkins.io
 resource "azurerm_network_security_rule" "allow_outbound_ssh_from_cijio_to_awscijio" {
-  provider               = azurerm.jenkins-sponsorship
-  name                   = "allow-out-https-from-cijio-to-awscijio"
-  priority               = 3900
-  direction              = "Outbound"
-  access                 = "Allow"
-  protocol               = "Tcp"
-  source_port_range      = "*"
-  destination_port_range = "22"
-  source_address_prefix  = "*"
+  provider                     = azurerm.jenkins-sponsorship
+  name                         = "allow-out-https-from-cijio-to-awscijio"
+  priority                     = 3900
+  direction                    = "Outbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefix        = "*"
   destination_address_prefixes = ["3.146.166.108/32"]
   resource_group_name          = module.ci_jenkins_io_sponsorship.controller_resourcegroup_name
   network_security_group_name  = module.ci_jenkins_io_sponsorship.controller_nsg_name

--- a/imports.tf
+++ b/imports.tf
@@ -1,0 +1,11 @@
+# TODO: delete once https://github.com/jenkins-infra/azure/pull/940 is applied with success
+import {
+  to       = kubernetes_namespace.ldap
+  provider = kubernetes.publick8s
+  id       = "ldap"
+}
+# TODO: delete once https://github.com/jenkins-infra/azure/pull/940 is applied with success
+import {
+  to = azurerm_storage_share.ldap
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/ldap/providers/Microsoft.Storage/storageAccounts/ldapjenkinsiobackups/fileServices/default/shares/ldap"
+}

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -107,10 +107,6 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
   ]
   bypass = ["Metrics", "Logging", "AzureServices"]
 }
-import {
-  to = azurerm_storage_share.ldap
-  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/ldap/providers/Microsoft.Storage/storageAccounts/ldapjenkinsiobackups/fileServices/default/shares/ldap"
-}
 resource "azurerm_storage_share" "ldap" {
   name               = "ldap"
   storage_account_id = azurerm_storage_account.ldap_backups.id
@@ -119,11 +115,6 @@ resource "azurerm_storage_share" "ldap" {
 }
 
 ## Kubernetes Resources (static provision of persistent volumes)
-import {
-  to       = kubernetes_namespace.ldap
-  provider = kubernetes.publick8s
-  id       = "ldap"
-}
 resource "kubernetes_namespace" "ldap" {
   provider = kubernetes.publick8s
 

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -171,10 +171,10 @@ resource "kubernetes_persistent_volume" "ldap_jenkins_io_backup" {
         driver  = "file.csi.azure.com"
         fs_type = "ext4"
         # `volumeHandle` must be unique on the cluster for this volume
-        volume_handle = "${kubernetes_secret.ldap_jenkins_io_backup.metadata[0].namespace}-${azurerm_storage_share.ldap.name}"
+        volume_handle = "${azurerm_storage_share.ldap.name}-rwx"
         read_only     = false
         volume_attributes = {
-          resourceGroup = azurerm_resource_group.ldap.name
+          resourceGroup = azurerm_storage_account.ldap_backups.resource_group_name
           shareName     = azurerm_storage_share.ldap.name
         }
         node_stage_secret_ref {
@@ -187,8 +187,9 @@ resource "kubernetes_persistent_volume" "ldap_jenkins_io_backup" {
 }
 resource "kubernetes_persistent_volume_claim" "ldap_jenkins_io_backup" {
   provider = kubernetes.publick8s
+
   metadata {
-    name      = "ldap-jenkins-io-backup"
+    name      = kubernetes_persistent_volume.ldap_jenkins_io_backup.metadata[0].name
     namespace = kubernetes_secret.ldap_jenkins_io_backup.metadata[0].namespace
   }
   spec {

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -94,25 +94,121 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
   storage_account_id = azurerm_storage_account.ldap_backups.id
 
   default_action = "Deny"
-  ip_rules = flatten(concat(
-    [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
-  ))
+  ip_rules = flatten(
+    concat(
+      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
+    )
+  )
   virtual_network_subnet_ids = [
     data.azurerm_subnet.publick8s_tier.id,
     data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
     data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
     data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
   ]
-  # Grant access to trusted Azure Services like Azure Backup (see # https://learn.microsoft.com/en-gb/azure/storage/common/storage-network-security?tabs=azure-portal#exceptions)
-  bypass = ["AzureServices"]
+  bypass = ["Metrics", "Logging", "AzureServices"]
 }
-# TODO: find out how to create this without the 403 error encountered in #394, #396 & #398
-# resource "azurerm_storage_share" "ldap" {
-#   name                 = "ldap"
-#   storage_account_name = azurerm_storage_account.ldap_backups.name
-#   quota                = 5120 # 5To
-# }
-output "ldap_backups_primary_access_key" {
-  value     = azurerm_storage_account.ldap_backups.primary_access_key
-  sensitive = true
+import {
+  to = azurerm_storage_share.ldap
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/ldap/providers/Microsoft.Storage/storageAccounts/ldapjenkinsiobackups/fileServices/default/shares/ldap"
+}
+resource "azurerm_storage_share" "ldap" {
+  name               = "ldap"
+  storage_account_id = azurerm_storage_account.ldap_backups.id
+  ## TODO: shall we shrink?
+  quota = 5120 # 5To
+}
+
+## Kubernetes Resources (static provision of persistent volumes)
+import {
+  to       = kubernetes_namespace.ldap
+  provider = kubernetes.publick8s
+  id       = "ldap"
+}
+resource "kubernetes_namespace" "ldap" {
+  provider = kubernetes.publick8s
+
+  metadata {
+    name = "ldap"
+    labels = {
+      name = "ldap"
+    }
+  }
+}
+resource "kubernetes_secret" "ldap_jenkins_io_backup" {
+  provider = kubernetes.publick8s
+
+  metadata {
+    name      = "ldap-backup-storage"
+    namespace = kubernetes_namespace.ldap.metadata[0].name
+  }
+
+  data = {
+    azurestorageaccountname = azurerm_storage_account.ldap_backups.name
+    azurestorageaccountkey  = azurerm_storage_account.ldap_backups.primary_access_key
+  }
+
+  type = "Opaque"
+}
+
+# Persistent Data available in read and write
+resource "kubernetes_persistent_volume" "ldap_jenkins_io_backup" {
+  provider = kubernetes.publick8s
+  metadata {
+    name = "ldap-jenkins-io-backup"
+  }
+  spec {
+    capacity = {
+      ## TODO: sync and shrink
+      # storage = "${azurerm_storage_share.ldap.quota}Gi"
+      storage = "100Gi"
+    }
+    access_modes                     = ["ReadWriteMany"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = kubernetes_storage_class.statically_provisioned_publick8s.id
+    mount_options = [
+      "dir_mode=0777",
+      "file_mode=0777",
+      "uid=0",
+      "gid=0",
+      "mfsymlinks",
+      "cache=strict", # Default on usual kernels but worth setting it explicitly
+      "nosharesock",  # Use new TCP connection for each CIFS mount (need more memory but avoid lost packets to create mount timeouts)
+      "nobrl",        # disable sending byte range lock requests to the server and for applications which have challenges with posix locks
+    ]
+    persistent_volume_source {
+      csi {
+        driver  = "file.csi.azure.com"
+        fs_type = "ext4"
+        # `volumeHandle` must be unique on the cluster for this volume
+        volume_handle = "${kubernetes_secret.ldap_jenkins_io_backup.metadata[0].namespace}-${azurerm_storage_share.ldap.name}"
+        read_only     = false
+        volume_attributes = {
+          resourceGroup = azurerm_resource_group.ldap.name
+          shareName     = azurerm_storage_share.ldap.name
+        }
+        node_stage_secret_ref {
+          name      = kubernetes_secret.ldap_jenkins_io_backup.metadata[0].name
+          namespace = kubernetes_secret.ldap_jenkins_io_backup.metadata[0].namespace
+        }
+      }
+    }
+  }
+}
+resource "kubernetes_persistent_volume_claim" "ldap_jenkins_io_backup" {
+  provider = kubernetes.publick8s
+  metadata {
+    name      = "ldap-jenkins-io-backup"
+    namespace = kubernetes_secret.ldap_jenkins_io_backup.metadata[0].namespace
+  }
+  spec {
+    access_modes       = kubernetes_persistent_volume.ldap_jenkins_io_backup.spec[0].access_modes
+    volume_name        = kubernetes_persistent_volume.ldap_jenkins_io_backup.metadata[0].name
+    storage_class_name = kubernetes_persistent_volume.ldap_jenkins_io_backup.spec[0].storage_class_name
+    resources {
+      requests = {
+        ## TODO: sync with PV or file share
+        storage = "100Gi"
+      }
+    }
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,9 +30,12 @@ resource "local_file" "jenkins_infra_data_report" {
       }
     },
     "ldap.jenkins.io" = {
-      "share_name" = azurerm_storage_share.ldap.name
-      "share_uri"  = "/",
-      "pvc_name"   = kubernetes_persistent_volume_claim.ldap_jenkins_io_backup.metadata[0].name,
+      "data" = {
+        "pvc_name" = kubernetes_persistent_volume_claim.ldap_jenkins_io_data.metadata[0].name,
+      },
+      "backup" = {
+        "pvc_name" = kubernetes_persistent_volume_claim.ldap_jenkins_io_backup.metadata[0].name,
+      },
     },
     "publick8s" = {
       hostname           = data.azurerm_kubernetes_cluster.publick8s.fqdn,

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,11 @@ resource "local_file" "jenkins_infra_data_report" {
         "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_geoipdata.metadata[0].name,
       }
     },
+    "ldap.jenkins.io" = {
+      "share_name" = azurerm_storage_share.ldap.name
+      "share_uri"  = "/",
+      "pvc_name"   = kubernetes_persistent_volume_claim.ldap_jenkins_io_backup.metadata[0].name,
+    },
     "publick8s" = {
       hostname           = data.azurerm_kubernetes_cluster.publick8s.fqdn,
       kubernetes_version = local.aks_clusters["publick8s"].kubernetes_version


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4544#issuecomment-2671068585

This PR sets up the LDAP backup Azure File volume to provide a statically provisioned PVC.
It uses the same technique as updates.jenkins.io's GeoIPdata volume which is the same kind (except LDAP backup are ReadWriteMany while GeoIpdata are ReadOnlyMany).