### PR TITLE
fix(ci.jenkins.io) correct SSH inbound rules to allow VPN routing through the public outbound interface

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -33,10 +33,10 @@ module "ci_jenkins_io_sponsorship" {
   jenkins_infra_ips = {
     ldap_ipv4   = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
     puppet_ipv4 = azurerm_public_ip.puppet_jenkins_io.ip_address
-    privatevpn_subnet = [
+    privatevpn_subnet = compact(flatten(concat(
       data.azurerm_subnet.private_vnet_data_tier.address_prefixes, # Routing through the private VPN interface (when destination is the VM private IPv4)
-      local.external_services["private.vpn.jenkins.io"],           # Routing through the public VPN outbound IP (when destination is reachable through Internet gateway)
-    ],
+      [local.external_services["private.vpn.jenkins.io"]],         # Routing through the public VPN outbound IP (when destination is reachable through Internet gateway)
+    ))),
   }
   controller_service_principal_ids = [
     data.azuread_service_principal.terraform_production.object_id,
@@ -74,7 +74,6 @@ module "ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
 
   jenkins_infra_ips = {
     privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
-    # acp_service_ips = azurerm_private_dns_a_record.artifact_caching_proxy.records
   }
 }
 

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -31,9 +31,12 @@ module "ci_jenkins_io_sponsorship" {
   controller_resourcegroup_name = "ci-jenkins-io"
 
   jenkins_infra_ips = {
-    ldap_ipv4         = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
-    puppet_ipv4       = azurerm_public_ip.puppet_jenkins_io.ip_address
-    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
+    ldap_ipv4   = azurerm_public_ip.ldap_jenkins_io_ipv4.ip_address
+    puppet_ipv4 = azurerm_public_ip.puppet_jenkins_io.ip_address
+    privatevpn_subnet = [
+      data.azurerm_subnet.private_vnet_data_tier.address_prefixes, # Routing through the private VPN interface (when destination is the VM private IPv4)
+      local.external_services["private.vpn.jenkins.io"],           # Routing through the public VPN outbound IP (when destination is reachable through Internet gateway)
+    ],
   }
   controller_service_principal_ids = [
     data.azuread_service_principal.terraform_production.object_id,

--- a/locals.tf
+++ b/locals.tf
@@ -22,11 +22,13 @@ locals {
     }
   }
 
+  # TODO: track with updatecli
   external_services = {
-    "updates.jenkins.io"    = "52.202.51.185"
-    "s390x.jenkins.io"      = "148.100.84.76"
-    "pkg.origin.jenkins.io" = "52.202.51.185"
-    "archives.jenkins.io"   = "46.101.121.132"
+    "updates.jenkins.io"     = "52.202.51.185",
+    "s390x.jenkins.io"       = "148.100.84.76",
+    "pkg.origin.jenkins.io"  = "52.202.51.185",
+    "archives.jenkins.io"    = "46.101.121.132",
+    "private.vpn.jenkins.io" = "172.176.126.194",
   }
 
   # Ref. https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-githubs-ip-addresses


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4620#issuecomment-2778047717