### PR TITLE
cleanup(infra.ci) remove infraciagents federated identity used for testing

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -365,17 +365,7 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_azurevm_agents_jenkins_s
   role_definition_name = "Storage File Data Privileged Contributor"
   principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.principal_id
 }
-resource "azurerm_federated_identity_credential" "infracijenkinsio_agents_2_infra_ci_jenkins_io_agents" {
-  provider            = azurerm.jenkins-sponsorship
-  name                = "infra-ci-jenkins-io-agents2"
-  resource_group_name = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.resource_group_name
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = azurerm_kubernetes_cluster.infracijenkinsio_agents_2.oidc_issuer_url
-  # Force dependency on the service account setup to ensure its annotations is not forgotten
-  # Ref.
-  parent_id = kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].annotations["azure.workload.identity/client-id"]
-  subject   = "system:serviceaccount:${kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}:${kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}"
-}
+
 # Azure SP for updatecli with minimum rights
 resource "azurerm_resource_group" "updatecli_infra_ci_jenkins_io" {
   name     = "updatecli-infra-ci-jenkins-io"


### PR DESCRIPTION
ref. https://github.com/jenkins-infra/helpdesk/issues/4696#issuecomment-3007450524

The Federated ID is currently in the sponsored subscription so let's start by removing it since it did not work.
We'll recreate a new one in a subsequent PR.