### PR TITLE
fixup(privatek8s-sponsorship) correct initial setup (zone for system pool and public IP RG)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,9 +8,15 @@ module "jenkins_infra_shared_data" {
   source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
 }
 
-# Resource group used to store (and lock) our public IPs
+# Resource groups used to store (and lock) our public IPs
 resource "azurerm_resource_group" "prod_public_ips" {
   name     = "prod-public-ips"
+  location = var.location
+  tags     = local.default_tags
+}
+resource "azurerm_resource_group" "prod_public_ips_sponsorship" {
+  provider = azurerm.jenkins-sponsorship
+  name     = "prod-public-ips-sponsorship"
   location = var.location
   tags     = local.default_tags
 }

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -61,7 +61,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s_sponsorship" {
     max_count            = 3 # for upgrade
     vnet_subnet_id       = data.azurerm_subnet.privatek8s_sponsorship_tier.id
     tags                 = local.default_tags
-    zones                = [3]
+    zones                = [1, 2] # Many zones to ensure it is always able to provide machines in the region. Note: Zone 3 is not allowed for system pool.
   }
 
   tags = local.default_tags

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -267,7 +267,7 @@ resource "kubernetes_storage_class" "privatek8s_sponsorship_statically_provision
 resource "azurerm_public_ip" "privatek8s_sponsorship" {
   provider            = azurerm.jenkins-sponsorship
   name                = "public-privatek8s"
-  resource_group_name = azurerm_resource_group.prod_public_ips.name
+  resource_group_name = azurerm_resource_group.prod_public_ips_sponsorship.name
   location            = var.location
   allocation_method   = "Static"
   sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"


### PR DESCRIPTION
Fixup of #997

- Use a new RG for public IP in the sponsored account. Ref. https://github.com/jenkins-infra/azure/pull/997/files#r2036991712.
- Use multiple but allowed zones for the system Node Pool. Ref. https://github.com/jenkins-infra/azure/pull/997/files#r2036989958.