### PR TITLE
fix(cijenkinsio-agents-1) use the corect `role` label for the BOM node pool

### DIFF
--- a/cijenkinsio-agents-1.tf
+++ b/cijenkinsio-agents-1.tf
@@ -150,7 +150,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "linux_x86_64_n3_bom_1" {
 
   node_labels = {
     "jenkins" = "ci.jenkins.io"
-    "role"    = "jenkins-agents"
+    "role"    = "jenkins-agents-bom"
   }
   node_taints = [
     "ci.jenkins.io/agents=true:NoSchedule",


### PR DESCRIPTION
ref. https://github.com/jenkins-infra/helpdesk/issues/4620

Otherwise BOM pods do not trigger the autoscaler because of label mismatch with pod template node selectors