### PR TITLE
feat(cert.ci.jenkins.io) use a module for LetsEncrypt DNS setup: stricter authorization and reusability

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -7,7 +7,7 @@ module "cert_ci_jenkins_io" {
     azuread     = azuread
   }
 
-  service_fqdn                 = azurerm_dns_zone.cert_ci_jenkins_io.name
+  service_fqdn                 = module.cert_ci_jenkins_io_letsencrypt.zone_name
   location                     = data.azurerm_resource_group.cert_ci_jenkins_io.location
   admin_username               = local.admin_username
   admin_ssh_publickey          = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDDpxwvySus2OWViWfJ02XMYr+Qa/uPADhjt/4el2SmEf7NlJXzq5vc8imcw8YxQZKwuuKJhonlTYTpk1Cjka4bJKWNOSQ8+Kx0O2ZnNjKn3ZETWJB90bZXHVqbrNHDtu6lN6S/yRW9Q+6fuDbHBW0MXWI8Lsv+bU5v8Zll6m62rc00/I/IT9c1TX1qjCtjf5XHMFw7nVxQiTX2Zf5UKG3RI7mkCMDIvx2H9kXdzM8jtYwATZPHKHuLzffARmvy1FpNPVuLLEGYE3hljP82rll1WZbbl1ZrhjzbFUUYO4fsA7AOQHWhHiVLvtnreB269JOl/ZkHgk37zcdwJMkqKpqoEbjP9z8PURf5uMA7TiDGcpgcFMzoaFk1ueqoHM2JaM2AZQAkPhbUfT7MSOFYRx91OEg5pg5N17zNeaBM6fyxl3v7mkxSOTkKlzjAXPRyo7XsosUVQ4qb4DfsAAJ0Rynts2olRQLEzJku0ZxbbXotuoppI8HivRl7PoTsAASJRpc="
@@ -104,15 +104,15 @@ module "cert_ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
 ## Service DNS records
 resource "azurerm_dns_a_record" "cert_ci_jenkins_io_controller" {
   name                = "controller"
-  zone_name           = azurerm_dns_zone.cert_ci_jenkins_io.name
-  resource_group_name = azurerm_dns_zone.cert_ci_jenkins_io.resource_group_name
+  zone_name           = module.cert_ci_jenkins_io_letsencrypt.zone_name
+  resource_group_name = module.cert_ci_jenkins_io_letsencrypt.zone_rg_name
   ttl                 = 60
   records             = [module.cert_ci_jenkins_io.controller_private_ipv4]
 }
 resource "azurerm_dns_a_record" "cert_ci_jenkins_io" {
   name                = "@" # Child zone: no CNAME possible!
-  zone_name           = azurerm_dns_zone.cert_ci_jenkins_io.name
-  resource_group_name = azurerm_dns_zone.cert_ci_jenkins_io.resource_group_name
+  zone_name           = module.cert_ci_jenkins_io_letsencrypt.zone_name
+  resource_group_name = module.cert_ci_jenkins_io_letsencrypt.zone_rg_name
   ttl                 = 60
   records             = [module.cert_ci_jenkins_io.controller_private_ipv4]
 }
@@ -155,26 +155,13 @@ resource "azurerm_network_security_rule" "allow_in_https_from_cert_ephemeral_age
   network_security_group_name = module.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }
 
-## Lets Encrypt with Azure DNS resources
-resource "azurerm_dns_zone" "cert_ci_jenkins_io" {
-  name                = "cert.ci.jenkins.io"
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+module "cert_ci_jenkins_io_letsencrypt" {
+  source = "./.shared-tools/terraform/modules/azure-letsencrypt-dns"
 
-  tags = local.default_tags
-}
-# create DNS record of type NS for child-zone in the parent zone (to allow propagation of DNS records)
-resource "azurerm_dns_ns_record" "cert_ci_jenkins_io" {
-  name                = trimsuffix(azurerm_dns_zone.cert_ci_jenkins_io.name, ".jenkins.io") # only the flat name not the fqdn
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
+  default_tags     = local.default_tags
+  zone_name        = "cert.ci.jenkins.io"
+  dns_rg_name      = data.azurerm_resource_group.proddns_jenkinsio.name
+  parent_zone_name = data.azurerm_dns_zone.jenkinsio.name
+  principal_id     = module.cert_ci_jenkins_io.controller_service_principal_id
 
-  records = azurerm_dns_zone.cert_ci_jenkins_io.name_servers
-
-  tags = local.default_tags
-}
-resource "azurerm_role_assignment" "cert_ci_jenkins_io_dns" {
-  scope                = azurerm_dns_zone.cert_ci_jenkins_io.id
-  role_definition_name = "DNS Zone Contributor" # Predefined standard role in Azure
-  principal_id         = module.cert_ci_jenkins_io.controller_service_principal_id
 }

--- a/imports.tf
+++ b/imports.tf
@@ -1,9 +1,0 @@
-import {
-  to = azurerm_dns_zone.cert_ci_jenkins_io
-  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/proddns_jenkinsio/providers/Microsoft.Network/dnsZones/cert.ci.jenkins.io"
-}
-
-import {
-  to = azurerm_dns_ns_record.cert_ci_jenkins_io
-  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/proddns_jenkinsio/providers/Microsoft.Network/dnsZones/jenkins.io/NS/cert.ci"
-}

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,14 @@
+moved {
+  from = azurerm_dns_zone.cert_ci_jenkins_io
+  to   = module.cert_ci_jenkins_io_letsencrypt.azurerm_dns_zone.custom_zone
+}
+
+moved {
+  from = azurerm_dns_ns_record.cert_ci_jenkins_io
+  to   = module.cert_ci_jenkins_io_letsencrypt.azurerm_dns_ns_record.custom_zone_parent_records
+}
+
+moved {
+  from = azurerm_role_assignment.cert_ci_jenkins_io_dns
+  to   = module.cert_ci_jenkins_io_letsencrypt.azurerm_role_assignment.custom_zone_read
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4629#issuecomment-2846851326

As per https://go-acme.github.io/lego/dns/azuredns/index.html#azure-managed-identity-with-azure-workload, we can restrict permissions even further.

This is the goal of this PR, along with defining resources into a reusable module to avoid risks of copy and pasting when applying to trusted.ci.

Requires https://github.com/jenkins-infra/shared-tools/commit/4542811deb41dbb5ea0d146c01f0c588141232b5