### PR TITLE
chore(output/publick8s/privatek8s)  export required outbound IP and CIDRs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -37,10 +37,18 @@ resource "local_file" "jenkins_infra_data_report" {
     "publick8s" = {
       hostname           = data.azurerm_kubernetes_cluster.publick8s.fqdn,
       kubernetes_version = local.aks_clusters["publick8s"].kubernetes_version
+      pod_cidrs          = azurerm_kubernetes_cluster.publick8s.network_profile[*].pod_cidrs,
+      lb_outbound_ips = {
+        "ipv4" = [for id, pip in data.azurerm_public_ip.publick8s_lb_outbound : pip.ip_address if can(cidrnetmask("${pip.ip_address}/32"))],
+        "ipv6" = [for id, pip in data.azurerm_public_ip.publick8s_lb_outbound : pip.ip_address if !can(cidrnetmask("${pip.ip_address}/32"))],
+      },
     },
     "privatek8s" = {
       hostname           = data.azurerm_kubernetes_cluster.privatek8s.fqdn,
-      kubernetes_version = local.aks_clusters["privatek8s"].kubernetes_version
+      kubernetes_version = local.aks_clusters["privatek8s"].kubernetes_version,
+      lb_outbound_ips = {
+        "ipv4" = [for id, pip in data.azurerm_public_ip.privatek8s_lb_outbound : pip.ip_address if can(cidrnetmask("${pip.ip_address}/32"))],
+      },
     },
     "infracijenkinsio_agents_1" = {
       # No hostname as it is a private control plane

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -409,7 +409,9 @@ module "privatek8s_admin_sa" {
 
 # Retrieve effective outbound IPs
 data "azurerm_public_ip" "privatek8s_lb_outbound" {
-  for_each = toset(concat(flatten(azurerm_kubernetes_cluster.privatek8s.network_profile[*].load_balancer_profile[*].effective_outbound_ips)))
+  ## Disable this resource when running in terratest
+  # to avoid the error "The "for_each" set includes values derived from resource attributes that cannot be determined until apply"
+  for_each = var.terratest ? toset([]) : toset(concat(flatten(azurerm_kubernetes_cluster.privatek8s.network_profile[*].load_balancer_profile[*].effective_outbound_ips)))
 
   name                = element(split("/", each.key), "-1")
   resource_group_name = azurerm_kubernetes_cluster.privatek8s.node_resource_group

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -407,11 +407,10 @@ module "privatek8s_admin_sa" {
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.privatek8s.kube_config.0.cluster_ca_certificate
 }
 
-output "kubeconfig_privatek8s" {
-  sensitive = true
-  value     = module.privatek8s_admin_sa.kubeconfig
-}
+# Retrieve effective outbound IPs
+data "azurerm_public_ip" "privatek8s_lb_outbound" {
+  for_each = toset(concat(flatten(azurerm_kubernetes_cluster.privatek8s.network_profile[*].load_balancer_profile[*].effective_outbound_ips)))
 
-output "privatek8s_kube_config_command" {
-  value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.privatek8s.name} --resource-group ${azurerm_kubernetes_cluster.privatek8s.resource_group_name}"
+  name                = element(split("/", each.key), "-1")
+  resource_group_name = azurerm_kubernetes_cluster.privatek8s.node_resource_group
 }

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -497,11 +497,10 @@ module "publick8s_admin_sa" {
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate
 }
 
-output "kubeconfig_publick8s" {
-  sensitive = true
-  value     = module.publick8s_admin_sa.kubeconfig
-}
+# Retrieve effective outbound IPs
+data "azurerm_public_ip" "publick8s_lb_outbound" {
+  for_each = toset(concat(flatten(azurerm_kubernetes_cluster.publick8s.network_profile[*].load_balancer_profile[*].effective_outbound_ips)))
 
-output "publick8s_kube_config_command" {
-  value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.publick8s.name} --resource-group ${azurerm_kubernetes_cluster.publick8s.resource_group_name}"
+  name                = element(split("/", each.key), "-1")
+  resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
 }

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -499,7 +499,9 @@ module "publick8s_admin_sa" {
 
 # Retrieve effective outbound IPs
 data "azurerm_public_ip" "publick8s_lb_outbound" {
-  for_each = toset(concat(flatten(azurerm_kubernetes_cluster.publick8s.network_profile[*].load_balancer_profile[*].effective_outbound_ips)))
+  ## Disable this resource when running in terratest
+  # to avoid the error "The "for_each" set includes values derived from resource attributes that cannot be determined until apply"
+  for_each = var.terratest ? toset([]) : toset(concat(flatten(azurerm_kubernetes_cluster.publick8s.network_profile[*].load_balancer_profile[*].effective_outbound_ips)))
 
   name                = element(split("/", each.key), "-1")
   resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,9 @@ variable "location" {
   type    = string
   default = "East US 2"
 }
+
+variable "terratest" {
+  type        = bool
+  description = "value"
+  default     = false
+}


### PR DESCRIPTION
This change add data sources to retrieve the effective outbound IPs (v4 and v6 when present) so that we can export these IPs.
It also exports the Pod CIDRs for `publick8s` 

=> the goal is to allow LDAP LB source allow-list to be updated properly