### PR TITLE
chore(outputs) export puppet.jenkins.io in and out IPv4s for easier tracking

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,11 @@ resource "local_file" "jenkins_infra_data_report" {
         "pvc_name" = kubernetes_persistent_volume_claim.ldap_jenkins_io_backup.metadata[0].name,
       },
     },
+    "puppet.jenkins.io" = {
+      "ipv4" = azurerm_public_ip.puppet_jenkins_io.ip_address,
+      # DMZ: same in and out public IP
+      "outbound_ips" = azurerm_public_ip.puppet_jenkins_io.ip_address,
+    },
     "publick8s" = {
       hostname           = data.azurerm_kubernetes_cluster.publick8s.fqdn,
       kubernetes_version = local.aks_clusters["publick8s"].kubernetes_version


### PR DESCRIPTION
The `puppet.jenkins.io` VM is in the DMZ, its public IP is used for both inbound requests (SSH, puppet) and outbound requests (HTTP, LDAP).

As such, we want to export both in the infra reports so we can track the IPs where they are needed (tracking security group rules to puppet instead of relying on a git submodule, allowing in LDAP, etc.)
