### PR TITLE
chore: fix warning messages about depreciated 'resource_manager_id' attribute

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -196,15 +196,15 @@ resource "azurerm_network_security_rule" "allow_out_https_from_cijio_agents_to_a
 
 ## Allow access to aws.ci.jenkins.io for migration (ref. https://github.com/jenkins-infra/helpdesk/issues/4688)
 resource "azurerm_network_security_rule" "allow_out_ssh_from_controller_to_awscijio" {
-  provider                = azurerm.jenkins-sponsorship
-  name                    = "allow-out-ssh-from-controller-to-awscijio"
-  priority                = 4051
-  direction               = "Outbound"
-  access                  = "Allow"
-  protocol                = "Tcp"
-  source_port_range       = "*"
-  destination_port_range  = "22"
-  source_address_prefixes = [module.ci_jenkins_io_sponsorship.controller_private_ipv4]
+  provider                     = azurerm.jenkins-sponsorship
+  name                         = "allow-out-ssh-from-controller-to-awscijio"
+  priority                     = 4051
+  direction                    = "Outbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefixes      = [module.ci_jenkins_io_sponsorship.controller_private_ipv4]
   destination_address_prefixes = ["18.217.202.59/32"]
   resource_group_name          = module.ci_jenkins_io_sponsorship.controller_resourcegroup_name
   network_security_group_name  = module.ci_jenkins_io_sponsorship.controller_nsg_name

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -69,13 +69,13 @@ resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io" {
 module "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_resource_manager_id = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
-  storage_account_id             = azurerm_storage_account.contributors_jenkins_io.id
-  default_tags                   = local.default_tags
+  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.contributors_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.contributors_jenkins_io.id
+  default_tags               = local.default_tags
 }
 output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
@@ -89,13 +89,13 @@ output "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_applicat
 module "infraci_docsjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_resource_manager_id = azurerm_storage_share.docs_jenkins_io.resource_manager_id
-  storage_account_id             = azurerm_storage_account.docs_jenkins_io.id
-  default_tags                   = local.default_tags
+  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.docs_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.docs_jenkins_io.id
+  default_tags               = local.default_tags
 }
 output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
@@ -109,13 +109,13 @@ output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_application_clie
 module "infraci_statsjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn                   = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_resource_manager_id = azurerm_storage_share.stats_jenkins_io.resource_manager_id
-  storage_account_id             = azurerm_storage_account.stats_jenkins_io.id
-  default_tags                   = local.default_tags
+  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.stats_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.stats_jenkins_io.id
+  default_tags               = local.default_tags
 }
 output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
@@ -251,13 +251,13 @@ resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infrac
 module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn                   = "infraci-pluginsjenkinsio-fileshare_serviceprincipal_writer"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = local.end_dates.infra_ci_jenkins_io.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_resource_manager_id = azurerm_storage_share.plugins_jenkins_io.resource_manager_id
-  storage_account_id             = azurerm_storage_account.plugins_jenkins_io.id
-  default_tags                   = local.default_tags
+  service_fqdn               = "infraci-pluginsjenkinsio-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.plugins_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.plugins_jenkins_io.id
+  default_tags               = local.default_tags
 }
 output "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
   value = module.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -346,13 +346,13 @@ resource "kubernetes_secret" "geoip_data" {
 module "cronjob_geoip_data_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn                   = "${azurerm_resource_group.publick8s.name}-fileshare_serviceprincipal_writer-redirects"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2025-07-06T00:00:00Z"
-  file_share_resource_manager_id = azurerm_storage_share.geoip_data.resource_manager_id
-  storage_account_id             = azurerm_storage_account.publick8s.id
-  default_tags                   = local.default_tags
+  service_fqdn               = "${azurerm_resource_group.publick8s.name}-fileshare_serviceprincipal_writer-redirects"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = "2025-07-06T00:00:00Z"
+  file_share_id              = azurerm_storage_share.geoip_data.id
+  storage_account_id         = azurerm_storage_account.publick8s.id
+  default_tags               = local.default_tags
 }
 
 # Used later by the load balancer deployed on the cluster, see https://github.com/jenkins-infra/kubernetes-management/config/publick8s.yaml

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -89,26 +89,26 @@ resource "azurerm_role_assignment" "trusted_ci_jenkins_io_azurevm_agents_jenkins
 module "trustedci_jenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn                   = "trustedci-jenkinsio-fileshare_serviceprincipal_writer"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2025-07-06T00:00:00Z"
-  file_share_resource_manager_id = azurerm_storage_share.jenkins_io.resource_manager_id
-  storage_account_id             = azurerm_storage_account.jenkins_io.id
-  default_tags                   = local.default_tags
+  service_fqdn               = "trustedci-jenkinsio-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = "2025-07-06T00:00:00Z"
+  file_share_id              = azurerm_storage_share.jenkins_io.id
+  storage_account_id         = azurerm_storage_account.jenkins_io.id
+  default_tags               = local.default_tags
 }
 
 # Required to allow azcopy sync of javadoc.jenkins.io File Share
 module "trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
 
-  service_fqdn                   = "trustedci-javadocjenkinsio-fileshare_serviceprincipal_writer"
-  active_directory_owners        = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url           = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date     = "2025-07-06T00:00:00Z"
-  file_share_resource_manager_id = azurerm_storage_share.javadoc_jenkins_io.resource_manager_id
-  storage_account_id             = azurerm_storage_account.javadoc_jenkins_io.id
-  default_tags                   = local.default_tags
+  service_fqdn               = "trustedci-javadocjenkinsio-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = "2025-07-06T00:00:00Z"
+  file_share_id              = azurerm_storage_share.javadoc_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.javadoc_jenkins_io.id
+  default_tags               = local.default_tags
 }
 
 ## Sponsorship subscription specific resources for controller


### PR DESCRIPTION
Fix warning messages such as:

```
│ Warning: Deprecated attribute
│ 
│   on infra.ci.jenkins.io.tf line 76, in module "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer":
│   76:   file_share_resource_manager_id = azurerm_storage_share.contributors_jenkins_io.resource_manager_id
│ 
│ The attribute "resource_manager_id" is deprecated. Refer to the provider documentation for details.
│ 
│ (and 6 more similar warnings elsewhere)
```

Requires https://github.com/jenkins-infra/shared-tools/commit/f847ce3da16ae12da0660bc8bae20bbeb1838e60