### PR TITLE
feat(release.ci) migrate jenkins home data to privatek8s-controller

### DIFF
--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -18,7 +18,7 @@ locals {
   jenkins_release_data_sponsorship = {
     "jenkins-release-data" = {},
     "jenkins-release-data-import" = {
-      source_resource_id = "/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/backup-sponsorhip/providers/Microsoft.Compute/snapshots/20250528-infra.ci-data"
+      source_resource_id = "/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/backup-sponsorhip/providers/Microsoft.Compute/snapshots/20240429-release.ci-data"
     },
   }
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2838032516

This PR defines the most recent snapshot for release.ci to be imported into privatek8s-sponsorship cluster.