### PR TITLE
feat(ci.jenkins.io) improve workload identity setup and outputs

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -26,7 +26,6 @@ module "ci_jenkins_io_sponsorship" {
   is_public                    = true
   enable_public_ipv6           = true
   default_tags                 = local.default_tags
-  enable_vm_system_identity    = true
 
   controller_resourcegroup_name = "ci-jenkins-io"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -77,6 +77,13 @@ resource "local_file" "jenkins_infra_data_report" {
         "ipv4" = module.ci_jenkins_io_sponsorship.controller_public_ipv4,
         "ipv6" = module.ci_jenkins_io_sponsorship.controller_public_ipv6,
       },
+      "azure-vm-agents" = {
+        "resource_group_name"         = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_resource_group_name,
+        "network_resource_group_name" = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_rg_name,
+        "virtual_network_name"        = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_name,
+        "sub_network_name"            = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_subnet_name,
+        "storage_account_name"        = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_storage_account_name,
+      },
     }
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure.json"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4620 and specifically https://github.com/jenkins-infra/helpdesk/issues/4628#issuecomment-2782788349

Requires the 2 following modules changes:

- Deprecates the boolean "use system identity" in favor of the presence/absence of the SP end date (absent on ci.jio, present on the other controllers): https://github.com/jenkins-infra/shared-tools/commit/925aa14b886b21f9db45b68ca47f621963b36f67
- Add more outputs: https://github.com/jenkins-infra/shared-tools/commit/4d27dbb98ff2af2ee07e7fef5ee89975a26a4060