### PR TITLE
fix(AKS clusters) ensure we only outputs required management elements with the correct cluster hostnames

### DIFF
--- a/cijenkinsio-agents-1.tf
+++ b/cijenkinsio-agents-1.tf
@@ -46,7 +46,7 @@ resource "azurerm_kubernetes_cluster" "cijenkinsio_agents_1" {
     node_count                   = 3 # 3 nodes for HA as per AKS best practises
     vnet_subnet_id               = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
     tags                         = local.default_tags
-    zones                        = local.cijenkinsio_agents_1_compute_zones
+    zones                        = local.aks_clusters.cijenkinsio_agents_1.compute_zones
   }
 
   tags = local.default_tags
@@ -64,7 +64,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_applications" {
   auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 3 # 2 nodes always up for HA, a 3rd one is allowed for surge upgrades
-  zones                 = local.cijenkinsio_agents_1_compute_zones
+  zones                 = local.aks_clusters.cijenkinsio_agents_1.compute_zones
   vnet_subnet_id        = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
 
   node_labels = {
@@ -94,7 +94,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_agents_1" {
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 50 # 4 pods per nodes, max 200 nodes
-  zones                 = local.cijenkinsio_agents_1_compute_zones
+  zones                 = local.aks_clusters.cijenkinsio_agents_1.compute_zones
   vnet_subnet_id        = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
 
   node_labels = {
@@ -124,7 +124,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n4_bom_1" {
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 50
-  zones                 = local.cijenkinsio_agents_1_compute_zones
+  zones                 = local.aks_clusters.cijenkinsio_agents_1.compute_zones
   vnet_subnet_id        = data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id
 
   node_labels = {
@@ -150,11 +150,12 @@ module "cijenkinsio_agents_1_admin_sa" {
   }
   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
   cluster_name               = azurerm_kubernetes_cluster.cijenkinsio_agents_1.name
-  cluster_hostname           = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.host
+  cluster_hostname           = local.aks_clusters_outputs.cijenkinsio_agents_1.cluster_hostname
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
 }
 
-output "kubeconfig_cijenkinsio_agents_1" {
+# For infra.ci credentials
+output "kubeconfig_management_cijenkinsio_agents_1" {
   sensitive = true
   value     = module.cijenkinsio_agents_1_admin_sa.kubeconfig
 }

--- a/infraci.jenkins.io-kubernetes-sponsored-agents.tf
+++ b/infraci.jenkins.io-kubernetes-sponsored-agents.tf
@@ -41,7 +41,7 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
     network_policy      = "azure"
     outbound_type       = "userAssignedNATGateway"
     load_balancer_sku   = "standard" # Required to customize the outbound type
-    pod_cidr            = local.infraci_jenkins_io_agents_1_pod_cidr
+    pod_cidr            = local.aks_clusters.infracijenkinsio_agents_1.pod_cidr
   }
 
   identity {
@@ -67,7 +67,7 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_1" {
     vnet_subnet_id       = data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id
     tags                 = local.default_tags
     # Avoid deploying system pool in the same zone as other node pools
-    zones = [for zone in local.infracijenkinsio_agents_1_compute_zones : zone + 1]
+    zones = [for zone in local.aks_clusters.infracijenkinsio_agents_1.compute_zones : zone + 1]
   }
 
   tags = local.default_tags
@@ -90,7 +90,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_agents_1_sponsorsh
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 20
-  zones                 = local.infracijenkinsio_agents_1_compute_zones
+  zones                 = local.aks_clusters.infracijenkinsio_agents_1.compute_zones
   vnet_subnet_id        = data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id
 
   node_labels = {
@@ -125,7 +125,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_arm64_agents_1_sponsorshi
   auto_scaling_enabled  = true
   min_count             = 1 # Azure autoscaler with ARM64 is really slow when starting from zero nodes.
   max_count             = 20
-  zones                 = local.infracijenkinsio_agents_1_compute_zones # need to be on zone 1 for arm availability
+  zones                 = local.aks_clusters.infracijenkinsio_agents_1.compute_zones
   vnet_subnet_id        = data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id
 
   node_labels = {
@@ -150,13 +150,10 @@ module "infracijenkinsio_agents_1_admin_sa_sponsorship" {
   }
   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
   cluster_name               = azurerm_kubernetes_cluster.infracijenkinsio_agents_1.name
-  cluster_hostname           = azurerm_kubernetes_cluster.infracijenkinsio_agents_1.fqdn
+  cluster_hostname           = local.aks_clusters_outputs.infracijenkinsio_agents_1.cluster_hostname
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.infracijenkinsio_agents_1.kube_config.0.cluster_ca_certificate
 }
-output "kubeconfig_infracijenkinsio_agents_1" {
+output "kubeconfig_management_infracijenkinsio_agents_1" {
   sensitive = true
   value     = module.infracijenkinsio_agents_1_admin_sa_sponsorship.kubeconfig
-}
-output "infracijenkinsio_agents_1_kube_config_command" {
-  value = "az aks get-credentials --name ${azurerm_kubernetes_cluster.infracijenkinsio_agents_1.name} --resource-group ${azurerm_kubernetes_cluster.infracijenkinsio_agents_1.resource_group_name}"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -49,29 +49,37 @@ locals {
     "infracijenkinsio_agents_1" = {
       name               = "infracijenkinsio-agents-1",
       kubernetes_version = "1.30.7",
-    }
+      compute_zones      = [1],
+      pod_cidr           = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
+    },
     "privatek8s" = {
       name               = "privatek8s-${random_pet.suffix_privatek8s.id}",
       kubernetes_version = "1.30.7",
-    }
+    },
     "publick8s" = {
       name               = "publick8s-${random_pet.suffix_publick8s.id}",
       kubernetes_version = "1.30.7",
-    }
+      compute_zones      = [3],
+    },
     "cijenkinsio_agents_1" = {
       name               = "cijenkinsio-agents-1",
-      kubernetes_version = "1.31.6"
-    }
+      kubernetes_version = "1.31.6",
+      pod_cidr           = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
+      compute_zones      = [1],
+    },
   }
 
-  ci_jenkins_io_fqdn                 = "ci.jenkins.io"
-  cijenkinsio_agents_1_compute_zones = [1]
-  ci_jenkins_io_agents_1_pod_cidr    = "10.100.0.0/14" # 10.100.0.1 - 10.103.255.255
+  # These cluster_hostname cannot be on the 'local.aks_cluster' to avoid cyclic dependencies (when expanding the map)
+  aks_clusters_outputs = {
+    "cijenkinsio_agents_1" = {
+      cluster_hostname = "https://${azurerm_kubernetes_cluster.cijenkinsio_agents_1.fqdn}:443", # Cannot use the kubeconfig host as it provides a private DNS name
+    },
+    "infracijenkinsio_agents_1" = {
+      cluster_hostname = "https://${azurerm_kubernetes_cluster.infracijenkinsio_agents_1.fqdn}:443", # Cannot use the kubeconfig host as it provides a private DNS name
+    },
+  }
 
-  infracijenkinsio_agents_1_compute_zones = [1]
-  infraci_jenkins_io_agents_1_pod_cidr    = "10.100.0.0/14" # 10.100.0.1 - 10.103.255.255
-
-  publick8s_compute_zones = [3]
+  ci_jenkins_io_fqdn = "ci.jenkins.io"
 
   end_dates = yamldecode(data.local_file.locals_yaml.content).end_dates
 }

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -387,15 +387,6 @@ resource "azurerm_dns_a_record" "private_privatek8s" {
   tags                = local.default_tags
 }
 
-output "privatek8s_kube_config" {
-  value     = azurerm_kubernetes_cluster.privatek8s.kube_config_raw
-  sensitive = true
-}
-
-output "privatek8s_public_ip_address" {
-  value = azurerm_public_ip.public_privatek8s.ip_address
-}
-
 # Configure the jenkins-infra/kubernetes-management admin service account
 module "privatek8s_admin_sa" {
   providers = {
@@ -405,6 +396,10 @@ module "privatek8s_admin_sa" {
   cluster_name               = azurerm_kubernetes_cluster.privatek8s.name
   cluster_hostname           = azurerm_kubernetes_cluster.privatek8s.kube_config.0.host
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.privatek8s.kube_config.0.cluster_ca_certificate
+}
+output "kubeconfig_management_privatek8s" {
+  sensitive = true
+  value     = module.privatek8s_admin_sa.kubeconfig
 }
 
 # Retrieve effective outbound IPs

--- a/providers.tf
+++ b/providers.tf
@@ -29,7 +29,7 @@ provider "kubernetes" {
 
 provider "kubernetes" {
   alias                  = "cijenkinsio_agents_1"
-  host                   = "https://${azurerm_kubernetes_cluster.cijenkinsio_agents_1.fqdn}:443" # Cannot use the kubeconfig host as it provides a private DNS name
+  host                   = local.aks_clusters_outputs.cijenkinsio_agents_1.cluster_hostname
   client_certificate     = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_certificate)
   client_key             = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_key)
   cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate)
@@ -37,7 +37,7 @@ provider "kubernetes" {
 
 provider "kubernetes" {
   alias                  = "infracijenkinsio_agents_1"
-  host                   = "https://${azurerm_kubernetes_cluster.infracijenkinsio_agents_1.fqdn}:443" # Cannot use the kubeconfig host as it provides a private DNS name
+  host                   = local.aks_clusters_outputs.infracijenkinsio_agents_1.cluster_hostname
   client_certificate     = base64decode(azurerm_kubernetes_cluster.infracijenkinsio_agents_1.kube_config.0.client_certificate)
   client_key             = base64decode(azurerm_kubernetes_cluster.infracijenkinsio_agents_1.kube_config.0.client_key)
   cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.infracijenkinsio_agents_1.kube_config.0.cluster_ca_certificate)

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -97,7 +97,7 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
     max_count            = 4
     vnet_subnet_id       = data.azurerm_subnet.publick8s_tier.id
     tags                 = local.default_tags
-    zones                = local.publick8s_compute_zones
+    zones                = local.aks_clusters.publick8s.compute_zones
   }
 
   identity {
@@ -125,7 +125,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "x86small" {
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 10
-  zones                 = local.publick8s_compute_zones
+  zones                 = local.aks_clusters.publick8s.compute_zones
   vnet_subnet_id        = data.azurerm_subnet.publick8s_tier.id
 
   lifecycle {
@@ -449,23 +449,6 @@ resource "azurerm_dns_a_record" "private_publick8s" {
   tags                = local.default_tags
 }
 
-output "publick8s_kube_config" {
-  value     = azurerm_kubernetes_cluster.publick8s.kube_config_raw
-  sensitive = true
-}
-
-output "publick8s_public_ipv4_address" {
-  value = azurerm_public_ip.publick8s_ipv4.ip_address
-}
-
-output "publick8s_public_ipv6_address" {
-  value = azurerm_public_ip.publick8s_ipv6.ip_address
-}
-
-output "ldap_jenkins_io_ipv4_address" {
-  value = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
-}
-
 # Configure the jenkins-infra/kubernetes-management admin service account
 module "publick8s_admin_sa" {
   providers = {
@@ -475,6 +458,10 @@ module "publick8s_admin_sa" {
   cluster_name               = azurerm_kubernetes_cluster.publick8s.name
   cluster_hostname           = azurerm_kubernetes_cluster.publick8s.kube_config.0.host
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.publick8s.kube_config.0.cluster_ca_certificate
+}
+output "kubeconfig_management_pub" {
+  sensitive = true
+  value     = module.infracijenkinsio_agents_1_admin_sa_sponsorship.kubeconfig
 }
 
 # Retrieve effective outbound IPs


### PR DESCRIPTION
As shown by hotfixes we had to apply (#978 #979) related to the cluster FQDNs in kubeconfigs,
this PR is a tentative to clean up all of these elements in the 4 AKS clusters:

- Removing unneeded outputs
- Ensure we have a sensitive output for each "kubernetes-management" kubeconfig for the infra.ci SOPS credentials. This should be the only "kubeconfig" output: if a maintainer is unable to retrieve the kubeconfig of a given AKS cluster for their machine, then they should not be granted maintainer permissions
- Fix the "kubernetes-management" kubeconfig to use the private FQDN (same as provider). Had to create a local for this as we cannot read the value from provider inside the kubernetes_sa module
  - The local must be distinct from the current `aks_cluster` otherwise we have a cyclical error when terraform expands it.
- Factorize the "input" parameters for clusters to the local 