### PR TITLE
fixup(privatek8s-sponsorship) use the same private CIDR for pods as in other private clusters

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -52,12 +52,14 @@ locals {
       name               = "infracijenkinsio-agents-1",
       kubernetes_version = "1.31.6",
       compute_zones      = [1],
-      pod_cidr           = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
+      # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
+      pod_cidr = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
     },
     "privatek8s_sponsorship" = {
       name               = "privatek8s-sponsorship",
       kubernetes_version = "1.31.6",
-      pod_cidr           = "10.50.0.0/14", # 10.48.0.1 - 10.51.255.255
+      # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
+      pod_cidr = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
     },
     "privatek8s" = {
       name               = "privatek8s-${random_pet.suffix_privatek8s.id}",
@@ -71,8 +73,9 @@ locals {
     "cijenkinsio_agents_1" = {
       name               = "cijenkinsio-agents-1",
       kubernetes_version = "1.31.6",
-      pod_cidr           = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
-      compute_zones      = [1],
+      # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
+      pod_cidr      = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
+      compute_zones = [1],
       agent_namespaces = {
         "jenkins-agents" = {
           pods_quota = 150,


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/azure/pull/997/files#r2037035929.

As per https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay, the pod IPs are NAT-ed. So we can reuse the same CIDR on all clusters.

The constraint is to be sure that, at maximum node capacity, the CIDR can have a `/24` carved out for each node.
Since this sizing fits ci-jenkins-io-agents-1, we should not worry here.