### PR TITLE
feat(privatek8s-sponsorship) add PV/PVCs for infra.ci and release.ci, including imported data

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -288,6 +288,27 @@ resource "azurerm_managed_disk" "jenkins_infra_data" {
   tags                 = local.default_tags
 }
 
+locals {
+  jenkins_infra_data_sponsorship = {
+    "jenkins-infra-data" = {},
+    "jenkins-infra-data-import" = {
+      source_resource_id = "/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/backup-sponsorhip/providers/Microsoft.Compute/snapshots/20250528-infra.ci-data"
+    },
+  }
+}
+resource "azurerm_managed_disk" "jenkins_infra_data_sponsorship" {
+  for_each             = local.jenkins_infra_data_sponsorship
+  provider             = azurerm.jenkins-sponsorship
+  name                 = each.key
+  location             = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.location
+  resource_group_name  = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
+  storage_account_type = "StandardSSD_ZRS"
+  create_option        = contains(keys(each.value), "source_resource_id") ? "Copy" : "Empty"
+  source_resource_id   = lookup(each.value, "source_resource_id", null)
+  disk_size_gb         = 64
+  tags                 = local.default_tags
+}
+
 resource "kubernetes_persistent_volume" "jenkins_infra_data" {
   provider = kubernetes.privatek8s
   metadata {

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -322,11 +322,6 @@ resource "kubernetes_storage_class" "privatek8s_sponsorship_statically_provision
 
 ## Persistent Volumes
 # File shares used by release.ci.jenkins.io agents (storing pkg.jion, get.jio, etc. data)
-import {
-  to       = kubernetes_namespace.jenkins_release_agents
-  id       = "jenkins-release-agents"
-  provider = kubernetes.privatek8s_sponsorship
-}
 resource "kubernetes_namespace" "jenkins_release_agents" {
   provider = kubernetes.privatek8s_sponsorship
 
@@ -336,11 +331,6 @@ resource "kubernetes_namespace" "jenkins_release_agents" {
       name = "jenkins-release-agents"
     }
   }
-}
-import {
-  to       = kubernetes_secret.core_packages
-  id       = "jenkins-release-agents/core-packages"
-  provider = kubernetes.privatek8s_sponsorship
 }
 resource "kubernetes_secret" "core_packages" {
   provider = kubernetes.privatek8s_sponsorship
@@ -370,16 +360,6 @@ locals {
       size_in_gb = azurerm_storage_share.get_jenkins_io_website.quota,
     },
   }
-}
-import {
-  to       = kubernetes_persistent_volume.privatek8s_sponsorship_core_packages["binary"]
-  id       = "binary-core-packages"
-  provider = kubernetes.privatek8s_sponsorship
-}
-import {
-  to       = kubernetes_persistent_volume.privatek8s_sponsorship_core_packages["website"]
-  id       = "website-core-packages"
-  provider = kubernetes.privatek8s_sponsorship
 }
 resource "kubernetes_persistent_volume" "privatek8s_sponsorship_core_packages" {
   provider = kubernetes.privatek8s_sponsorship
@@ -424,16 +404,6 @@ resource "kubernetes_persistent_volume" "privatek8s_sponsorship_core_packages" {
       }
     }
   }
-}
-import {
-  to       = kubernetes_persistent_volume_claim.privatek8s_sponsorship_core_packages["binary"]
-  id       = "jenkins-release-agents/binary-core-packages"
-  provider = kubernetes.privatek8s_sponsorship
-}
-import {
-  to       = kubernetes_persistent_volume_claim.privatek8s_sponsorship_core_packages["website"]
-  id       = "jenkins-release-agents/website-core-packages"
-  provider = kubernetes.privatek8s_sponsorship
 }
 resource "kubernetes_persistent_volume_claim" "privatek8s_sponsorship_core_packages" {
   provider = kubernetes.privatek8s_sponsorship

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -548,7 +548,7 @@ resource "kubernetes_persistent_volume_claim" "jenkins_release_data_sponsorship"
     storage_class_name = kubernetes_persistent_volume.jenkins_release_data_sponsorship[each.key].spec.0.storage_class_name
     resources {
       requests = {
-        storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].disk_size_gb}Gi"
+        storage = "${azurerm_managed_disk.jenkins_release_data_sponsorship[each.key].disk_size_gb}Gi"
       }
     }
   }

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -320,6 +320,240 @@ resource "kubernetes_storage_class" "privatek8s_sponsorship_statically_provision
   allow_volume_expansion = true
 }
 
+## Persistent Volumes
+# File shares used by release.ci.jenkins.io agents (storing pkg.jion, get.jio, etc. data)
+import {
+  to       = kubernetes_namespace.jenkins_release_agents
+  id       = "jenkins-release-agents"
+  provider = kubernetes.privatek8s_sponsorship
+}
+resource "kubernetes_namespace" "jenkins_release_agents" {
+  provider = kubernetes.privatek8s_sponsorship
+
+  metadata {
+    name = "jenkins-release-agents"
+    labels = {
+      name = "jenkins-release-agents"
+    }
+  }
+}
+import {
+  to       = kubernetes_secret.core_packages
+  id       = "jenkins-release-agents/core-packages"
+  provider = kubernetes.privatek8s_sponsorship
+}
+resource "kubernetes_secret" "core_packages" {
+  provider = kubernetes.privatek8s_sponsorship
+
+  wait_for_service_account_token = false
+
+  metadata {
+    name      = "core-packages"
+    namespace = kubernetes_namespace.jenkins_release_agents.metadata[0].name
+  }
+
+  data = {
+    azurestorageaccountname = base64encode(azurerm_storage_account.get_jenkins_io.name)
+    azurestorageaccountkey  = base64encode(azurerm_storage_account.get_jenkins_io.primary_access_key)
+  }
+
+  type = "Opaque"
+}
+locals {
+  privatek8s_sponsorship_core_packages = {
+    "binary" = {
+      share_name = azurerm_storage_share.get_jenkins_io.name,
+      size_in_gb = azurerm_storage_share.get_jenkins_io.quota,
+    },
+    "website" = {
+      share_name = azurerm_storage_share.get_jenkins_io_website.name,
+      size_in_gb = azurerm_storage_share.get_jenkins_io_website.quota,
+    },
+  }
+}
+import {
+  to       = kubernetes_persistent_volume.privatek8s_sponsorship_core_packages["binary"]
+  id       = "binary-core-packages"
+  provider = kubernetes.privatek8s_sponsorship
+}
+import {
+  to       = kubernetes_persistent_volume.privatek8s_sponsorship_core_packages["website"]
+  id       = "website-core-packages"
+  provider = kubernetes.privatek8s_sponsorship
+}
+resource "kubernetes_persistent_volume" "privatek8s_sponsorship_core_packages" {
+  provider = kubernetes.privatek8s_sponsorship
+
+  for_each = local.privatek8s_sponsorship_core_packages
+
+  metadata {
+    name = "${each.key}-core-packages"
+  }
+  spec {
+    capacity = {
+      storage = "${each.value["size_in_gb"]}Gi"
+    }
+    access_modes                     = ["ReadWriteMany"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = kubernetes_storage_class.privatek8s_sponsorship_statically_provisioned.id
+    mount_options = [
+      "dir_mode=0777",
+      "file_mode=0777",
+      "uid=1000",
+      "gid=1000",
+      "mfsymlinks",
+      "cache=strict", # Default on usual kernels but worth setting it explicitly
+      "nosharesock",  # Use new TCP connection for each CIFS mount (need more memory but avoid lost packets to create mount timeouts)
+      "nobrl",        # disable sending byte range lock requests to the server and for applications which have challenges with posix locks
+    ]
+    persistent_volume_source {
+      csi {
+        driver = "file.csi.azure.com"
+        # fs_type = "ext4"
+        # `volumeHandle` must be unique on the cluster for this volume
+        volume_handle = "${each.key}-core-packages"
+        read_only     = false
+        volume_attributes = {
+          resourceGroup = azurerm_resource_group.get_jenkins_io.name
+          shareName     = each.value["share_name"]
+        }
+        node_stage_secret_ref {
+          name      = kubernetes_secret.core_packages.metadata[0].name
+          namespace = kubernetes_secret.core_packages.metadata[0].namespace
+        }
+      }
+    }
+  }
+}
+import {
+  to       = kubernetes_persistent_volume_claim.privatek8s_sponsorship_core_packages["binary"]
+  id       = "jenkins-release-agents/binary-core-packages"
+  provider = kubernetes.privatek8s_sponsorship
+}
+import {
+  to       = kubernetes_persistent_volume_claim.privatek8s_sponsorship_core_packages["website"]
+  id       = "jenkins-release-agents/website-core-packages"
+  provider = kubernetes.privatek8s_sponsorship
+}
+resource "kubernetes_persistent_volume_claim" "privatek8s_sponsorship_core_packages" {
+  provider = kubernetes.privatek8s_sponsorship
+
+  for_each = local.privatek8s_sponsorship_core_packages
+
+  metadata {
+    name      = "${each.key}-core-packages"
+    namespace = kubernetes_secret.core_packages.metadata[0].namespace
+  }
+  spec {
+    access_modes       = kubernetes_persistent_volume.privatek8s_sponsorship_core_packages[each.key].spec[0].access_modes
+    volume_name        = kubernetes_persistent_volume.privatek8s_sponsorship_core_packages[each.key].metadata[0].name
+    storage_class_name = kubernetes_persistent_volume.privatek8s_sponsorship_core_packages[each.key].spec[0].storage_class_name
+    resources {
+      requests = {
+        storage = "${each.value["size_in_gb"]}Gi"
+      }
+    }
+  }
+}
+# Data for infra.ci
+resource "kubernetes_persistent_volume" "jenkins_infra_data_sponsorship" {
+  provider = kubernetes.privatek8s_sponsorship
+  for_each = local.jenkins_infra_data_sponsorship
+  metadata {
+    name = each.key
+  }
+  spec {
+    capacity = {
+      storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].disk_size_gb}Gi"
+    }
+    access_modes                     = ["ReadWriteOnce"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = kubernetes_storage_class.privatek8s_sponsorship_statically_provisioned.id
+    persistent_volume_source {
+      csi {
+        driver        = "disk.csi.azure.com"
+        volume_handle = azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].id
+      }
+    }
+  }
+}
+resource "kubernetes_namespace" "jenkins_infra" {
+  provider = kubernetes.privatek8s_sponsorship
+  metadata {
+    name = "jenkins-infra"
+    labels = {
+      name = "jenkins-infra"
+    }
+  }
+}
+resource "kubernetes_persistent_volume_claim" "jenkins_infra_data_sponsorship" {
+  provider = kubernetes.privatek8s_sponsorship
+  for_each = local.jenkins_infra_data_sponsorship
+  metadata {
+    name      = "jenkins-infra-data"
+    namespace = kubernetes_namespace.jenkins_infra.metadata.0.name
+  }
+  spec {
+    access_modes       = kubernetes_persistent_volume.jenkins_infra_data_sponsorship[each.key].spec.0.access_modes
+    volume_name        = kubernetes_persistent_volume.jenkins_infra_data_sponsorship[each.key].metadata.0.name
+    storage_class_name = kubernetes_persistent_volume.jenkins_infra_data_sponsorship[each.key].spec.0.storage_class_name
+    resources {
+      requests = {
+        storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].disk_size_gb}Gi"
+      }
+    }
+  }
+}
+# Data for release.ci
+resource "kubernetes_persistent_volume" "jenkins_release_data_sponsorship" {
+  provider = kubernetes.privatek8s_sponsorship
+  for_each = local.jenkins_release_data_sponsorship
+  metadata {
+    name = each.key
+  }
+  spec {
+    capacity = {
+      storage = "${azurerm_managed_disk.jenkins_release_data_sponsorship[each.key].disk_size_gb}Gi"
+    }
+    access_modes                     = ["ReadWriteOnce"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = kubernetes_storage_class.privatek8s_sponsorship_statically_provisioned.id
+    persistent_volume_source {
+      csi {
+        driver        = "disk.csi.azure.com"
+        volume_handle = azurerm_managed_disk.jenkins_release_data_sponsorship[each.key].id
+      }
+    }
+  }
+}
+resource "kubernetes_namespace" "jenkins_release" {
+  provider = kubernetes.privatek8s_sponsorship
+  metadata {
+    name = "jenkins-release"
+    labels = {
+      name = "jenkins-release"
+    }
+  }
+}
+resource "kubernetes_persistent_volume_claim" "jenkins_release_data_sponsorship" {
+  provider = kubernetes.privatek8s_sponsorship
+  for_each = local.jenkins_release_data_sponsorship
+  metadata {
+    name      = "jenkins-release-data"
+    namespace = kubernetes_namespace.jenkins_release.metadata.0.name
+  }
+  spec {
+    access_modes       = kubernetes_persistent_volume.jenkins_release_data_sponsorship[each.key].spec.0.access_modes
+    volume_name        = kubernetes_persistent_volume.jenkins_release_data_sponsorship[each.key].metadata.0.name
+    storage_class_name = kubernetes_persistent_volume.jenkins_release_data_sponsorship[each.key].spec.0.storage_class_name
+    resources {
+      requests = {
+        storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].disk_size_gb}Gi"
+      }
+    }
+  }
+}
+
 # Configure the jenkins-infra/kubernetes-management admin service account
 module "privatek8s_sponsorship_admin_sa" {
   providers = {

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -13,6 +13,28 @@ resource "azurerm_managed_disk" "jenkins_release_data" {
   tags                 = local.default_tags
 }
 
+
+locals {
+  jenkins_release_data_sponsorship = {
+    "jenkins-release-data" = {},
+    "jenkins-release-data-import" = {
+      source_resource_id = "/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/backup-sponsorhip/providers/Microsoft.Compute/snapshots/20250528-infra.ci-data"
+    },
+  }
+}
+resource "azurerm_managed_disk" "jenkins_release_data_sponsorship" {
+  for_each             = local.jenkins_release_data_sponsorship
+  provider             = azurerm.jenkins-sponsorship
+  name                 = each.key
+  location             = azurerm_resource_group.release_ci_jenkins_io_controller_jenkins_sponsorship.location
+  resource_group_name  = azurerm_resource_group.release_ci_jenkins_io_controller_jenkins_sponsorship.name
+  storage_account_type = "StandardSSD_ZRS"
+  create_option        = contains(keys(each.value), "source_resource_id") ? "Copy" : "Empty"
+  source_resource_id   = lookup(each.value, "source_resource_id", null)
+  disk_size_gb         = 64
+  tags                 = local.default_tags
+}
+
 resource "kubernetes_persistent_volume" "jenkins_release_data" {
   provider = kubernetes.privatek8s
   metadata {
@@ -68,4 +90,14 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_allow_azurerm" {
   scope              = azurerm_resource_group.release_ci_controller.id
   role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
+}
+
+####################################################################################
+## Sponsorship subscription specific resources for controller
+####################################################################################
+resource "azurerm_resource_group" "release_ci_jenkins_io_controller_jenkins_sponsorship" {
+  provider = azurerm.jenkins-sponsorship
+  name     = "release-ci-jenkins-io-controller"
+  location = var.location
+  tags     = local.default_tags
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2824642025

This PR defines the persistent volumes (and associated resources) in the privatek8s-sponsorship cluster for infra.ci.jenkins.io and release.ci.jenkins.io but in a statically define provisioning.

There are 2 cases:

- File shares (for release.ci agents in https://github.com/jenkins-infra/release/blob/c860d3c765aceefcc40e3a99f6f634ce944408d8/PodTemplates.d/package-linux.yaml#L35-L41):
  - The PV/PVCs are Azure File Shares. They've been created in https://github.com/jenkins-infra/kubernetes-management/pull/6520, and they are now imported by this PR.
  - Once merged: we'll have to revert https://github.com/jenkins-infra/kubernetes-management/pull/6520 AND we will be able to deprecate the helm chart https://github.com/jenkins-infra/helm-charts/tree/main/charts/env-jenkins-release
- Disks (for release.ci and infra.ci controllers):
  - Each disk is created empty, and we define PV and PVCs statically
  - For each disk, a second disk (with PV/PVC) is created in "Copy"  mode from a snapshot from live production (will be rsynced one more time during final migration)


Plan is the following:

- Apply https://github.com/jenkins-infra/kubernetes-management/pull/6520 to create the Release Core persistent volumes
- Run a first time this PR and check result
- Revert https://github.com/jenkins-infra/kubernetes-management/pull/6520 and delete the volumes
- Run this PR again for full creation