### PR TITLE
fix(publick8s,privatek8s,infraciagents1) enable workload identity on AKS clusters

### DIFF
--- a/infraci.jenkins.io-agents-2.tf
+++ b/infraci.jenkins.io-agents-2.tf
@@ -17,8 +17,10 @@ resource "azurerm_kubernetes_cluster" "infracijenkinsio_agents_2" {
   location                            = azurerm_resource_group.infracijenkinsio_agents_2.location
   resource_group_name                 = azurerm_resource_group.infracijenkinsio_agents_2.name
   kubernetes_version                  = local.aks_clusters["infracijenkinsio_agents_2"].kubernetes_version
-  role_based_access_control_enabled   = true # default value but made explicit to please trivy
-  oidc_issuer_enabled                 = true
+  # default value but made explicit to please trivy
+  role_based_access_control_enabled = true
+  oidc_issuer_enabled               = true
+  workload_identity_enabled         = true
 
   image_cleaner_interval_hours = 48
 

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -19,9 +19,10 @@ resource "azurerm_kubernetes_cluster" "privatek8s_sponsorship" {
   location                            = azurerm_resource_group.privatek8s_sponsorship.location
   resource_group_name                 = azurerm_resource_group.privatek8s_sponsorship.name
   kubernetes_version                  = local.aks_clusters["privatek8s_sponsorship"].kubernetes_version
-  role_based_access_control_enabled   = true # default value but made explicit to please trivy
-
-  oidc_issuer_enabled = true
+  # default value but made explicit to please trivy
+  role_based_access_control_enabled = true
+  oidc_issuer_enabled               = true
+  workload_identity_enabled         = true
 
   image_cleaner_interval_hours = 48
 

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -25,13 +25,15 @@ data "azurerm_subnet" "public_vnet_data_tier" {
 
 #trivy:ignore:azure-container-logging #trivy:ignore:azure-container-limit-authorized-ips
 resource "azurerm_kubernetes_cluster" "publick8s" {
-  name                              = local.aks_clusters["publick8s"].name
-  location                          = azurerm_resource_group.publick8s.location
-  resource_group_name               = azurerm_resource_group.publick8s.name
-  kubernetes_version                = local.aks_clusters["publick8s"].kubernetes_version
-  dns_prefix                        = local.aks_clusters["publick8s"].name
-  role_based_access_control_enabled = true # default value but made explicit to please trivy
+  name                = local.aks_clusters["publick8s"].name
+  location            = azurerm_resource_group.publick8s.location
+  resource_group_name = azurerm_resource_group.publick8s.name
+  kubernetes_version  = local.aks_clusters["publick8s"].kubernetes_version
+  dns_prefix          = local.aks_clusters["publick8s"].name
+  # default value but made explicit to please trivy
+  role_based_access_control_enabled = true
   oidc_issuer_enabled               = true
+  workload_identity_enabled         = true
 
   upgrade_override {
     # TODO: disable to avoid "surprise" upgrades


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4696#issuecomment-3007359208

As per https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#workload_identity_enabled-1:

>  To enable Azure AD Workload Identity `oidc_issuer_enabled` must be set to `true`.

=> Already the case ✅ 

> Enabling this option will allocate Workload Identity resources to the `kube-system` namespace in Kubernetes. If you wish to customize the deployment of Workload Identity, you can refer to [the documentation on Azure AD Workload Identity.](https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html)


Note: did not enable on cijenkinsioagents1 because it will [soon be decommissioned](https://github.com/jenkins-infra/helpdesk/issues/4688)

