### PR TITLE
fix(infra.ci.jenkins.io) finish migration to privatek8s CDF cluster (cleanup leftovers from privatek8s-sponsorship and fix agent NSG rules)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -102,7 +102,7 @@ locals {
       ],
     },
     "infra.ci.jenkins.io" = {
-      "controller" = [data.azurerm_subnet.privatek8s_sponsorship_infra_ci_controller_tier.id],
+      "controller" = [data.azurerm_subnet.privatek8s_infra_ci_controller_tier.id],
       "agents" = [
         # VM agents (CDF subscription)
         data.azurerm_subnet.infra_ci_jenkins_io_ephemeral_agents.id,

--- a/vnets.tf
+++ b/vnets.tf
@@ -144,12 +144,6 @@ data "azurerm_subnet" "privatek8s_sponsorship_release_tier" {
   resource_group_name  = data.azurerm_resource_group.private_sponsorship.name
   virtual_network_name = data.azurerm_virtual_network.private_sponsorship.name
 }
-data "azurerm_subnet" "privatek8s_sponsorship_infra_ci_controller_tier" {
-  provider             = azurerm.jenkins-sponsorship
-  name                 = "privatek8s-sponsorship-infraci-ctrl-tier"
-  resource_group_name  = data.azurerm_resource_group.private_sponsorship.name
-  virtual_network_name = data.azurerm_virtual_network.private_sponsorship.name
-}
 data "azurerm_subnet" "privatek8s_sponsorship_release_ci_controller_tier" {
   provider             = azurerm.jenkins-sponsorship
   name                 = "privatek8s-sponsorship-releaseci-ctrl-tier"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4690

- Remove all infra.ci.jenkins leftover resources from `privatek8s-sponsorship`
- Fix the NSG rules to allow VM ephemeral agent to reach infra.ci.jenkins.io in the (CDF) privatek8s cluster