### PR TITLE
fix(infra.ci.jenkins.io) fixup of #1118 (many errors)

### DIFF
--- a/infra.ci.jenkins.io-agents-sponsored.tf
+++ b/infra.ci.jenkins.io-agents-sponsored.tf
@@ -46,23 +46,11 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer" {
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.infra_ci_jenkins_io.object_id
 }
-resource "azurerm_role_assignment" "infra_ci_jenkins_io_read_packer" {
-  provider             = azurerm.jenkins-sponsorship
-  scope                = azurerm_resource_group.packer_images["prod"].id
-  role_definition_name = "Reader"
-  principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io.principal_id
-}
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_privatek8s_sponsorship_private_vnet_reader" {
   provider           = azurerm.jenkins-sponsorship
   scope              = data.azurerm_virtual_network.private_sponsorship.id
   role_definition_id = azurerm_role_definition.private_sponsorship_vnet_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.infra_ci_jenkins_io.object_id
-}
-resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io" {
-  provider            = azurerm.jenkins-sponsorship
-  location            = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.location
-  name                = "infracijenkinsio"
-  resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
 }
 
 # Required to allow controller to check for subnets inside the sponsorship network
@@ -81,12 +69,6 @@ resource "azurerm_role_assignment" "infra_controller_vnet_reader" {
   role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_vnet_sponsorship_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.infra_ci_jenkins_io.object_id
 }
-resource "azurerm_role_assignment" "infra_ci_jenkins_io_vnet_reader" {
-  provider           = azurerm.jenkins-sponsorship
-  scope              = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.id
-  role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_vnet_sponsorship_reader.role_definition_resource_id
-  principal_id       = azurerm_user_assigned_identity.infra_ci_jenkins_io.principal_id
-}
 
 module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
   providers = {
@@ -102,7 +84,6 @@ module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship" {
   controller_rg_name               = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   controller_ips                   = data.azurerm_subnet.privatek8s_sponsorship_infra_ci_controller_tier.address_prefixes # Pod IPs: controller IP may change in the pods IP subnet
   controller_service_principal_id  = azuread_service_principal.infra_ci_jenkins_io.object_id
-  additional_identities            = [azurerm_user_assigned_identity.infra_ci_jenkins_io.principal_id]
 
   default_tags         = local.default_tags
   storage_account_name = "infraciagentssub" # Max 24 chars

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -76,11 +76,10 @@ module "infra_ci_jenkins_io_azurevm_agents" {
   controller_rg_name               = azurerm_resource_group.infra_ci_jenkins_io_controller.name
   controller_ips                   = data.azurerm_subnet.privatek8s_sponsorship_infra_ci_controller_tier.address_prefixes # Pod IPs: controller IP may change in the pods IP subnet
   controller_service_principal_id  = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id
-  ## TODO: remove once sponsored subscrption agent are cleaned up if credentialless works
+  ## TODO: remove once sponsored subscription agent are cleaned up if credential-less works
   # additional_identities            = [azurerm_user_assigned_identity.infra_ci_jenkins_io.principal_id]
 
-  default_tags         = local.default_tags
-  storage_account_name = "infraciagentssub" # Max 24 chars
+  default_tags = local.default_tags
 
   jenkins_infra_ips = {
     privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
@@ -185,7 +184,7 @@ resource "azurerm_managed_disk" "infra_ci_jenkins_io_data" {
 }
 # Required to allow AKS CSI driver to access the Azure disk
 resource "azurerm_role_definition" "infra_ci_jenkins_io_controller_disk_reader" {
-  name  = "ReadInfraCISponsorshipDisk"
+  name  = "ReadInfraCIDisk"
   scope = azurerm_resource_group.infra_ci_jenkins_io_controller.id
 
   permissions {

--- a/infraci.jenkins.io-agents-2.tf
+++ b/infraci.jenkins.io-agents-2.tf
@@ -156,11 +156,12 @@ resource "kubernetes_service_account" "infracijenkinsio_agents_2_infra_ci_jenkin
   }
 }
 resource "azurerm_federated_identity_credential" "infracijenkinsio_agents_2_infra_ci_jenkins_io_agents" {
-  name                = "infracijenkinsio-agents-2-${kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}"
-  resource_group_name = azurerm_kubernetes_cluster.infracijenkinsio_agents_2.resource_group_name
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = azurerm_kubernetes_cluster.infracijenkinsio_agents_2.oidc_issuer_url
-  parent_id           = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents.id
+  name      = "infracijenkinsio-agents-2-${kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}"
+  audience  = ["api://AzureADTokenExchange"]
+  issuer    = azurerm_kubernetes_cluster.infracijenkinsio_agents_2.oidc_issuer_url
+  parent_id = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents.id
+  # RG must be the same for both the UAID and the federated ID
+  resource_group_name = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents.resource_group_name
   subject             = "system:serviceaccount:${kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}:${kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,12 +18,12 @@ resource "local_file" "jenkins_infra_data_report" {
       "controller_namespace"       = kubernetes_namespace.privatek8s_sponsorship["jenkins-infra"].metadata[0].name,
       "controller_service_account" = kubernetes_service_account.privatek8s_sponsorship_jenkins_infra_controller.metadata[0].name,
       "agents_azure_vms" = {
-        "resource_group_name"         = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_resource_group_name,
-        "network_resource_group_name" = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_rg_name,
-        "virtual_network_name"        = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_network_name,
-        "sub_network_name"            = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_subnet_name,
-        "storage_account_name"        = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.ephemeral_agents_storage_account_name,
-        "user_assigned_identity"      = azurerm_user_assigned_identity.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsorship.id,
+        "resource_group_name"         = module.infra_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name,
+        "network_resource_group_name" = module.infra_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_rg_name,
+        "virtual_network_name"        = module.infra_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_name,
+        "sub_network_name"            = module.infra_ci_jenkins_io_azurevm_agents.ephemeral_agents_subnet_name,
+        "storage_account_name"        = module.infra_ci_jenkins_io_azurevm_agents.ephemeral_agents_storage_account_name,
+        "user_assigned_identity"      = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents.id,
       },
       "agents_kubernetes_clusters" = {
         "infracijenkinsio_agents_2" = {
@@ -141,4 +141,11 @@ output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_application_clie
 output "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
   value     = module.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
+}
+output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
+  sensitive = true
+  value     = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -501,7 +501,7 @@ resource "kubernetes_persistent_volume_claim" "jenkins_release_data_sponsorship"
 
 ### Workload Identity Resources
 
-## For infra.ci.jenkins.io controller
+## For infra.ci.jenkins.io controllerinfracijenkinsio_agents_2_infra_ci_jenkins_io_agents
 resource "kubernetes_service_account" "privatek8s_sponsorship_jenkins_infra_controller" {
   provider = kubernetes.privatek8s_sponsorship
 
@@ -510,7 +510,7 @@ resource "kubernetes_service_account" "privatek8s_sponsorship_jenkins_infra_cont
     namespace = kubernetes_namespace.privatek8s_sponsorship["jenkins-infra"].metadata[0].name
 
     annotations = {
-      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.infra_ci_jenkins_io.client_id,
+      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.client_id,
     }
   }
 }
@@ -520,7 +520,7 @@ resource "azurerm_federated_identity_credential" "privatek8s_sponsorship_jenkins
   resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
   audience            = ["api://AzureADTokenExchange"]
   issuer              = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
-  parent_id           = azurerm_user_assigned_identity.infra_ci_jenkins_io.id
+  parent_id           = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.id
   subject             = "system:serviceaccount:${kubernetes_namespace.privatek8s_sponsorship["jenkins-infra"].metadata[0].name}:${kubernetes_service_account.privatek8s_sponsorship_jenkins_infra_controller.metadata[0].name}"
 }
 ## End of infra.ci


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4692
See https://github.com/jenkins-infra/azure/pull/1118#issuecomment-3112773659

- Fix the infra.ci agents storage account naming to avoid collisions
- Update outputs (add missing elements and switch report to infra.ci CDF agents setup)
- NSG rules failed to create with `Rules cannot have the same Priority and Direction` have been manually removed so replacement will happen once this PR is merged
- Role Definition `azurerm_role_definition.infra_ci_jenkins_io_controller_disk_reader` not created due to `RoleDefinitionWithSameNameExists: A custom role with the same name already` error:  typo fixed (removing the "sponsoring" string in the name
- Remove the (currently unused) UAID `infra_ci_jenkins_io` from the sponsored subscrption in favor of the new one created in #1118 in the CDF subscrption (will update infra.ci controller as it changes its service account: will requires a restart of the pod to be effective AFAICT)