### PR TITLE
hotfix(ci.jenkins.io) use correct provider for the `maven-cache` Azure File Share

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -40,9 +40,10 @@ resource "azurerm_storage_account" "ci_jenkins_io" {
   }
 }
 resource "azurerm_storage_share" "ci_jenkins_io_maven_cache" {
-  name                 = "ci-jenkins-io-maven-cache"
-  storage_account_name = azurerm_storage_account.ci_jenkins_io.name
-  quota                = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
+  provider           = azurerm.jenkins-sponsorship
+  name               = "ci-jenkins-io-maven-cache"
+  storage_account_id = azurerm_storage_account.ci_jenkins_io.id
+  quota              = 100 # Minimum size of premium is 100 - https://learn.microsoft.com/en-us/azure/storage/files/understanding-billing#provisioning-method
 }
 
 ## Service DNS records


### PR DESCRIPTION
Fixup of #985 #987 and #988

Ref. https://github.com/jenkins-infra/helpdesk/issues/4619


The failure to locate the azure file comes from a missing `provider` on the Azure File Share resource in the TF code.
The share has been created but cannot be read as it searches in a distinct subscription (Azure CDF instead of Azure Sponsored).