### PR TITLE
feat(privatek8s/release.ci-agents): add credential-less workload identity for release agents

### DIFF
--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -524,6 +524,30 @@ resource "azurerm_federated_identity_credential" "privatek8s_sponsorship_jenkins
   subject             = "system:serviceaccount:${kubernetes_namespace.privatek8s_sponsorship["jenkins-infra"].metadata[0].name}:${kubernetes_service_account.privatek8s_sponsorship_jenkins_infra_controller.metadata[0].name}"
 }
 ## End of infra.ci
+
+## For release.ci.jenkins.io agents
+resource "kubernetes_service_account" "privatek8s_sponsorship_jenkins_release_agents" {
+  provider = kubernetes.privatek8s_sponsorship
+
+  metadata {
+    name      = "jenkins-release-agents"
+    namespace = kubernetes_namespace.privatek8s_sponsorship["jenkins-release-agents"].metadata[0].name
+
+    annotations = {
+      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.client_id,
+    }
+  }
+}
+resource "azurerm_federated_identity_credential" "privatek8s_sponsorship_jenkins_release_agents" {
+  provider            = azurerm.jenkins-sponsorship
+  name                = "privatek8s-sponsorship-${kubernetes_service_account.privatek8s_sponsorship_jenkins_release_agents.metadata[0].name}"
+  resource_group_name = azurerm_resource_group.release_ci_jenkins_io_controller_jenkins_sponsorship.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.id
+  subject             = "system:serviceaccount:${kubernetes_namespace.privatek8s_sponsorship["jenkins-release-agents"].metadata[0].name}:${kubernetes_service_account.privatek8s_sponsorship_jenkins_release_agents.metadata[0].name}"
+}
+## End of release.ci.jenkins.io agents
 ### End of  Workload Identity Resources
 
 # Configure the jenkins-infra/kubernetes-management admin service account

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -34,3 +34,15 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_sponsorship
   role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_sponsorship_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsorship.identity[0].principal_id
 }
+
+resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents" {
+  location            = var.location
+  name                = "release-ci-jenkins-io-agents"
+  resource_group_name = azurerm_resource_group.release_ci_jenkins_io_controller_jenkins_sponsorship.name
+}
+resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_buildsreports_share" {
+  scope = azurerm_storage_account.builds_reports_jenkins_io.id
+  # Allow writing
+  role_definition_name = "Storage File Data Privileged Contributor"
+  principal_id         = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.principal_id
+}


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4696#issuecomment-3008168249

lets set the necessary objects for workload identity, as per jenkins-infra-ci controller.