### PR TITLE
hotfix(ci.jenkins.io-agent-1) do not create a kubernetes admin SA

### DIFF
--- a/ci.jenkins.io-kubernetes-agents.tf
+++ b/ci.jenkins.io-kubernetes-agents.tf
@@ -143,14 +143,3 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
 
   tags = local.default_tags
 }
-
-# Configure the jenkins-infra/kubernetes-management admin service account
-module "cijenkinsio_agents_1_admin_sa" {
-  providers = {
-    kubernetes = kubernetes.cijenkinsio_agents_1
-  }
-  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
-  cluster_name               = azurerm_kubernetes_cluster.cijenkinsio_agents_1.name
-  cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.host
-  cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
-}


### PR DESCRIPTION
We want to avoid any credentials from the ci.jenkins.io controller