### PR TITLE
feat(trusted.ci) ensure ephemeral agentsin the CDF account uses default values and are outputed

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -53,7 +53,7 @@ resource "local_file" "jenkins_infra_data_report" {
         "virtual_network_name"        = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_name,
         "sub_network_name"            = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_subnet_name,
         "storage_account_name"        = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_storage_account_name,
-        "user_assigned_identity"      = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id,
+        "user_assigned_identity"      = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.id,
       },
     },
     "updates.jenkins.io" = {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -50,7 +50,6 @@ module "trusted_ci_jenkins_io" {
 module "trusted_ci_jenkins_io_azurevm_agents" {
   source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-azurevm-agents"
 
-  custom_resourcegroup_name        = "jenkinsinfra-trusted-ephemeral-agents"
   service_fqdn                     = module.trusted_ci_jenkins_io.service_fqdn
   service_short_stripped_name      = module.trusted_ci_jenkins_io.service_short_stripped_name
   ephemeral_agents_network_rg_name = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.resource_group_name


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4694

Follows up #1107 (and its hotfix)