### PR TITLE
chore(release.ci/trusted.ci) rename resources and cleanup unused 'moved' blocks

### DIFF
--- a/privatek8s-sponsorship.tf
+++ b/privatek8s-sponsorship.tf
@@ -534,7 +534,7 @@ resource "kubernetes_service_account" "privatek8s_sponsorship_jenkins_release_ag
     namespace = kubernetes_namespace.privatek8s_sponsorship["jenkins-release-agents"].metadata[0].name
 
     annotations = {
-      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.client_id,
+      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsorship.client_id,
     }
   }
 }
@@ -544,8 +544,8 @@ resource "azurerm_federated_identity_credential" "privatek8s_sponsorship_jenkins
   audience = ["api://AzureADTokenExchange"]
   issuer   = azurerm_kubernetes_cluster.privatek8s_sponsorship.oidc_issuer_url
   # RG must be the same for both the UAID and the federated ID (otherwise you get HTTP/404 during the "apply" phase)
-  resource_group_name = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.resource_group_name
-  parent_id           = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.id
+  resource_group_name = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsorship.resource_group_name
+  parent_id           = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsorship.id
   subject             = "system:serviceaccount:${kubernetes_namespace.privatek8s_sponsorship["jenkins-release-agents"].metadata[0].name}:${kubernetes_service_account.privatek8s_sponsorship_jenkins_release_agents.metadata[0].name}"
 }
 ## End of release.ci.jenkins.io agents

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -1,3 +1,4 @@
+#### TODO: remove resources below when cleaning up for https://github.com/jenkins-infra/helpdesk/issues/4690
 resource "azurerm_resource_group" "release_ci_jenkins_io_controller_jenkins_sponsorship" {
   provider = azurerm.jenkins-sponsorship
   name     = "release-ci-jenkins-io-controller"
@@ -34,16 +35,24 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_sponsorship
   role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_sponsorship_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsorship.identity[0].principal_id
 }
-
-resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents" {
+moved {
+  from = azurerm_user_assigned_identity.release_ci_jenkins_io_agents
+  to   = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsorship
+}
+resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents_sponsorship" {
   provider            = azurerm.jenkins-sponsorship
   location            = var.location
   name                = "release-ci-jenkins-io-agents"
   resource_group_name = azurerm_kubernetes_cluster.privatek8s_sponsorship.resource_group_name
 }
-resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_buildsreports_share" {
+moved {
+  from = azurerm_role_assignment.release_ci_jenkins_io_azurevm_agents_write_buildsreports_share
+  to   = azurerm_role_assignment.release_ci_jenkins_io_azurevm_agents_write_buildsreports_share_sponsorship
+}
+resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_buildsreports_share_sponsorship" {
   scope = azurerm_storage_account.builds_reports_jenkins_io.id
   # Allow writing
   role_definition_name = "Storage File Data Privileged Contributor"
-  principal_id         = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.principal_id
+  principal_id         = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsorship.principal_id
 }
+####


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4690

Required for #1133 so naming is easier and avoid confusion between subscriptions