### PR TITLE
hotfix(privatek8s-sponsorship) correct PV secret and custom roles typos

### DIFF
--- a/custom-roles.tf
+++ b/custom-roles.tf
@@ -9,7 +9,7 @@ resource "azurerm_role_definition" "private_vnet_reader" {
 
 resource "azurerm_role_definition" "private_sponsorship_vnet_reader" {
   provider = azurerm.jenkins-sponsorship
-  name     = "ReadPrivateVNET"
+  name     = "ReadPrivateSponsorshipVNET"
   scope    = data.azurerm_virtual_network.private_sponsorship.id
 
   permissions {

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -333,8 +333,8 @@ resource "kubernetes_secret" "core_packages" {
   }
 
   data = {
-    azurestorageaccountname = base64encode(azurerm_storage_account.get_jenkins_io.name)
-    azurestorageaccountkey  = base64encode(azurerm_storage_account.get_jenkins_io.primary_access_key)
+    azurestorageaccountname = azurerm_storage_account.get_jenkins_io.name
+    azurestorageaccountkey  = azurerm_storage_account.get_jenkins_io.primary_access_key
   }
 
   type = "Opaque"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2838032516

- As per https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret, if we specify the secret through the `data` attribute, no need to base64 encode it. Fixup of #1020 
- Typo on the name of the role allowing infra.ci to read vnet for VM agents in thge new private-sponsored virtual network. Fixup of #1022 