### PR TITLE
fix(infra.ci, cert.ci, trusted.ci) allow controllers to read the CDF packer resource group

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -28,7 +28,8 @@ module "cert_ci_jenkins_io" {
     data.azuread_service_principal.terraform_production.object_id,
   ]
   controller_packer_rg_ids = [
-    azurerm_resource_group.packer_images["prod"].id
+    azurerm_resource_group.packer_images["prod"].id,
+    azurerm_resource_group.packer_images_cdf["prod"].id,
   ]
 
   agent_ip_prefixes = concat(

--- a/infra.ci.jenkins.io-agents-sponsored.tf
+++ b/infra.ci.jenkins.io-agents-sponsored.tf
@@ -41,8 +41,13 @@ resource "azuread_application_password" "infra_ci_jenkins_io" {
   display_name   = "infra.ci.jenkins.io-tf-managed"
   end_date       = "2025-09-07T00:00:00Z"
 }
-resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer" {
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer_sponso" {
   scope                = azurerm_resource_group.packer_images["prod"].id
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.infra_ci_jenkins_io.object_id
+}
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer_cdf" {
+  scope                = azurerm_resource_group.packer_images_cdf["prod"].id
   role_definition_name = "Reader"
   principal_id         = azuread_service_principal.infra_ci_jenkins_io.object_id
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -36,7 +36,8 @@ module "trusted_ci_jenkins_io" {
     "b847a030-25e1-4791-ad04-9e8484d87bce",
   ]
   controller_packer_rg_ids = [
-    azurerm_resource_group.packer_images["prod"].id
+    azurerm_resource_group.packer_images["prod"].id,
+    azurerm_resource_group.packer_images_cdf["prod"].id,
   ]
 
   agent_ip_prefixes = concat(


### PR DESCRIPTION
Fixup of #1113 for https://github.com/jenkins-infra/helpdesk/issues/4701

See https://github.com/jenkins-infra/jenkins-infra/pull/4292#issuecomment-3112924781 for the cause and error fixed