### PR TITLE
fix(privatek8s) ensure federated IDs are using the same resource group as their parent principal identity

### DIFF
--- a/infraci.jenkins.io-agents-2.tf
+++ b/infraci.jenkins.io-agents-2.tf
@@ -160,7 +160,7 @@ resource "azurerm_federated_identity_credential" "infracijenkinsio_agents_2_infr
   audience  = ["api://AzureADTokenExchange"]
   issuer    = azurerm_kubernetes_cluster.infracijenkinsio_agents_2.oidc_issuer_url
   parent_id = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents.id
-  # RG must be the same for both the UAID and the federated ID
+  # RG must be the same for both the UAID and the federated ID (otherwise you get HTTP/404 during the "apply" phase)
   resource_group_name = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents.resource_group_name
   subject             = "system:serviceaccount:${kubernetes_namespace.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}:${kubernetes_service_account.infracijenkinsio_agents_2_infra_ci_jenkins_io_agents.metadata[0].name}"
 }

--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -515,11 +515,12 @@ resource "kubernetes_service_account" "privatek8s_sponsorship_jenkins_infra_cont
   }
 }
 resource "azurerm_federated_identity_credential" "privatek8s_sponsorship_jenkins_infra_controller" {
-  provider            = azurerm.jenkins-sponsorship
-  name                = "privatek8s-sponsorship-${kubernetes_service_account.privatek8s_sponsorship_jenkins_infra_controller.metadata[0].name}"
-  resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller_jenkins_sponsorship.name
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
+  provider = azurerm.jenkins-sponsorship
+  name     = "privatek8s-sponsorship-${kubernetes_service_account.privatek8s_sponsorship_jenkins_infra_controller.metadata[0].name}"
+  audience = ["api://AzureADTokenExchange"]
+  issuer   = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
+  # RG must be the same for both the UAID and the federated ID (otherwise you get HTTP/404 during the "apply" phase)
+  resource_group_name = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.resource_group_name
   parent_id           = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.id
   subject             = "system:serviceaccount:${kubernetes_namespace.privatek8s_sponsorship["jenkins-infra"].metadata[0].name}:${kubernetes_service_account.privatek8s_sponsorship_jenkins_infra_controller.metadata[0].name}"
 }
@@ -539,11 +540,12 @@ resource "kubernetes_service_account" "privatek8s_sponsorship_jenkins_release_ag
   }
 }
 resource "azurerm_federated_identity_credential" "privatek8s_sponsorship_jenkins_release_agents" {
-  provider            = azurerm.jenkins-sponsorship
-  name                = "privatek8s-sponsorship-${kubernetes_service_account.privatek8s_sponsorship_jenkins_release_agents.metadata[0].name}"
-  resource_group_name = azurerm_kubernetes_cluster.privatek8s_sponsorship.resource_group_name
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
+  provider = azurerm.jenkins-sponsorship
+  name     = "privatek8s-sponsorship-${kubernetes_service_account.privatek8s_sponsorship_jenkins_release_agents.metadata[0].name}"
+  audience = ["api://AzureADTokenExchange"]
+  issuer   = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
+  # RG must be the same for both the UAID and the federated ID (otherwise you get HTTP/404 during the "apply" phase)
+  resource_group_name = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.resource_group_name
   parent_id           = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.id
   subject             = "system:serviceaccount:${kubernetes_namespace.privatek8s_sponsorship["jenkins-release-agents"].metadata[0].name}:${kubernetes_service_account.privatek8s_sponsorship_jenkins_release_agents.metadata[0].name}"
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4692

Fixup of #1118 and #1119: see https://github.com/jenkins-infra/azure/pull/1119#issuecomment-3112936240 for details about the error it fixes