### PR TITLE
cleanup(trusted.ci/outputs) deprecate rsyncd data

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -65,14 +65,9 @@ resource "local_file" "jenkins_infra_data_report" {
         "share_uri"  = "/content/",
         "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_data.metadata[0].name,
       },
-      "redirections-unsecured" = {
+      "redirections" = {
         "share_name" = azurerm_storage_share.updates_jenkins_io_data.name
-        "share_uri"  = "/redirections-unsecured/",
-        "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_data.metadata[0].name,
-      },
-      "redirections-secured" = {
-        "share_name" = azurerm_storage_share.updates_jenkins_io_data.name
-        "share_uri"  = "/redirections-secured/",
+        "share_uri"  = "/redirections/",
         "pvc_name"   = kubernetes_persistent_volume_claim.updates_jenkins_io_data.metadata[0].name,
       },
       "geoip_data" = {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -294,12 +294,11 @@ resource "azurerm_network_security_rule" "allow_out_from_trusted_all_to_uc" {
   protocol          = "Tcp"
   source_port_range = "*"
   destination_port_ranges = [
-    "22",   # SSH (for rsync)
     "3390", # mirrorbits CLI (content)
   ]
   source_address_prefixes = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes
   destination_address_prefixes = [
-    # Update Center (mirrorbits CLI, rsync, etc.)
+    # Update Center (mirrorbits CLI)
     azurerm_private_endpoint.updates_jenkins_io_for_trustedci.private_service_connection[0].private_ip_address,
   ]
   resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name
@@ -399,12 +398,11 @@ resource "azurerm_network_security_rule" "allow_in_many_from_trusted_agents_to_u
   protocol          = "Tcp"
   source_port_range = "*"
   destination_port_ranges = [
-    "22",   # SSH (for rsync)
     "3390", # mirrorbits CLI (content)
   ]
   source_address_prefixes = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes
   destination_address_prefixes = [
-    # Update Center (mirrorbits CLI, rsync, etc.)
+    # Update Center (mirrorbits CLI)
     azurerm_private_endpoint.updates_jenkins_io_for_trustedci.private_service_connection[0].private_ip_address,
   ]
   resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4758#issuecomment-3159980783