### PR TITLE
fix(infra.ci/privatek8s) correct disk permission to allow access from the correct cluster

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -201,7 +201,7 @@ resource "azurerm_role_definition" "infra_ci_jenkins_io_controller_disk_reader" 
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_disk_reader" {
   scope              = azurerm_resource_group.infra_ci_jenkins_io_controller.id
   role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
-  principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsorship.identity[0].principal_id
+  principal_id       = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
 }
 
 ## Allow access to/from ACR endpoint

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -150,6 +150,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_releasepool" {
   upgrade_settings {
     max_surge = "10%"
   }
+  os_sku                = "AzureLinux"
   os_disk_type          = "Ephemeral"
   os_disk_size_gb       = 300 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series#dpdsv5-series (depends on the instance size)
   orchestrator_version  = local.aks_clusters["privatek8s"].kubernetes_version


### PR DESCRIPTION
Ref. github.com/jenkins-infra/helpdesk/issues/4690

This PR fixes the disk permissions to allow `privatek8s` to read and write all disks in the infra.ci.jenkins.io's controller resource group (CDF).

Fixup of https://github.com/jenkins-infra/azure/pull/1108 and https://github.com/jenkins-infra/azure/pull/1133