### PR TITLE
fix(privatek8s-sponsorship) correct hostname for AKS API to use internal DNS

### DIFF
--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -320,7 +320,7 @@ module "privatek8s_sponsorship_admin_sa" {
   }
   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
   cluster_name               = azurerm_kubernetes_cluster.privatek8s_sponsorship.name
-  cluster_hostname           = azurerm_kubernetes_cluster.privatek8s_sponsorship.kube_config.0.host
+  cluster_hostname           = local.aks_clusters_outputs.privatek8s_sponsorship.cluster_hostname
   cluster_ca_certificate_b64 = azurerm_kubernetes_cluster.privatek8s_sponsorship.kube_config.0.cluster_ca_certificate
 }
 output "kubeconfig_management_privatek8s_sponsorship" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2824642025

This change applies the same technique as for the provider. We have to use the DNS hostname (instead of the "privatelink" default hostname). Same as what we did for cijenkinsioagents1 and infraciagents1