### PR TITLE
fix(builds.reports.jio) add PVC and switch PVC to SAS token

### DIFF
--- a/reports.jenkins.io.tf
+++ b/reports.jenkins.io.tf
@@ -77,16 +77,6 @@ resource "azurerm_storage_share" "builds_reports_jenkins_io" {
   # Less than 50Mb of files
   quota = 1
 }
-resource "azurerm_user_assigned_identity" "builds_reports_jenkins_io" {
-  location            = azurerm_resource_group.reports_jenkins_io.location
-  name                = azurerm_storage_share.builds_reports_jenkins_io.name
-  resource_group_name = azurerm_resource_group.reports_jenkins_io.name
-}
-resource "azurerm_role_assignment" "builds_reports_jenkins_io" {
-  scope                = azurerm_storage_account.reports_jenkins_io.id
-  role_definition_name = "Storage Account Contributor"
-  principal_id         = azurerm_user_assigned_identity.builds_reports_jenkins_io.principal_id
-}
 resource "kubernetes_namespace" "builds_reports_jenkins_io" {
   provider = kubernetes.publick8s
 
@@ -97,18 +87,81 @@ resource "kubernetes_namespace" "builds_reports_jenkins_io" {
     }
   }
 }
-resource "kubernetes_service_account" "builds_reports_jenkins_io" {
+resource "kubernetes_secret" "builds_reports_jenkins_io" {
   provider = kubernetes.publick8s
+
   metadata {
     name      = azurerm_storage_share.builds_reports_jenkins_io.name
-    namespace = kubernetes_namespace.builds_reports_jenkins_io.metadata[0].name
+    namespace = azurerm_storage_share.builds_reports_jenkins_io.name
+  }
+
+  data = {
+    azurestorageaccountname = azurerm_storage_account.reports_jenkins_io.name
+    azurestorageaccountkey  = azurerm_storage_account.reports_jenkins_io.primary_access_key
+  }
+
+  type = "Opaque"
+}
+resource "kubernetes_persistent_volume" "builds_reports_jenkins_io" {
+  provider = kubernetes.publick8s
+  metadata {
+    name = azurerm_storage_share.builds_reports_jenkins_io.name
+  }
+  spec {
+    capacity = {
+      storage = "${azurerm_storage_share.builds_reports_jenkins_io.quota}Gi"
+    }
+    access_modes                     = ["ReadOnlyMany"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = kubernetes_storage_class.statically_provisioned_publick8s.id
+    # Ensure that only the designated PVC can claim this PV (to avoid injection as PV are not namespaced)
+    claim_ref {                                                                   # To ensure no other PVCs can claim this PV
+      namespace = kubernetes_namespace.builds_reports_jenkins_io.metadata[0].name # Namespace is required even though it's in "default" namespace.
+      name      = azurerm_storage_share.builds_reports_jenkins_io.name            # Name of your PVC (cannot be a direct reference to avoid cyclical errors)
+    }
+    mount_options = [
+      "dir_mode=0777",
+      "file_mode=0777",
+      "uid=0",
+      "gid=0",
+      "mfsymlinks",
+      "cache=strict", # Default on usual kernels but worth setting it explicitly
+      "nosharesock",  # Use new TCP connection for each CIFS mount (need more memory but avoid lost packets to create mount timeouts)
+      "nobrl",        # disable sending byte range lock requests to the server and for applications which have challenges with posix locks
+    ]
+    persistent_volume_source {
+      csi {
+        driver  = "file.csi.azure.com"
+        fs_type = "ext4"
+        # `volumeHandle` must be unique on the cluster for this volume
+        volume_handle = format("%s-%s", azurerm_storage_account.reports_jenkins_io.name, azurerm_storage_share.builds_reports_jenkins_io.name)
+        read_only     = true
+        volume_attributes = {
+          resourceGroup = azurerm_storage_account.reports_jenkins_io.resource_group_name
+          shareName     = azurerm_storage_share.builds_reports_jenkins_io.name
+        }
+        node_stage_secret_ref {
+          name      = kubernetes_secret.builds_reports_jenkins_io.metadata[0].name
+          namespace = kubernetes_secret.builds_reports_jenkins_io.metadata[0].namespace
+        }
+      }
+    }
   }
 }
-resource "azurerm_federated_identity_credential" "builds_reports_jenkins_io" {
-  name                = azurerm_storage_share.builds_reports_jenkins_io.name
-  resource_group_name = azurerm_resource_group.reports_jenkins_io.name
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = azurerm_kubernetes_cluster.publick8s.oidc_issuer_url
-  parent_id           = azurerm_user_assigned_identity.builds_reports_jenkins_io.id
-  subject             = "system:serviceaccount:${kubernetes_namespace.builds_reports_jenkins_io.metadata[0].name}:${kubernetes_service_account.builds_reports_jenkins_io.metadata[0].name}"
+resource "kubernetes_persistent_volume_claim" "builds_reports_jenkins_io" {
+  provider = kubernetes.publick8s
+  metadata {
+    name      = kubernetes_persistent_volume.builds_reports_jenkins_io.metadata[0].name
+    namespace = kubernetes_namespace.builds_reports_jenkins_io.metadata[0].name
+  }
+  spec {
+    access_modes       = kubernetes_persistent_volume.builds_reports_jenkins_io.spec[0].access_modes
+    volume_name        = kubernetes_persistent_volume.builds_reports_jenkins_io.metadata[0].name
+    storage_class_name = kubernetes_persistent_volume.builds_reports_jenkins_io.spec[0].storage_class_name
+    resources {
+      requests = {
+        storage = kubernetes_persistent_volume.builds_reports_jenkins_io.spec[0].capacity.storage
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixup of #1075 and #1074 

=> Azurefile CSI does not work and not needed with managed AKS as per https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/workload-identity-deploy-csi-driver.md#workload-identity-support

> workload identity is NOT supported on AKS managed Azure File CSI driver since the driver controller is managed by AKS control plane which is already using [managed identity](https://learn.microsoft.com/en-us/azure/aks/use-managed-identity) by default, it's not necessary to use workload identity for AKS managed Azure File CSI driver.