### PR TITLE
chore(updatecli) update values for geoip SA renewal message

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -68,7 +68,7 @@ end_dates:
         > ⚠️ Merging this PR will prevent the "geoip kubernetes cronjob" to succeed and update the mirrorbits geoip databases.
         > You'll have to update the sops secrets `./secrets/config/geoipdata/secrets.yaml`
         >
-        > This credential value can be retrieved in the Terraform state from `module.cronjob_geoip_fileshare_serviceprincipal_writer.azuread_application_password.fileshare_serviceprincipal_writer`.
+        > This credential value can be retrieved in the Terraform state from `module.cronjob_geoip_data_fileshare_serviceprincipal_writer.azuread_application_password.fileshare_serviceprincipal_writer`.
 updatecli_end_dates:
   infra.ci.jenkins.io:
     custom_hcl_key: resource.azuread_application_password.updatecli_infra_ci_jenkins_io.end_date


### PR DESCRIPTION
correct the credential key in the json file to match the correct one and avoid searching it.