### PR TITLE
hotfix(providers) uses the correct FQDN for the cluster cijenkinsio-agents-1

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -29,7 +29,7 @@ provider "kubernetes" {
 
 provider "kubernetes" {
   alias                  = "cijenkinsio_agents_1"
-  host                   = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.host
+  host                   = "https://${azurerm_kubernetes_cluster.cijenkinsio_agents_1.fqdn}:443" # Cannot use the kubeconfig host as it provides a private DNS name
   client_certificate     = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_certificate)
   client_key             = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_key)
   cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate)


### PR DESCRIPTION
Fixup of #975 which did not reverted the changes on `providers.tf` from #951 .

That should allow the changes from #979 to pass