### PR TITLE
fix(packer-images): correct the NSG with both sponsorship and CDF subscription

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -178,8 +178,10 @@ module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
   }
 }
 
+
 # Allow infra.ci VM agents to reach packer VMs with SSH on azure
-resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents_to_packer_vms_cdf" {
+resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents_to_packer_vms" {
+  provider                    = azurerm.jenkins-sponsorship
   name                        = "allow-outbound-ssh-from-infraci-agents-to-packer-vms"
   priority                    = 4080
   direction                   = "Outbound"
@@ -188,13 +190,17 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents
   source_port_range           = "*"
   destination_port_range      = "22"
   source_address_prefix       = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
-  destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_packer_builds.address_prefix
+  destination_address_prefixes  = [
+    data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix,
+    data.azurerm_subnet.infra_ci_jenkins_io_packer_builds.address_prefix
+  ]
   resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }
 
 # Allow infra.ci VM agents to reach packer VMs with SSH on aws
-resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents_to_aws_packer_cdf" {
+resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents_to_aws_packer" {
+  provider                    = azurerm.jenkins-sponsorship
   name                        = "allow-outbound-ssh-from-infraci-agents-to-aws-packer"
   priority                    = 4079
   direction                   = "Outbound"
@@ -209,7 +215,8 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents
 }
 
 # Allow infra.ci VM agents to reach packer VMs with WinRM (HTTP without TLS)
-resource "azurerm_network_security_rule" "allow_outbound_winrm_http_from_infraci_agents_to_packer_vms_cdf" {
+resource "azurerm_network_security_rule" "allow_outbound_winrm_http_from_infraci_agents_to_packer_vms" {
+  provider               = azurerm.jenkins-sponsorship
   name                   = "allow-outbound-winrm-http-from-infraci-agents-to-packer-vms"
   priority               = 4081
   direction              = "Outbound"
@@ -219,14 +226,15 @@ resource "azurerm_network_security_rule" "allow_outbound_winrm_http_from_infraci
   destination_port_range = "5985"
   source_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
   ## Restriction to only Azure private subnet
-  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_packer_builds.address_prefix
+  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
   ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }
 # Allow infra.ci VM agents to reach packer VMs with WinRM (HTTPS)
-resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infraci_agents_to_packer_vms_cdf" {
+resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infraci_agents_to_packer_vms" {
+  provider               = azurerm.jenkins-sponsorship
   name                   = "allow-outbound-winrm-https-from-infraci-agents-to-packer-vms"
   priority               = 4082
   direction              = "Outbound"
@@ -236,12 +244,13 @@ resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infrac
   destination_port_range = "5986"
   source_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
   ## Restriction to only Azure private subnet
-  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_packer_builds.address_prefix
+  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
   ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }
+
 
 # Required to allow azcopy sync of plugins.jenkins.io File Share
 module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
@@ -495,77 +504,4 @@ resource "azurerm_key_vault" "infra_ci_jenkins_io_vault" {
       "Sign",
     ]
   }
-}
-
-
-## Resources to be deleted as part of https://github.com/jenkins-infra/helpdesk/issues/4701,
-## when workload is migrated to CDF subscription
-
-# Allow infra.ci VM agents to reach packer VMs with SSH on azure
-resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents_to_packer_vms" {
-  provider                    = azurerm.jenkins-sponsorship
-  name                        = "allow-outbound-ssh-from-infraci-agents-to-packer-vms"
-  priority                    = 4080
-  direction                   = "Outbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "22"
-  source_address_prefix       = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
-  destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
-  resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
-  network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
-}
-
-# Allow infra.ci VM agents to reach packer VMs with SSH on aws
-resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents_to_aws_packer" {
-  provider                    = azurerm.jenkins-sponsorship
-  name                        = "allow-outbound-ssh-from-infraci-agents-to-aws-packer"
-  priority                    = 4079
-  direction                   = "Outbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "22"
-  source_address_prefix       = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
-  destination_address_prefix  = "*" # Allow all the internet for now need to define a correct target for packer vm in aws
-  resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
-  network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
-}
-
-# Allow infra.ci VM agents to reach packer VMs with WinRM (HTTP without TLS)
-resource "azurerm_network_security_rule" "allow_outbound_winrm_http_from_infraci_agents_to_packer_vms" {
-  provider               = azurerm.jenkins-sponsorship
-  name                   = "allow-outbound-winrm-http-from-infraci-agents-to-packer-vms"
-  priority               = 4081
-  direction              = "Outbound"
-  access                 = "Allow"
-  protocol               = "Tcp"
-  source_port_range      = "*"
-  destination_port_range = "5985"
-  source_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
-  ## Restriction to only Azure private subnet
-  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
-  ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
-  destination_address_prefix  = "*"
-  resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
-  network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
-}
-# Allow infra.ci VM agents to reach packer VMs with WinRM (HTTPS)
-resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infraci_agents_to_packer_vms" {
-  provider               = azurerm.jenkins-sponsorship
-  name                   = "allow-outbound-winrm-https-from-infraci-agents-to-packer-vms"
-  priority               = 4082
-  direction              = "Outbound"
-  access                 = "Allow"
-  protocol               = "Tcp"
-  source_port_range      = "*"
-  destination_port_range = "5986"
-  source_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.address_prefix
-  ## Restriction to only Azure private subnet
-  # destination_address_prefix  = data.azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.address_prefix
-  ## Allow all destinations as we cannot know the AWS EC2 public IPs of instance in advance
-  destination_address_prefix  = "*"
-  resource_group_name         = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
-  network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_nsg_name
 }


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4701
following: https://github.com/jenkins-infra/azure/pull/1113

fixup with both network ips in the destination prefixes AND a manual remove of the ressources group and gallery that remained from previous migration