### PR TITLE
feat(release.ci,privatek8s) manage SVC account for release.ci.jenkins.io controller

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -40,8 +40,9 @@ resource "local_file" "jenkins_infra_data_report" {
       },
     },
     "release.ci.jenkins.io" = {
-      "controller_namespace" = kubernetes_namespace.privatek8s["release-ci-jenkins-io"].metadata[0].name,
-      "controller_pvc"       = kubernetes_persistent_volume_claim.privatek8s_release_ci_jenkins_io_data.metadata[0].name,
+      "controller_namespace"       = kubernetes_namespace.privatek8s["release-ci-jenkins-io"].metadata[0].name,
+      "controller_service_account" = kubernetes_service_account.privatek8s_release_ci_jenkins_io_controller.metadata[0].name,
+      "controller_pvc"             = kubernetes_persistent_volume_claim.privatek8s_release_ci_jenkins_io_data.metadata[0].name,
       "agents_kubernetes_clusters" = {
         "privatek8s" = {
           "agents_service_account" = kubernetes_service_account.privatek8s_release_ci_jenkins_io_agents.metadata[0].name,

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -519,7 +519,19 @@ resource "azurerm_federated_identity_credential" "privatek8s_infra_ci_jenkins_io
 }
 ## End of infra.ci
 
-## For release.ci.jenkins.io agents
+## For release.ci.jenkins.io
+resource "kubernetes_service_account" "privatek8s_release_ci_jenkins_io_controller" {
+  provider = kubernetes.privatek8s
+
+  metadata {
+    name      = "release-ci-jenkins-io-controller"
+    namespace = kubernetes_namespace.privatek8s["release-ci-jenkins-io"].metadata[0].name
+
+    annotations = {
+      "azure.workload.identity/client-id" = azurerm_user_assigned_identity.release_ci_jenkins_io_controller.client_id,
+    }
+  }
+}
 resource "kubernetes_service_account" "privatek8s_release_ci_jenkins_io_agents" {
   provider = kubernetes.privatek8s
 

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -3,7 +3,11 @@ resource "azurerm_resource_group" "release_ci_jenkins_io_controller" {
   location = var.location
   tags     = local.default_tags
 }
-
+resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_controller" {
+  location            = azurerm_resource_group.release_ci_jenkins_io_controller.location
+  name                = "releasecijenkinsiocontroller"
+  resource_group_name = azurerm_resource_group.release_ci_jenkins_io_controller.name
+}
 resource "azurerm_managed_disk" "release_ci_jenkins_io_data" {
   name                 = "release-ci-jenkins-io-data"
   location             = azurerm_resource_group.release_ci_jenkins_io_controller.location


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4690

This PR carries an improvement (compared to last migration in https://github.com/jenkins-infra/helpdesk/issues/4250) to allow the [Helmfile release used to set up release.ci container agent resources](https://github.com/jenkins-infra/kubernetes-management/blob/4d3f1ab3571ccecb14d2904a67ad3e77a8a1c9a0/clusters/privatek8s.yaml#L103-L110] to be independent from the controller's helmfile release.

It also paves the way to manage workload identity for release.ci controller.