### PR TITLE
feat(infra.ci.jenkins.io) enable workload identity and allow it to manage Azure VM agents

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -46,11 +46,33 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer" {
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.infra_ci_jenkins_io.object_id
 }
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_read_packer" {
+  provider             = azurerm.jenkins-sponsorship
+  scope                = azurerm_resource_group.packer_images["prod"].id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io.id
+}
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_sponsorship_private_vnet_reader" {
   provider           = azurerm.jenkins-sponsorship
   scope              = data.azurerm_virtual_network.private_sponsorship.id
   role_definition_id = azurerm_role_definition.private_sponsorship_vnet_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.infra_ci_jenkins_io.object_id
+}
+resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io" {
+  provider            = azurerm.jenkins-sponsorship
+  location            = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.location
+  name                = "infra.ci.jenkins.io"
+  resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
+}
+resource "azurerm_federated_identity_credential" "infra_ci_jenkins_io" {
+  provider            = azurerm.jenkins-sponsorship
+  name                = "infra.ci.jenkins.io"
+  resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.infra_ci_jenkins_io.id
+  # TODO: Sync to (or from) the controller helm chart installation values in https://github.com/jenkins-infra/kubernetes-management/blob/main/config/jenkins_infra.ci.jenkins.io.yaml
+  subject = "system:serviceaccount:jenkins-infra:jenkins-infra-controller"
 }
 
 # Required to allow azcopy sync of contributors.jenkins.io File Share
@@ -135,6 +157,12 @@ resource "azurerm_role_assignment" "infra_controller_vnet_reader" {
   role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_vnet_sponsorship_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.infra_ci_jenkins_io.object_id
 }
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_vnet_reader" {
+  provider           = azurerm.jenkins-sponsorship
+  scope              = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.id
+  role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_vnet_sponsorship_reader.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.infra_ci_jenkins_io.id
+}
 module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
   providers = {
     azurerm = azurerm.jenkins-sponsorship
@@ -149,8 +177,10 @@ module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
   controller_rg_name               = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   controller_ips                   = data.azurerm_subnet.privatek8s_sponsorship_infra_ci_controller_tier.address_prefixes # Pod IPs: controller IP may change in the pods IP subnet
   controller_service_principal_id  = azuread_service_principal.infra_ci_jenkins_io.object_id
-  default_tags                     = local.default_tags
-  storage_account_name             = "infraciagentssub" # Max 24 chars
+  additional_identities            = [azurerm_user_assigned_identity.infra_ci_jenkins_io.id]
+
+  default_tags         = local.default_tags
+  storage_account_name = "infraciagentssub" # Max 24 chars
 
   jenkins_infra_ips = {
     privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -21,11 +21,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s_sponsorship" {
   kubernetes_version                  = local.aks_clusters["privatek8s_sponsorship"].kubernetes_version
   role_based_access_control_enabled   = true # default value but made explicit to please trivy
 
-  ## TODO need to understand how it's handled `upgrade_override`
-  #   upgrade_override {
-  #     # TODO: disable to avoid "surprise" upgrades
-  #     force_upgrade_enabled = true
-  #   }
+  oidc_issuer_enabled = true
 
   image_cleaner_interval_hours = 48
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4651#issuecomment-2916842618

Requires https://github.com/jenkins-infra/shared-tools/commit/5021d7a28b66ef8ee77c3e8835f327c960de43c0 to ensure we can specify additional identities for permissions.