### PR TITLE
feat(infracijioagents2): set minimum autoscaler to 1 for arm64 nodepool

### DIFF
--- a/infraci.jenkins.io-agents-2.tf
+++ b/infraci.jenkins.io-agents-2.tf
@@ -110,7 +110,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "infracijenkinsio_agents_2_linux
   orchestrator_version  = local.aks_clusters["infracijenkinsio_agents_2"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.infracijenkinsio_agents_2.id
   auto_scaling_enabled  = true
-  min_count             = 0
+  min_count             = 1
   max_count             = 20
   zones                 = local.aks_clusters.compute_zones.arm64_pool
   vnet_subnet_id        = data.azurerm_subnet.infracijenkinsio_agents_2.id


### PR DESCRIPTION
autoscaler seem to be a bit off with arm64 and nodepool starting at 0 ... as we use arm64 pods a lot, lets set it to 1 as min and check that the autoscaler works from here.