### PR TITLE
cleanup(publick8s) remove `x86small` node pool

### DIFF
--- a/publick8s.tf
+++ b/publick8s.tf
@@ -110,29 +110,6 @@ data "azurerm_kubernetes_cluster" "publick8s" {
   resource_group_name = azurerm_resource_group.publick8s.name
 }
 
-resource "azurerm_kubernetes_cluster_node_pool" "x86small" {
-  name    = "x86small"
-  vm_size = "Standard_D4s_v3" # 4 vCPU, 16 GB RAM, 32 GB disk, 8 000 IOPS
-  upgrade_settings {
-    max_surge = "10%"
-  }
-  os_disk_type          = "Ephemeral"
-  os_disk_size_gb       = 100 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (depends on the instance size)
-  orchestrator_version  = local.aks_clusters["publick8s"].kubernetes_version
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.publick8s.id
-  auto_scaling_enabled  = true
-  min_count             = 0
-  max_count             = 10
-  zones                 = local.aks_clusters.publick8s.compute_zones
-  vnet_subnet_id        = data.azurerm_subnet.publick8s_tier.id
-
-  lifecycle {
-    ignore_changes = [node_count]
-  }
-
-  tags = local.default_tags
-}
-
 resource "azurerm_kubernetes_cluster_node_pool" "arm64small2" {
   name    = "arm64small2"
   vm_size = "Standard_D4pds_v5" # 4 vCPU, 16 GB RAM, local disk: 150 GB and 19000 IOPS


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3837#issuecomment-2855545179

Since https://github.com/jenkins-infra/kubernetes-management/pull/5398, there are no more applications running on this node pool: it's scaled to zero VMs:

<img width="1359" alt="Capture d’écran 2025-05-06 à 20 34 28" src="https://github.com/user-attachments/assets/276325df-ee2f-4db2-b049-0e6ec63bd1dc" />
