### PR TITLE
fix: ensure all azurerm_storage_account are network-allowed for all agents (using local)

### DIFF
--- a/archives.tf
+++ b/archives.tf
@@ -19,11 +19,13 @@ resource "azurerm_storage_account" "archives" {
     ip_rules = flatten(concat(
       [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
     ))
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-    ]
+    virtual_network_subnet_ids = concat(
+      # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+      [data.azurerm_subnet.privatek8s_sponsorship_tier.id],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+    )
     bypass = ["AzureServices"]
   }
 

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -250,14 +250,14 @@ resource "azurerm_storage_account" "ci_jenkins_io" {
         [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
       )
     )
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.ci_jenkins_io_controller_sponsorship.id,
-      data.azurerm_subnet.ci_jenkins_io_ephemeral_agents_jenkins_sponsorship.id,
-      data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id,
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-    ]
+    virtual_network_subnet_ids = concat(
+      # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+      [data.azurerm_subnet.privatek8s_sponsorship_tier.id],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+      # Required for using the resource
+      local.app_subnets["ci.jenkins.io"].agents,
+    )
     bypass = ["Metrics", "Logging", "AzureServices"]
   }
 }

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -19,12 +19,16 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
     ip_rules = flatten(concat(
       [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
     ))
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-    ]
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using the resource
+        data.azurerm_subnet.publick8s_tier.id,
+        # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+        data.azurerm_subnet.privatek8s_sponsorship_tier.id,
+      ],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+    )
     bypass = ["AzureServices"]
   }
 

--- a/docs.jenkins.io.tf
+++ b/docs.jenkins.io.tf
@@ -19,12 +19,16 @@ resource "azurerm_storage_account" "docs_jenkins_io" {
     ip_rules = flatten(concat(
       [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
     ))
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-    ]
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using the resource
+        data.azurerm_subnet.publick8s_tier.id,
+        # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+        data.azurerm_subnet.privatek8s_sponsorship_tier.id,
+      ],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+    )
     bypass = ["AzureServices"]
   }
 

--- a/javadoc.jenkins.io.tf
+++ b/javadoc.jenkins.io.tf
@@ -22,14 +22,18 @@ resource "azurerm_storage_account" "javadoc_jenkins_io" {
         [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
       )
     )
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                        # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id,   # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,    # infra.ci container VM agents
-      data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,             # trusted.ci agents
-      data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id, # trusted.ci update center agent (fallback of other agents)
-    ]
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using the resource
+        data.azurerm_subnet.publick8s_tier.id,
+        # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+        data.azurerm_subnet.privatek8s_sponsorship_tier.id,
+      ],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+      # Required for populating the resource when a release is performed
+      local.app_subnets["trusted.ci.jenkins.io"].agents,
+    )
     bypass = ["Metrics", "Logging", "AzureServices"]
   }
 

--- a/jenkins.io.tf
+++ b/jenkins.io.tf
@@ -22,14 +22,18 @@ resource "azurerm_storage_account" "jenkins_io" {
         [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
       )
     )
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                        # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id,   # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,    # infra.ci container VM agents
-      data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,             # trusted.ci agents
-      data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id, # trusted.ci update center agent (fallback of other agents)
-    ]
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using the resource
+        data.azurerm_subnet.publick8s_tier.id,
+        # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+        data.azurerm_subnet.privatek8s_sponsorship_tier.id,
+      ],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+      # Required for populating the resource when a release is performed
+      local.app_subnets["trusted.ci.jenkins.io"].agents,
+    )
     bypass = ["Metrics", "Logging", "AzureServices"]
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -113,4 +113,54 @@ locals {
   ci_jenkins_io_fqdn = "ci.jenkins.io"
 
   end_dates = yamldecode(data.local_file.locals_yaml.content).end_dates
+
+  app_subnets = {
+    "ci.jenkins.io" = {
+      "controller" = [data.azurerm_subnet.ci_jenkins_io_controller_sponsorship.id],
+      "agents" = [
+        # VM agents (sponsored subscription)
+        data.azurerm_subnet.ci_jenkins_io_ephemeral_agents_jenkins_sponsorship.id,
+        # Container agents (sponsored subscription)
+        data.azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.id,
+      ],
+    },
+    "release.ci.jenkins.io" = {
+      "controller" = [data.azurerm_subnet.privatek8s_sponsorship_release_ci_controller_tier.id],
+      "agents" = [
+        # Container agents (sponsored subscription)
+        data.azurerm_subnet.privatek8s_sponsorship_release_tier.id,
+      ],
+    },
+    "infra.ci.jenkins.io" = {
+      "controller" = [data.azurerm_subnet.privatek8s_sponsorship_infra_ci_controller_tier.id],
+      "agents" = [
+        # VM agents (sponsored subscription)
+        data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id,
+        # Container agents (sponsored subscription)
+        data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,
+        # Container agents (CDF subscription)
+        data.azurerm_subnet.infracijenkinsio_agents_2.id,
+      ],
+    },
+    "trusted.ci.jenkins.io" = {
+      "controller" = [data.azurerm_subnet.trusted_ci_jenkins_io_controller.id],
+      "agents" = [
+        # Permanent agents (Update Center generation)
+        data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.id,
+        # VM agents (sponsored subscription)
+        data.azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.id,
+        # VM agents (CDF subscription)
+        data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,
+      ],
+    },
+    "cert.ci.jenkins.io" = {
+      "controller" = [data.azurerm_subnet.cert_ci_jenkins_io_controller.id],
+      "agents" = [
+        # VM agents (sponsored subscription)
+        data.azurerm_subnet.cert_ci_jenkins_io_sponsorship_ephemeral_agents.id,
+        # VM agents (CDF subscription)
+        data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.id,
+      ],
+    },
+  }
 }

--- a/plugins.jenkins.io.tf
+++ b/plugins.jenkins.io.tf
@@ -22,12 +22,16 @@ resource "azurerm_storage_account" "plugins_jenkins_io" {
         [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
       )
     )
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-    ]
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using the resource
+        data.azurerm_subnet.publick8s_tier.id,
+        # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+        data.azurerm_subnet.privatek8s_sponsorship_tier.id,
+      ],
+      # Required for managing and populating the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+    )
     bypass = ["Metrics", "Logging", "AzureServices"]
   }
 

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -296,11 +296,16 @@ resource "azurerm_storage_account" "publick8s" {
         [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
       )
     )
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci (Terraform management) Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci (Terraform management) container agents
-    ]
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using and populating the resource
+        data.azurerm_subnet.publick8s_tier.id,
+        # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+        data.azurerm_subnet.privatek8s_sponsorship_tier.id,
+      ],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+    )
     bypass = ["Metrics", "Logging", "AzureServices"]
   }
 }

--- a/stats.jenkins.io.tf
+++ b/stats.jenkins.io.tf
@@ -19,12 +19,16 @@ resource "azurerm_storage_account" "stats_jenkins_io" {
     ip_rules = flatten(concat(
       [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
     ))
-    virtual_network_subnet_ids = [
-      data.azurerm_subnet.publick8s_tier.id,
-      data.azurerm_subnet.privatek8s_sponsorship_tier.id,                      # required for management from infra.ci (terraform)
-      data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.id, # infra.ci Azure VM agents
-      data.azurerm_subnet.infraci_jenkins_io_kubernetes_agent_sponsorship.id,  # infra.ci container VM agents
-    ]
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using and populating the resource
+        data.azurerm_subnet.publick8s_tier.id,
+        # TODO: check if still needed? (used to be infra.ci container agents when they were in the privatek8s cluster)
+        data.azurerm_subnet.privatek8s_sponsorship_tier.id,
+      ],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+    )
     bypass = ["AzureServices"]
   }
 


### PR DESCRIPTION
While pairing on https://github.com/jenkins-infra/helpdesk/issues/4689, we realized that the subnets and allowed IPs of our controllers are spread which can lead to build errors when manipulating network resources.

This PR improves the subnet specification per controller component to improve the specification and centralize the definition of which subnet is used by which controller and component.

Note: it is a fix as it adds the subnet used by the [new `infracijenkinsioagents2` AKS cluster](https://github.com/jenkins-infra/azure/pull/1057) to all azure storage account's allowed networks