### PR TITLE
feat(ci.jenkins.io/cijenkinsio-agents-1) create required storage and PV/PVCs for maven cacher

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -1,3 +1,49 @@
+resource "azurerm_resource_group" "ci_jenkins_io" {
+  provider = azurerm.jenkins-sponsorship
+  name     = "ci-jenkins-io"
+  location = var.location
+  tags     = local.default_tags
+}
+
+resource "azurerm_storage_account" "ci_jenkins_io" {
+  provider            = azurerm.jenkins-sponsorship
+  name                = "cijenkinsio"
+  resource_group_name = azurerm_resource_group.ci_jenkins_io.name
+  location            = azurerm_resource_group.ci_jenkins_io.location
+
+  account_tier                      = "Premium"
+  account_kind                      = "FileStorage"
+  access_tier                       = "Hot"
+  account_replication_type          = "ZRS"
+  min_tls_version                   = "TLS1_2" # default value, needed for tfsec
+  infrastructure_encryption_enabled = true
+
+  tags = local.default_tags
+
+  # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"
+  network_rules {
+    default_action = "Deny"
+    ip_rules = flatten(
+      concat(
+        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
+      )
+    )
+    virtual_network_subnet_ids = [
+      data.azurerm_subnet.ci_jenkins_io_controller_sponsorship.id,
+      data.azurerm_subnet.ci_jenkins_io_ephemeral_agents_jenkins_sponsorship.id,
+      data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id,
+      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
+      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
+    ]
+    bypass = ["Metrics", "Logging", "AzureServices"]
+  }
+}
+resource "azurerm_storage_share" "ci_jenkins_io_maven_cache" {
+  name               = "ci-jenkins-io-maven-cache"
+  storage_account_id = azurerm_storage_account.ci_jenkins_io.id
+  quota              = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
+}
+
 ## Service DNS records
 resource "azurerm_dns_cname_record" "ci_jenkins_io" {
   name                = trimsuffix(trimsuffix(local.ci_jenkins_io_fqdn, data.azurerm_dns_zone.jenkinsio.name), ".")

--- a/get.jenkins.io.tf
+++ b/get.jenkins.io.tf
@@ -43,7 +43,7 @@ resource "azurerm_storage_account" "get_jenkins_io" {
 resource "azurerm_storage_share" "get_jenkins_io" {
   name                 = "mirrorbits"
   storage_account_name = azurerm_storage_account.get_jenkins_io.name
-  quota                = 700 # 512.14GiB used (Begining 2024)
+  quota                = 700 # 512.14GiB used (Beginning 2024)
 }
 
 resource "azurerm_storage_share" "get_jenkins_io_website" {

--- a/locals.tf
+++ b/locals.tf
@@ -66,6 +66,14 @@ locals {
       kubernetes_version = "1.31.6",
       pod_cidr           = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
       compute_zones      = [1],
+      agent_namespaces = {
+        "jenkins-agents" = {
+          pods_quota = 150,
+        },
+        "jenkins-agents-bom" = {
+          pods_quota = 150,
+        },
+      },
     },
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -58,6 +58,12 @@ resource "local_file" "jenkins_infra_data_report" {
     "cijenkinsio_agents_1" = {
       hostname           = local.aks_clusters_outputs.cijenkinsio_agents_1.cluster_hostname
       kubernetes_version = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
+      agent_namespaces   = local.aks_clusters.cijenkinsio_agents_1.agent_namespaces,
+      maven_cache_pvcs = merge(
+        { for agent_ns, agent_setup in local.aks_clusters.cijenkinsio_agents_1.agent_namespaces :
+        agent_ns => kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_readonly[agent_ns].metadata[0].name },
+        { "${kubernetes_namespace.ci_jenkins_io_maven_cache.metadata[0].name}" = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_write.metadata[0].name },
+      ),
     },
     "infracijenkinsio_agents_1" = {
       hostname           = local.aks_clusters_outputs.infracijenkinsio_agents_1.cluster_hostname

--- a/vnets.tf
+++ b/vnets.tf
@@ -139,6 +139,18 @@ data "azurerm_subnet" "infra_ci_jenkins_io_sponsorship_packer_builds" {
   virtual_network_name = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name
   resource_group_name  = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.resource_group_name
 }
+data "azurerm_subnet" "ci_jenkins_io_controller_sponsorship" {
+  provider             = azurerm.jenkins-sponsorship
+  name                 = "${data.azurerm_virtual_network.public_jenkins_sponsorship.name}-ci_jenkins_io_controller"
+  virtual_network_name = data.azurerm_virtual_network.public_jenkins_sponsorship.name
+  resource_group_name  = data.azurerm_virtual_network.public_jenkins_sponsorship.resource_group_name
+}
+data "azurerm_subnet" "ci_jenkins_io_ephemeral_agents_jenkins_sponsorship" {
+  provider             = azurerm.jenkins-sponsorship
+  name                 = "${data.azurerm_virtual_network.public_jenkins_sponsorship.name}-ci_jenkins_io_agents"
+  virtual_network_name = data.azurerm_virtual_network.public_jenkins_sponsorship.name
+  resource_group_name  = data.azurerm_virtual_network.public_jenkins_sponsorship.resource_group_name
+}
 data "azurerm_subnet" "ci_jenkins_io_kubernetes_sponsorship" {
   provider             = azurerm.jenkins-sponsorship
   name                 = "${data.azurerm_virtual_network.public_jenkins_sponsorship.name}-ci_jenkins_io_kubernetes"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4619

This PR creates the storage account with required network restrictions (hence adding the missing subnets), fileshare (premium SMB at 100 Gb), and the 3 couples of PV/PVC, along with the outputs