### PR TITLE
fix(infra.ci/infracijenkins-agents-2) manage service account for infra.ci.jio container agent

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -371,8 +371,10 @@ resource "azurerm_federated_identity_credential" "infracijenkinsio_agents_2_infr
   resource_group_name = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.resource_group_name
   audience            = ["api://AzureADTokenExchange"]
   issuer              = azurerm_kubernetes_cluster.infracijenkinsio_agents_2.oidc_issuer_url
-  parent_id           = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id
-  subject             = "system:serviceaccount:${kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}:default"
+  # Force dependency on the service account setup to ensure its annotations is not forgotten
+  # Ref.
+  parent_id = kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].annotations["azure.workload.identity/client-id"]
+  subject   = "system:serviceaccount:${kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}:${kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}"
 }
 # Azure SP for updatecli with minimum rights
 resource "azurerm_resource_group" "updatecli_infra_ci_jenkins_io" {

--- a/infraci.jenkins.io-agents-2.tf
+++ b/infraci.jenkins.io-agents-2.tf
@@ -141,6 +141,18 @@ resource "kubernetes_namespace" "infracijenkinsio_agents_2_infra_ci_jenkins_io_a
     }
   }
 }
+resource "kubernetes_service_account" "infracijenkinsio_agents_2_infra_ci_jenkins_io_agents" {
+  provider = kubernetes.infracijenkinsio_agents_2
+
+  metadata {
+    name      = "jenkins-infra-agent"
+    namespace = kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name
+
+    annotations = {
+      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id
+    }
+  }
+}
 
 #Configure the jenkins-infra/kubernetes-management admin service account
 module "infracijenkinsio_agents_2_admin_sa" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,8 +7,47 @@ resource "local_file" "jenkins_infra_data_report" {
       "service_hostname" = azurerm_redis_cache.public_redis.hostname,
       "service_port"     = azurerm_redis_cache.public_redis.port,
     },
+    "cert.ci.jenkins.io" = {
+      "agents_azure_vms" = {
+        "resource_group_name"         = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name,
+        "network_resource_group_name" = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_rg_name,
+        "virtual_network_name"        = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_name,
+        "sub_network_name"            = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_subnet_name,
+        "storage_account_name"        = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_storage_account_name,
+        "user_assigned_identity"      = azurerm_user_assigned_identity.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id,
+      },
+    },
     "infra.ci.jenkins.io" = {
-      "agents_identity" = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id,
+      "agents_azure_vms" = {
+        "resource_group_name"         = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_resource_group_name,
+        "network_resource_group_name" = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_rg_name,
+        "virtual_network_name"        = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_name,
+        "sub_network_name"            = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_subnet_name,
+        "storage_account_name"        = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_storage_account_name,
+        "user_assigned_identity"      = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id,
+      },
+      "agents_kubernetes_clusters" = {
+        "infracijenkinsio_agents_2" = {
+          "hostname"           = local.aks_clusters_outputs.infracijenkinsio_agents_2.cluster_hostname
+          "kubernetes_version" = local.aks_clusters["infracijenkinsio_agents_2"].kubernetes_version
+          "agents_namespaces" = {
+            "${kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}" = {
+              pods_quota = 150,
+            },
+          },
+          "agents_service_account" = kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name,
+        },
+      },
+    },
+    "trusted.ci.jenkins.io" = {
+      "agents_azure_vms" = {
+        "resource_group_name"         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name,
+        "network_resource_group_name" = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_rg_name,
+        "virtual_network_name"        = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_name,
+        "sub_network_name"            = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_subnet_name,
+        "storage_account_name"        = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_storage_account_name,
+        "user_assigned_identity"      = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id,
+      },
     },
     "updates.jenkins.io" = {
       "content" = {
@@ -67,32 +106,29 @@ resource "local_file" "jenkins_infra_data_report" {
         "ipv4" = azurerm_dns_a_record.privatek8s_sponsorship_private.records,
       }
     },
-    "cijenkinsio_agents_1" = {
-      hostname           = local.aks_clusters_outputs.cijenkinsio_agents_1.cluster_hostname
-      kubernetes_version = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
-      agent_namespaces   = local.aks_clusters.cijenkinsio_agents_1.agent_namespaces,
-      maven_cache_pvcs = merge(
-        { for agent_ns, agent_setup in local.aks_clusters.cijenkinsio_agents_1.agent_namespaces :
-        agent_ns => kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_readonly[agent_ns].metadata[0].name },
-        { "${kubernetes_namespace.ci_jenkins_io_maven_cache.metadata[0].name}" = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_write.metadata[0].name },
-      ),
-    },
-    "infracijenkinsio_agents_2" = {
-      hostname           = local.aks_clusters_outputs.infracijenkinsio_agents_2.cluster_hostname
-      kubernetes_version = local.aks_clusters["infracijenkinsio_agents_2"].kubernetes_version
-      agent_namespaces   = kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name,
-    },
     "azure.ci.jenkins.io" = {
       "service_ips" = {
         "ipv4" = module.ci_jenkins_io_sponsorship.controller_public_ipv4,
         "ipv6" = module.ci_jenkins_io_sponsorship.controller_public_ipv6,
       },
-      "azure-vm-agents" = {
+      "agents_azure_vms" = {
         "resource_group_name"         = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_resource_group_name,
         "network_resource_group_name" = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_rg_name,
         "virtual_network_name"        = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_name,
         "sub_network_name"            = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_subnet_name,
         "storage_account_name"        = module.ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_storage_account_name,
+      },
+      "agents_kubernetes_clusters" = {
+        "cijenkinsio_agents_1" = {
+          "hostname"           = local.aks_clusters_outputs.cijenkinsio_agents_1.cluster_hostname
+          "kubernetes_version" = local.aks_clusters["cijenkinsio_agents_1"].kubernetes_version
+          "agents_namespaces"  = local.aks_clusters.cijenkinsio_agents_1.agent_namespaces,
+          maven_cache_pvcs = merge(
+            { for agent_ns, agent_setup in local.aks_clusters.cijenkinsio_agents_1.agent_namespaces :
+            agent_ns => kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_readonly[agent_ns].metadata[0].name },
+            { "${kubernetes_namespace.ci_jenkins_io_maven_cache.metadata[0].name}" = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_write.metadata[0].name },
+          ),
+        },
       },
     }
   })


### PR DESCRIPTION
To ensure federated identity works as expected, we need to explicitly specify a service account into our kubernetes pod agent templates: It's done in https://github.com/jenkins-infra/kubernetes-management/pull/6727.

However, since the service account requires an annotation with the User Assigned Identity and the federated credential needs the service account name, then it sounds way more coherent to manage the aforementioned SVC account in Terraform here and export its name for kubernetes-management. 

Ref. https://github.com/jenkins-infra/helpdesk/issues/4696#issuecomment-3000046567


Note: this PR also updates the reports content and may break some downstream `updatecli` manifests. I'll check them (mostly puppet and kubernetes AFAICT)
