### PR TITLE
cleanup: remove leftovers of the decommissioned Azure sponsored subscription and the shared terraform 'infra' module

### DIFF
--- a/archives.tf
+++ b/archives.tf
@@ -16,9 +16,6 @@ resource "azurerm_storage_account" "archives" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(concat(
-      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-    ))
     virtual_network_subnet_ids = concat(
       # Required for managing the resource
       local.app_subnets["infra.ci.jenkins.io"].agents,

--- a/builds.reports.jenkins.io.tf
+++ b/builds.reports.jenkins.io.tf
@@ -18,9 +18,6 @@ resource "azurerm_storage_account" "builds_reports_jenkins_io" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(concat(
-      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
-    ))
     virtual_network_subnet_ids = concat(
       [
         # Required for using the resource

--- a/contributors.jenkins.io.tf
+++ b/contributors.jenkins.io.tf
@@ -16,9 +16,6 @@ resource "azurerm_storage_account" "contributors_jenkins_io" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(concat(
-      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
-    ))
     virtual_network_subnet_ids = concat(
       [
         # Required for using the resource

--- a/docs.jenkins.io.tf
+++ b/docs.jenkins.io.tf
@@ -16,9 +16,6 @@ resource "azurerm_storage_account" "docs_jenkins_io" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(concat(
-      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
-    ))
     virtual_network_subnet_ids = concat(
       [
         # Required for using the resource

--- a/get.jenkins.io.tf
+++ b/get.jenkins.io.tf
@@ -24,8 +24,7 @@ resource "azurerm_storage_account" "get_jenkins_io" {
     default_action = "Deny"
     ip_rules = flatten(
       concat(
-        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-        module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
+        split(" ", local.external_services["pkg.origin.jenkins.io"]),
       )
     )
     virtual_network_subnet_ids = concat(

--- a/javadoc.jenkins.io.tf
+++ b/javadoc.jenkins.io.tf
@@ -17,11 +17,6 @@ resource "azurerm_storage_account" "javadoc_jenkins_io" {
   # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(
-      concat(
-        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-      )
-    )
     virtual_network_subnet_ids = concat(
       [
         # Required for using the resource

--- a/jenkins.io.tf
+++ b/jenkins.io.tf
@@ -17,11 +17,6 @@ resource "azurerm_storage_account" "jenkins_io" {
   # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(
-      concat(
-        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-      )
-    )
     virtual_network_subnet_ids = concat(
       [
         # Required for using the resource

--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -94,11 +94,6 @@ resource "azurerm_storage_account_network_rules" "ldap_access" {
   storage_account_id = azurerm_storage_account.ldap_backups.id
 
   default_action = "Deny"
-  ip_rules = flatten(
-    concat(
-      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-    )
-  )
   virtual_network_subnet_ids = concat(
     [
       # Mounting share in the publick8s AKS cluster

--- a/locals.tf
+++ b/locals.tf
@@ -22,13 +22,30 @@ locals {
     }
   }
 
+  # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+  outbound_ips_trusted_ci_jenkins_io = "104.209.128.236"
+  # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+  outbound_ips_infra_ci_jenkins_io = "20.57.120.46 52.179.141.53 172.210.200.59 20.10.193.4"
+  # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+  outbound_ips_private_vpn_jenkins_io = "172.176.126.194"
+  # TODO: remove when publick8s will be changed to a "private" cluster
+  outbound_ips_publick8s_jenkins_io = [
+    "20.22.30.74",  # Outbound IPv4 of the cluster LB
+    "20.22.30.9",   # Outbound IPv4 of the cluster LB
+    "20.85.71.108", # Outbound IPv4 of the cluster LB
+    "20.7.192.189", # Outbound IP of the NAT gateway - https://github.com/jenkins-infra/azure-net/blob/7aa7fc5a8a39dd7bafee0e89c4fffe096692baa8/outputs.tf#L23-L25
+  ]
+
+  admin_public_ips = {
+    dduportal = ["89.84.210.161"],
+    smerle33  = ["82.64.5.129"],
+    mwaite    = ["162.142.59.220"],
+  }
+
   # TODO: track with updatecli
   external_services = {
-    "updates.jenkins.io"     = "52.202.51.185",
-    "s390x.jenkins.io"       = "148.100.84.76",
-    "pkg.origin.jenkins.io"  = "52.202.51.185",
-    "archives.jenkins.io"    = "46.101.121.132",
-    "private.vpn.jenkins.io" = "172.176.126.194",
+    "pkg.origin.jenkins.io" = "52.202.51.185",
+    "archives.jenkins.io"   = "46.101.121.132",
   }
 
   # Ref. https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-githubs-ip-addresses

--- a/main.tf
+++ b/main.tf
@@ -4,10 +4,6 @@ data "azuread_service_principal" "terraform_production" {
   display_name = "terraform-azure-production"
 }
 
-module "jenkins_infra_shared_data" {
-  source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
-}
-
 # Resource groups used to store (and lock) our public IPs
 resource "azurerm_resource_group" "prod_public_ips" {
   name     = "prod-public-ips"

--- a/outputs.tf
+++ b/outputs.tf
@@ -107,6 +107,7 @@ resource "local_file" "jenkins_infra_data_report" {
         "ipv4" = azurerm_dns_a_record.privatek8s_private.records,
       }
     },
+    "admin_public_ips" = local.admin_public_ips,
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure.json"
 }

--- a/plugins.jenkins.io.tf
+++ b/plugins.jenkins.io.tf
@@ -17,11 +17,6 @@ resource "azurerm_storage_account" "plugins_jenkins_io" {
   # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(
-      concat(
-        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-      )
-    )
     virtual_network_subnet_ids = concat(
       [
         # Required for using the resource

--- a/puppet.jenkins.io.tf
+++ b/puppet.jenkins.io.tf
@@ -68,7 +68,7 @@ resource "azurerm_network_security_rule" "allow_inbound_ssh_from_admins_to_puppe
   destination_port_range = "22"
   source_address_prefixes = flatten(
     concat(
-      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
+      [for key, value in local.admin_public_ips : value]
     )
   )
   destination_address_prefix  = azurerm_linux_virtual_machine.puppet_jenkins_io.private_ip_address

--- a/stats.jenkins.io.tf
+++ b/stats.jenkins.io.tf
@@ -16,9 +16,6 @@ resource "azurerm_storage_account" "stats_jenkins_io" {
 
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(concat(
-      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value]
-    ))
     virtual_network_subnet_ids = concat(
       [
         # Required for using and populating the resource

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -336,8 +336,8 @@ resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_to_
 }
 # Ignore the rule as it does not detect the IP restriction to only update.jenkins.io"s host
 #trivy:ignore:azure-network-no-public-egress
-resource "azurerm_network_security_rule" "allow_outbound_ssh_from_permanent_agent_to_updatecenter" {
-  name                        = "allow-outbound-ssh-from-permanent-agent-to-updatecenter"
+resource "azurerm_network_security_rule" "allow_outbound_ssh_from_permanent_agent_to_pkg" {
+  name                        = "allow-outbound-ssh-from-permanent-agent-to-pkg"
   priority                    = 4080
   direction                   = "Outbound"
   access                      = "Allow"
@@ -345,7 +345,7 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_permanent_agen
   source_port_range           = "*"
   destination_port_range      = "22"
   source_address_prefix       = azurerm_linux_virtual_machine.trusted_permanent_agent.private_ip_address
-  destination_address_prefix  = local.external_services["updates.${data.azurerm_dns_zone.jenkinsio.name}"]
+  destination_address_prefix  = local.external_services["pkg.origin.jenkins.io"]
   resource_group_name         = module.trusted_ci_jenkins_io.controller_resourcegroup_name
   network_security_group_name = module.trusted_ci_jenkins_io.controller_nsg_name
 }

--- a/updatecli/updatecli.d/service-ips.yaml
+++ b/updatecli/updatecli.d/service-ips.yaml
@@ -1,0 +1,78 @@
+name: Update external service IPs
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getTrustedCiJenkinsIo:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: .trusted\.ci\.jenkins\.io.outbound_ips
+    transformers:
+      - trimprefix: "["
+      - trimsuffix: "]"
+
+  getInfraCiJenkinsIo:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: .infra\.ci\.jenkins\.io.outbound_ips
+    transformers:
+      - trimprefix: "["
+      - trimsuffix: "]"
+
+  getPrivateVpn:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: .private\.vpn\.jenkins\.io.outbound_ips
+    transformers:
+      - trimprefix: "["
+      - trimsuffix: "]"
+
+targets:
+  setTrustedCiJenkinsIo:
+    sourceid: getTrustedCiJenkinsIo
+    name: Update trusted.ci.jenkins.io outbound IPs
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.outbound_ips_trusted_ci_jenkins_io
+    scmid: default
+
+  setInfraCiJenkinsIo:
+    sourceid: getInfraCiJenkinsIo
+    name: Update infra.ci.jenkins.io outbound IPs
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.outbound_ips_infra_ci_jenkins_io
+    scmid: default
+
+  setPrivateVpn:
+    sourceid: getPrivateVpn
+    name: Update private.vpn.jenkins.io outbound IPs
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.outbound_ips_private_vpn_jenkins_io
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update the service IPs
+    spec:
+      labels:
+        - dependencies

--- a/updates.jenkins.io.tf
+++ b/updates.jenkins.io.tf
@@ -24,11 +24,6 @@ resource "azurerm_storage_account" "updates_jenkins_io" {
   # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"
   network_rules {
     default_action = "Deny"
-    ip_rules = flatten(
-      concat(
-        [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
-      )
-    )
     # Only NFS share means only private network access - https://learn.microsoft.com/en-us/azure/storage/files/files-nfs-protocol#security-and-networking
     virtual_network_subnet_ids = concat(
       [


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4765

Note: by stopping the usage of the terraform module, we are switching to an updatecli "automated updates" pattern instead.

A few important changes:

- Admin public IPs are migrated to `local` and also exported to the report (to migrate them on other projects)
- No more public admin IP allowed for storage accounts
- trusted.ci.jenkins.io: using the `pkg.origin.jenkins.io` naming instead of `updates.jenkins.io` since we migrated the Update Center a few months ago

----

Updatecli check is expected to fail (diff on a remote, not local branch) but was tested locally with success by commenting out the target's `scmid` attributes