### PR TITLE
fix(ci.jenkins.io) move to system identity instead of distinct Azure AD SP

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -41,7 +41,6 @@ module "ci_jenkins_io_sponsorship" {
   controller_service_principal_ids = [
     data.azuread_service_principal.terraform_production.object_id,
   ]
-  controller_service_principal_end_date = "2025-04-07T00:00:00Z"
   controller_packer_rg_ids = [
     azurerm_resource_group.packer_images["prod"].id
   ]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4620

Requires https://github.com/jenkins-infra/shared-tools/commit/f27614a0581a0c96284b86390c486720eec6b29e which disables non system identity Azure AD resource (AD App, SP and SP password).