### PR TITLE
feat(uplink) add a runtime server for the purpose of migration

### DIFF
--- a/uplink.jenkins.io.tf
+++ b/uplink.jenkins.io.tf
@@ -46,3 +46,22 @@ removed {
 #     url: postgres://${postgresql_role.uplink.name}:${random_password.pgsql_uplink_user_password.result}@${azurerm_postgresql_flexible_server.public_db.fqdn}:5432/${postgresql_database.uplink.name}
 #   EOT
 # }
+
+## TODO: remove once the DB is migrated in public-db
+import {
+  to = azurerm_postgresql_flexible_server.uplink_migration_runtime
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/public/providers/Microsoft.DBforPostgreSQL/flexibleServers/uplink-migration-runtime"
+}
+resource "azurerm_postgresql_flexible_server" "uplink_migration_runtime" {
+  name                          = "uplink-migration-runtime"
+  resource_group_name           = data.azurerm_resource_group.public.name
+  location                      = var.location
+  public_network_access_enabled = true
+  administrator_login           = "pgadmin"
+  # administrator_password is defined in SOPS (in config/uplink/migration-runtime-server-secrets.yaml)
+  sku_name     = "GP_Standard_D4ds_v4"
+  storage_mb   = "131072"
+  storage_tier = "P10"
+  version      = "13"
+  zone         = "1"
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4667#issuecomment-2894701228

This PR imports the runtime server (a pgsql flexible temp. instance with public access) to be used as runtime server and created through the wizard.