### PR TITLE
feat(cert.ci.jio/trusted.ci.jio) allow agents to write to builds.reports.jenkins.io

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -281,6 +281,11 @@ resource "azurerm_linux_virtual_machine" "trusted_permanent_agent" {
     sku       = "minimal-22_04-lts-gen2"
     version   = "latest"
   }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id]
+  }
 }
 resource "azurerm_managed_disk" "trusted_permanent_agent_data_disk" {
   name                 = "trusted-permanent-agent-data-disk"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4696

Apply the same VM agents identity technique as #1079 but for cert.ci and trusted.ci.
