### PR TITLE
fix(infraciagents2): remove maxsurge as it's not available for spot instances

### DIFF
--- a/infraci.jenkins.io-agents-2.tf
+++ b/infraci.jenkins.io-agents-2.tf
@@ -69,9 +69,6 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_2" {
 resource "azurerm_kubernetes_cluster_node_pool" "infracijenkinsio_agents_2_linux_x86_64_agents_1" {
   name    = "lx86n14agt1"
   vm_size = "Standard_D8ads_v5" # https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series Standard_D8ads_v5 	8vcpu 	32Go 	300ssd
-  upgrade_settings {
-    max_surge = "10%"
-  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 300 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series (depends on the instance size)
@@ -107,9 +104,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracijenkinsio_agents_2_linux
 
   name    = "la64n14agt2"
   vm_size = "Standard_D16pds_v5" # temporarily upgrade https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dpdsv5-series?tabs=sizebasic 	16vcpu 	64Go 	600ssd
-  upgrade_settings {
-    max_surge = "10%"
-  }
   os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 600 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dpdsv5-series?tabs=sizebasic (depends on the instance size)


### PR DESCRIPTION
following  #1064 and #1063

max surge not available for spot instances
