### PR TITLE
cleanup(infra.ci, release.ci) remove old privatek8s data volumes and migration data volumes along with old Entra permissions in old subscription

### DIFF
--- a/custom-roles.tf
+++ b/custom-roles.tf
@@ -1,12 +1,3 @@
-resource "azurerm_role_definition" "private_vnet_reader" {
-  name  = "ReadPrivateVNET"
-  scope = data.azurerm_virtual_network.private.id
-
-  permissions {
-    actions = ["Microsoft.Network/virtualNetworks/read"]
-  }
-}
-
 resource "azurerm_role_definition" "private_sponsorship_vnet_reader" {
   provider = azurerm.jenkins-sponsorship
   name     = "ReadPrivateSponsorshipVNET"

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,24 @@
+moved {
+  from = azurerm_managed_disk.jenkins_infra_data_sponsorship["jenkins-infra-data"]
+  to   = azurerm_managed_disk.jenkins_infra_data_sponsorship
+}
+moved {
+  from = kubernetes_persistent_volume.jenkins_infra_data_sponsorship["jenkins-infra-data"]
+  to   = kubernetes_persistent_volume.jenkins_infra_data_sponsorship
+}
+moved {
+  from = kubernetes_persistent_volume_claim.jenkins_infra_data_sponsorship["jenkins-infra-data"]
+  to   = kubernetes_persistent_volume_claim.jenkins_infra_data_sponsorship
+}
+moved {
+  from = azurerm_managed_disk.jenkins_release_data_sponsorship["jenkins-release-data"]
+  to   = azurerm_managed_disk.jenkins_release_data_sponsorship
+}
+moved {
+  from = kubernetes_persistent_volume.jenkins_release_data_sponsorship["jenkins-release-data"]
+  to   = kubernetes_persistent_volume.jenkins_release_data_sponsorship
+}
+moved {
+  from = kubernetes_persistent_volume_claim.jenkins_release_data_sponsorship["jenkins-release-data"]
+  to   = kubernetes_persistent_volume_claim.jenkins_release_data_sponsorship
+}

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -415,16 +415,16 @@ resource "kubernetes_persistent_volume_claim" "privatek8s_sponsorship_core_packa
     }
   }
 }
-# Data for infra.ci
+# Persistent Volumes for infra.ci controller
 resource "kubernetes_persistent_volume" "jenkins_infra_data_sponsorship" {
   provider = kubernetes.privatek8s_sponsorship
-  for_each = local.jenkins_infra_data_sponsorship
+
   metadata {
-    name = each.key
+    name = "jenkins-infra-data"
   }
   spec {
     capacity = {
-      storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].disk_size_gb}Gi"
+      storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship.disk_size_gb}Gi"
     }
     access_modes                     = ["ReadWriteOnce"]
     persistent_volume_reclaim_policy = "Retain"
@@ -432,39 +432,39 @@ resource "kubernetes_persistent_volume" "jenkins_infra_data_sponsorship" {
     persistent_volume_source {
       csi {
         driver        = "disk.csi.azure.com"
-        volume_handle = azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].id
+        volume_handle = azurerm_managed_disk.jenkins_infra_data_sponsorship.id
       }
     }
   }
 }
 resource "kubernetes_persistent_volume_claim" "jenkins_infra_data_sponsorship" {
   provider = kubernetes.privatek8s_sponsorship
-  for_each = local.jenkins_infra_data_sponsorship
+
   metadata {
-    name      = each.key
+    name      = "jenkins-infra-data"
     namespace = kubernetes_namespace.privatek8s_sponsorship["jenkins-infra"].metadata.0.name
   }
   spec {
-    access_modes       = kubernetes_persistent_volume.jenkins_infra_data_sponsorship[each.key].spec.0.access_modes
-    volume_name        = kubernetes_persistent_volume.jenkins_infra_data_sponsorship[each.key].metadata.0.name
-    storage_class_name = kubernetes_persistent_volume.jenkins_infra_data_sponsorship[each.key].spec.0.storage_class_name
+    access_modes       = kubernetes_persistent_volume.jenkins_infra_data_sponsorship.spec.0.access_modes
+    volume_name        = kubernetes_persistent_volume.jenkins_infra_data_sponsorship.metadata.0.name
+    storage_class_name = kubernetes_persistent_volume.jenkins_infra_data_sponsorship.spec.0.storage_class_name
     resources {
       requests = {
-        storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship[each.key].disk_size_gb}Gi"
+        storage = "${azurerm_managed_disk.jenkins_infra_data_sponsorship.disk_size_gb}Gi"
       }
     }
   }
 }
-# Data for release.ci
+# Persistent Volumes for release.ci controller
 resource "kubernetes_persistent_volume" "jenkins_release_data_sponsorship" {
   provider = kubernetes.privatek8s_sponsorship
-  for_each = local.jenkins_release_data_sponsorship
+
   metadata {
-    name = each.key
+    name = "jenkins-release-data"
   }
   spec {
     capacity = {
-      storage = "${azurerm_managed_disk.jenkins_release_data_sponsorship[each.key].disk_size_gb}Gi"
+      storage = "${azurerm_managed_disk.jenkins_release_data_sponsorship.disk_size_gb}Gi"
     }
     access_modes                     = ["ReadWriteOnce"]
     persistent_volume_reclaim_policy = "Retain"
@@ -472,7 +472,7 @@ resource "kubernetes_persistent_volume" "jenkins_release_data_sponsorship" {
     persistent_volume_source {
       csi {
         driver        = "disk.csi.azure.com"
-        volume_handle = azurerm_managed_disk.jenkins_release_data_sponsorship[each.key].id
+        volume_handle = azurerm_managed_disk.jenkins_release_data_sponsorship.id
       }
     }
   }
@@ -489,18 +489,18 @@ resource "kubernetes_namespace" "privatek8s_sponsorship" {
 }
 resource "kubernetes_persistent_volume_claim" "jenkins_release_data_sponsorship" {
   provider = kubernetes.privatek8s_sponsorship
-  for_each = local.jenkins_release_data_sponsorship
+
   metadata {
-    name      = each.key
+    name      = "jenkins-release-data"
     namespace = kubernetes_namespace.privatek8s_sponsorship["jenkins-release"].metadata.0.name
   }
   spec {
-    access_modes       = kubernetes_persistent_volume.jenkins_release_data_sponsorship[each.key].spec.0.access_modes
-    volume_name        = kubernetes_persistent_volume.jenkins_release_data_sponsorship[each.key].metadata.0.name
-    storage_class_name = kubernetes_persistent_volume.jenkins_release_data_sponsorship[each.key].spec.0.storage_class_name
+    access_modes       = kubernetes_persistent_volume.jenkins_release_data_sponsorship.spec.0.access_modes
+    volume_name        = kubernetes_persistent_volume.jenkins_release_data_sponsorship.metadata.0.name
+    storage_class_name = kubernetes_persistent_volume.jenkins_release_data_sponsorship.spec.0.storage_class_name
     resources {
       requests = {
-        storage = "${azurerm_managed_disk.jenkins_release_data_sponsorship[each.key].disk_size_gb}Gi"
+        storage = "${azurerm_managed_disk.jenkins_release_data_sponsorship.disk_size_gb}Gi"
       }
     }
   }

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -1,36 +1,17 @@
-resource "azurerm_resource_group" "release_ci_controller" {
-  name     = "release-ci"
+resource "azurerm_resource_group" "release_ci_jenkins_io_controller_jenkins_sponsorship" {
+  provider = azurerm.jenkins-sponsorship
+  name     = "release-ci-jenkins-io-controller"
   location = var.location
+  tags     = local.default_tags
 }
 
-resource "azurerm_managed_disk" "jenkins_release_data" {
-  name                 = "jenkins-release-data"
-  location             = azurerm_resource_group.release_ci_controller.location
-  resource_group_name  = azurerm_resource_group.release_ci_controller.name
-  storage_account_type = "StandardSSD_ZRS"
-  create_option        = "Empty"
-  disk_size_gb         = 64
-  tags                 = local.default_tags
-}
-
-
-locals {
-  jenkins_release_data_sponsorship = {
-    "jenkins-release-data" = {},
-    "jenkins-release-data-import" = {
-      source_resource_id = "/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/backup-sponsorhip/providers/Microsoft.Compute/snapshots/20240429-release.ci-data"
-    },
-  }
-}
 resource "azurerm_managed_disk" "jenkins_release_data_sponsorship" {
-  for_each             = local.jenkins_release_data_sponsorship
   provider             = azurerm.jenkins-sponsorship
-  name                 = each.key
+  name                 = "jenkins-release-data"
   location             = azurerm_resource_group.release_ci_jenkins_io_controller_jenkins_sponsorship.location
   resource_group_name  = azurerm_resource_group.release_ci_jenkins_io_controller_jenkins_sponsorship.name
   storage_account_type = "StandardSSD_ZRS"
-  create_option        = contains(keys(each.value), "source_resource_id") ? "Copy" : "Empty"
-  source_resource_id   = lookup(each.value, "source_resource_id", null)
+  create_option        = "Empty"
   disk_size_gb         = 64
   tags                 = local.default_tags
 }
@@ -52,71 +33,4 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_sponsorship
   scope              = azurerm_resource_group.release_ci_jenkins_io_controller_jenkins_sponsorship.id
   role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_sponsorship_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsorship.identity[0].principal_id
-}
-
-resource "kubernetes_persistent_volume" "jenkins_release_data" {
-  provider = kubernetes.privatek8s
-  metadata {
-    name = "jenkins-release-pv"
-  }
-  spec {
-    capacity = {
-      storage = "${azurerm_managed_disk.jenkins_release_data.disk_size_gb}Gi"
-    }
-    access_modes                     = ["ReadWriteOnce"]
-    persistent_volume_reclaim_policy = "Retain"
-    storage_class_name               = kubernetes_storage_class.statically_provisionned_privatek8s.id
-    persistent_volume_source {
-      csi {
-        driver        = "disk.csi.azure.com"
-        volume_handle = azurerm_managed_disk.jenkins_release_data.id
-      }
-    }
-  }
-}
-
-resource "kubernetes_persistent_volume_claim" "jenkins_release_data" {
-  provider = kubernetes.privatek8s
-  metadata {
-    name      = "jenkins-release-data"
-    namespace = "jenkins-release"
-  }
-  spec {
-    access_modes       = kubernetes_persistent_volume.jenkins_release_data.spec[0].access_modes
-    volume_name        = kubernetes_persistent_volume.jenkins_release_data.metadata.0.name
-    storage_class_name = kubernetes_storage_class.statically_provisionned_privatek8s.id
-    resources {
-      requests = {
-        storage = "${azurerm_managed_disk.jenkins_release_data.disk_size_gb}Gi"
-      }
-    }
-  }
-}
-
-# Required to allow AKS CSI driver to access the Azure disk
-resource "azurerm_role_definition" "release_ci_jenkins_io_controller_disk_reader" {
-  name  = "ReadreleaseCIDisk"
-  scope = azurerm_resource_group.release_ci_controller.id
-
-  permissions {
-    actions = [
-      "Microsoft.Compute/disks/read",
-      "Microsoft.Compute/disks/write",
-    ]
-  }
-}
-resource "azurerm_role_assignment" "release_ci_jenkins_io_allow_azurerm" {
-  scope              = azurerm_resource_group.release_ci_controller.id
-  role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
-  principal_id       = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
-}
-
-####################################################################################
-## Sponsorship subscription specific resources for controller
-####################################################################################
-resource "azurerm_resource_group" "release_ci_jenkins_io_controller_jenkins_sponsorship" {
-  provider = azurerm.jenkins-sponsorship
-  name     = "release-ci-jenkins-io-controller"
-  location = var.location
-  tags     = local.default_tags
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2839488075

This PR removes the data volumes not used anymore along with a bunch of unused infra.ci resources in the CDF subscription.

It also updates occurrences of old subnets with the new subnet (it should fix the failing VM agents on infra.ci)