### PR TITLE
fix(cijenkinsio-agents-1) create the missing admin SA

### DIFF
--- a/cijenkinsio-agents-1.tf
+++ b/cijenkinsio-agents-1.tf
@@ -153,3 +153,8 @@ module "cijenkinsio_agents_1_admin_sa" {
   cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.host
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
 }
+
+output "kubeconfig_cijenkinsio_agents_1" {
+  sensitive = true
+  value     = module.cijenkinsio_agents_1_admin_sa.kubeconfig
+}

--- a/cijenkinsio-agents-1.tf
+++ b/cijenkinsio-agents-1.tf
@@ -142,3 +142,14 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
 
   tags = local.default_tags
 }
+
+# Configure the jenkins-infra/kubernetes-management admin service account
+module "cijenkinsio_agents_1_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.cijenkinsio_agents_1
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = azurerm_kubernetes_cluster.cijenkinsio_agents_1.name
+  cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.host
+  cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
+}

--- a/cijenkinsio-agents-1.tf
+++ b/cijenkinsio-agents-1.tf
@@ -3,7 +3,6 @@ resource "azurerm_resource_group" "cijenkinsio_kubernetes_agents" {
   name     = "cijenkinsio-kubernetes-agents"
   location = var.location
   tags     = local.default_tags
-
 }
 
 #trivy:ignore:avd-azu-0040 # No need to enable oms_agent for Azure monitoring as we already have datadog

--- a/locals.tf
+++ b/locals.tf
@@ -64,14 +64,14 @@ locals {
     }
   }
 
-  ci_jenkins_io_fqdn = "ci.jenkins.io"
+  ci_jenkins_io_fqdn                 = "ci.jenkins.io"
   cijenkinsio_agents_1_compute_zones = [1]
   ci_jenkins_io_agents_1_pod_cidr    = "10.100.0.0/14" # 10.100.0.1 - 10.103.255.255
 
   infracijenkinsio_agents_1_compute_zones = [1]
   infraci_jenkins_io_agents_1_pod_cidr    = "10.100.0.0/14" # 10.100.0.1 - 10.103.255.255
 
-  publick8s_compute_zones            = [3]
+  publick8s_compute_zones = [3]
 
   end_dates = yamldecode(data.local_file.locals_yaml.content).end_dates
 }


### PR DESCRIPTION
Now that the network routing is fixed, we can proceed with the SA re-creation, so that infra.ci may manage the cluster.

Ref. https://github.com/jenkins-infra/helpdesk/issues/4619#issuecomment-2769875877