### PR TITLE
fix(privatek8s-sponsorship) allow access to all resources already allowing the former privatek8s cluster

### DIFF
--- a/archives.tf
+++ b/archives.tf
@@ -20,7 +20,7 @@ resource "azurerm_storage_account" "archives" {
       [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
     ))
     virtual_network_subnet_ids = [
-      data.azurerm_subnet.privatek8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -254,6 +254,7 @@ resource "azurerm_storage_account" "ci_jenkins_io" {
       data.azurerm_subnet.ci_jenkins_io_controller_sponsorship.id,
       data.azurerm_subnet.ci_jenkins_io_ephemeral_agents_jenkins_sponsorship.id,
       data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -21,6 +21,7 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
     ))
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/custom-roles.tf
+++ b/custom-roles.tf
@@ -7,6 +7,16 @@ resource "azurerm_role_definition" "private_vnet_reader" {
   }
 }
 
+resource "azurerm_role_definition" "private_sponsorship_vnet_reader" {
+  provider = azurerm.jenkins-sponsorship
+  name     = "ReadPrivateVNET"
+  scope    = data.azurerm_virtual_network.private_sponsorship.id
+
+  permissions {
+    actions = ["Microsoft.Network/virtualNetworks/read"]
+  }
+}
+
 resource "azurerm_role_definition" "public_vnet_reader" {
   name  = "ReadPublicVNET"
   scope = data.azurerm_virtual_network.public.id
@@ -15,4 +25,3 @@ resource "azurerm_role_definition" "public_vnet_reader" {
     actions = ["Microsoft.Network/virtualNetworks/read"]
   }
 }
-

--- a/docs.jenkins.io.tf
+++ b/docs.jenkins.io.tf
@@ -21,6 +21,7 @@ resource "azurerm_storage_account" "docs_jenkins_io" {
     ))
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/get.jenkins.io.tf
+++ b/get.jenkins.io.tf
@@ -30,10 +30,12 @@ resource "azurerm_storage_account" "get_jenkins_io" {
     )
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-      data.azurerm_subnet.privatek8s_release_tier.id,
+      data.azurerm_subnet.privatek8s_release_tier.id,                          # release.ci agents when running the Core packaging job
+      data.azurerm_subnet.privatek8s_sponsorship_release_tier.id,              # release.ci agents when running the Core packaging job
     ]
     bypass = ["Metrics", "Logging", "AzureServices"]
   }

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -67,6 +67,17 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_subnet_privat
   role_definition_id = azurerm_role_definition.private_vnet_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.infra_ci_jenkins_io.object_id
 }
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_sponsorship_subnet_role" {
+  scope                = data.azurerm_subnet.privatek8s_sponsorship_tier.id
+  role_definition_name = "Virtual Machine Contributor"
+  principal_id         = azuread_service_principal.infra_ci_jenkins_io.object_id
+}
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_sponsorship_private_vnet_reader" {
+  provider           = azurerm.jenkins-sponsorship
+  scope              = data.azurerm_virtual_network.private_sponsorship.id
+  role_definition_id = azurerm_role_definition.private_sponsorship_vnet_reader.role_definition_resource_id
+  principal_id       = azuread_service_principal.infra_ci_jenkins_io.object_id
+}
 
 # Required to allow azcopy sync of contributors.jenkins.io File Share
 module "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer" {

--- a/javadoc.jenkins.io.tf
+++ b/javadoc.jenkins.io.tf
@@ -24,6 +24,7 @@ resource "azurerm_storage_account" "javadoc_jenkins_io" {
     )
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/jenkins.io.tf
+++ b/jenkins.io.tf
@@ -24,11 +24,12 @@ resource "azurerm_storage_account" "jenkins_io" {
     )
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-      data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,
-      data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                        # required for management from infra.ci (terraform)
+      data.azurerm_subnet.privatek8s_tier.id,                                    # required for management from infra.ci (terraform)
+      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id,   # infra.ci Azure VM agents
+      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,    # infra.ci container VM agents
+      data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,             # trusted.ci agents
+      data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id, # trusted.ci update center agent (fallback of other agents)
     ]
     bypass = ["Metrics", "Logging", "AzureServices"]
   }

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -101,6 +101,7 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
   )
   virtual_network_subnet_ids = [
     data.azurerm_subnet.publick8s_tier.id,
+    data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
     data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
     data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
     data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/plugins.jenkins.io.tf
+++ b/plugins.jenkins.io.tf
@@ -24,6 +24,7 @@ resource "azurerm_storage_account" "plugins_jenkins_io" {
     )
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -60,6 +60,8 @@ resource "azurerm_kubernetes_cluster" "publick8s" {
       data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
       # privatek8s nodes subnet
       data.azurerm_subnet.privatek8s_tier.address_prefixes,
+      # privatek8s-sponsorship nodes subnet
+      data.azurerm_subnet.privatek8s_sponsorship_tier.address_prefixes,
     )
   }
 

--- a/stats.jenkins.io.tf
+++ b/stats.jenkins.io.tf
@@ -21,6 +21,7 @@ resource "azurerm_storage_account" "stats_jenkins_io" {
     ))
     virtual_network_subnet_ids = [
       data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -35,6 +35,7 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
       data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.id,
       data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id,
       data.azurerm_subnet.publick8s_tier.id,
+      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
       data.azurerm_subnet.privatek8s_tier.id,                                  # required for management from infra.ci (terraform)
       data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
       data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2838032516