### PR TITLE
feat(trusted.ci): switch to workload identity

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -35,7 +35,6 @@ module "trusted_ci_jenkins_io" {
     # data.azuread_service_principal.terraform_production.id,
     "b847a030-25e1-4791-ad04-9e8484d87bce",
   ]
-  controller_service_principal_end_date = "2025-05-10T00:00:00Z"
   controller_packer_rg_ids = [
     azurerm_resource_group.packer_images["prod"].id
   ]

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -54,15 +54,6 @@ end_dates:
       service: "stats.jenkins.io"
       secret: "STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
   trusted_ci_jenkins_io:
-    trustedci_jenkinsio_fileshare_serviceprincipal_writer:
-      service: "www.jenkins.io"
-      doc_how_to_get_credential: |
-        > [!IMPORTANT]
-        >
-        > ⚠️ Merging this PR will prevent the "jenkins.io" deployment job to succeed and update the www.jenkins.io website.
-        > You'll have to update the top-level credential `trustedci_jenkinsio_fileshare_serviceprincipal_writer` on trusted.ci.jenkins.io UI.
-        >
-        > This credential value can be retrieved in the Terraform state from `module.trustedci_jenkinsio_fileshare_serviceprincipal_writer.azuread_application.fileshare_serviceprincipal_writer`.
     trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer:
       service: "javadoc.jenkins.io"
       doc_how_to_get_credential: |


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4630

and following https://github.com/jenkins-infra/azure/pull/1001/files

remove the service principal and switch to workload identity for trusted.