### PR TITLE
feat(release.ci.jenkins.io/privatek8s) create data-storage NFS PV/PVS for packaging agents

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,20 @@ resource "local_file" "jenkins_infra_data_report" {
         "privatek8s" = {
           "agents_service_account" = kubernetes_service_account.privatek8s_release_ci_jenkins_io_agents.metadata[0].name,
         }
+        "persistentVolumeClaims" = {
+          "binary-core-packages" = {
+            "share_uri" = "/",
+            "pvc_name"  = kubernetes_persistent_volume_claim.privatek8s_core_packages["binary-core-packages"].metadata[0].name,
+          },
+          "website-core-packages" = {
+            "share_uri" = "/",
+            "pvc_name"  = kubernetes_persistent_volume_claim.privatek8s_core_packages["website-core-packages"].metadata[0].name,
+          }
+          "data-storage-jenkins-io" = {
+            "share_uri" = "/",
+            "pvc_name"  = kubernetes_persistent_volume_claim.privatek8s_release_ci_jenkins_io_agents_data_storage.metadata[0].name,
+          }
+        }
       }
     },
     "trusted.ci.jenkins.io" = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,11 +46,11 @@ resource "local_file" "jenkins_infra_data_report" {
         "persistentVolumeClaims" = {
           "binary-core-packages" = {
             "share_uri" = "/",
-            "pvc_name"  = kubernetes_persistent_volume_claim.privatek8s_core_packages["binary-core-packages"].metadata[0].name,
+            "pvc_name"  = kubernetes_persistent_volume_claim.privatek8s_core_packages["binary"].metadata[0].name,
           },
           "website-core-packages" = {
             "share_uri" = "/",
-            "pvc_name"  = kubernetes_persistent_volume_claim.privatek8s_core_packages["website-core-packages"].metadata[0].name,
+            "pvc_name"  = kubernetes_persistent_volume_claim.privatek8s_core_packages["website"].metadata[0].name,
           }
           "data-storage-jenkins-io" = {
             "share_uri" = "/",

--- a/privatek8s.tf
+++ b/privatek8s.tf
@@ -306,101 +306,6 @@ resource "kubernetes_storage_class" "privatek8s_statically_provisioned" {
   allow_volume_expansion = true
 }
 
-## Persistent Volumes
-# File shares used by release.ci.jenkins.io agents (storing pkg.jion, get.jio, etc. data)
-resource "kubernetes_secret" "privatek8s_core_packages" {
-  provider = kubernetes.privatek8s
-
-  wait_for_service_account_token = false
-
-  metadata {
-    name      = "core-packages"
-    namespace = kubernetes_namespace.privatek8s["release-ci-jenkins-io-agents"].metadata[0].name
-  }
-
-  data = {
-    azurestorageaccountname = azurerm_storage_account.get_jenkins_io.name
-    azurestorageaccountkey  = azurerm_storage_account.get_jenkins_io.primary_access_key
-  }
-
-  type = "Opaque"
-}
-locals {
-  privatek8s_core_packages = {
-    "binary" = {
-      share_name = azurerm_storage_share.get_jenkins_io.name,
-      size_in_gb = azurerm_storage_share.get_jenkins_io.quota,
-    },
-    "website" = {
-      share_name = azurerm_storage_share.get_jenkins_io_website.name,
-      size_in_gb = azurerm_storage_share.get_jenkins_io_website.quota,
-    },
-  }
-}
-resource "kubernetes_persistent_volume" "privatek8s_core_packages" {
-  provider = kubernetes.privatek8s
-
-  for_each = local.privatek8s_core_packages
-
-  metadata {
-    name = "${each.key}-core-packages"
-  }
-  spec {
-    capacity = {
-      storage = "${each.value["size_in_gb"]}Gi"
-    }
-    access_modes                     = ["ReadWriteMany"]
-    persistent_volume_reclaim_policy = "Retain"
-    storage_class_name               = kubernetes_storage_class.privatek8s_statically_provisioned.id
-    mount_options = [
-      "dir_mode=0777",
-      "file_mode=0777",
-      "uid=1000",
-      "gid=1000",
-      "mfsymlinks",
-      "cache=strict", # Default on usual kernels but worth setting it explicitly
-      "nosharesock",  # Use new TCP connection for each CIFS mount (need more memory but avoid lost packets to create mount timeouts)
-      "nobrl",        # disable sending byte range lock requests to the server and for applications which have challenges with posix locks
-    ]
-    persistent_volume_source {
-      csi {
-        driver = "file.csi.azure.com"
-        # fs_type = "ext4"
-        # `volumeHandle` must be unique on the cluster for this volume
-        volume_handle = "${each.key}-core-packages"
-        read_only     = false
-        volume_attributes = {
-          resourceGroup = azurerm_resource_group.get_jenkins_io.name
-          shareName     = each.value["share_name"]
-        }
-        node_stage_secret_ref {
-          name      = kubernetes_secret.privatek8s_core_packages.metadata[0].name
-          namespace = kubernetes_secret.privatek8s_core_packages.metadata[0].namespace
-        }
-      }
-    }
-  }
-}
-resource "kubernetes_persistent_volume_claim" "privatek8s_core_packages" {
-  provider = kubernetes.privatek8s
-
-  for_each = local.privatek8s_core_packages
-
-  metadata {
-    name      = "${each.key}-core-packages"
-    namespace = kubernetes_secret.privatek8s_core_packages.metadata[0].namespace
-  }
-  spec {
-    access_modes       = kubernetes_persistent_volume.privatek8s_core_packages[each.key].spec[0].access_modes
-    volume_name        = kubernetes_persistent_volume.privatek8s_core_packages[each.key].metadata[0].name
-    storage_class_name = kubernetes_persistent_volume.privatek8s_core_packages[each.key].spec[0].storage_class_name
-    resources {
-      requests = {
-        storage = "${each.value["size_in_gb"]}Gi"
-      }
-    }
-  }
-}
 # Persistent Volumes for infra.ci controller
 resource "kubernetes_persistent_volume" "privatek8s_infra_ci_jenkins_io_data" {
   provider = kubernetes.privatek8s
@@ -464,7 +369,7 @@ resource "kubernetes_persistent_volume" "privatek8s_release_ci_jenkins_io_data" 
   }
 }
 resource "kubernetes_namespace" "privatek8s" {
-  for_each = toset(["release-ci-jenkins-io", "infra-ci-jenkins-io", "release-ci-jenkins-io-agents"])
+  for_each = toset(["release-ci-jenkins-io", "infra-ci-jenkins-io", "release-ci-jenkins-io-agents", "data-storage-jenkins-io"])
   provider = kubernetes.privatek8s
   metadata {
     name = each.key
@@ -491,7 +396,21 @@ resource "kubernetes_persistent_volume_claim" "privatek8s_release_ci_jenkins_io_
     }
   }
 }
+resource "kubernetes_secret" "privatek8s_data_storage_jenkins_io_storage_account" {
+  provider = kubernetes.privatek8s
 
+  metadata {
+    name      = "data-storage-jenkins-io-storage-account"
+    namespace = kubernetes_namespace.privatek8s["data-storage-jenkins-io"].metadata[0].name
+  }
+
+  data = {
+    azurestorageaccountname = azurerm_storage_account.data_storage_jenkins_io.name
+    azurestorageaccountkey  = azurerm_storage_account.data_storage_jenkins_io.primary_access_key
+  }
+
+  type = "Opaque"
+}
 
 ###################################################################################
 ## Workload Identity Resources

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -98,3 +98,157 @@ resource "azurerm_key_vault" "prodreleasecore" {
     ]
   }
 }
+
+######## Persistent Volumes used by the "packaging" job
+# kubernetes_namespace.privatek8s["release-ci-jenkins-io-agents"].metadata[0].name
+resource "kubernetes_persistent_volume" "privatek8s_release_ci_jenkins_io_agents_data_storage" {
+  provider = kubernetes.privatek8s
+  metadata {
+    name = "release-ci-jenkins-io-agents-data-storage"
+  }
+  spec {
+    capacity = {
+      storage = "${azurerm_storage_share.data_storage_jenkins_io.quota}Gi"
+    }
+    access_modes                     = ["ReadWriteMany"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = kubernetes_storage_class.privatek8s_statically_provisioned.id
+    mount_options = [
+      "nconnect=4", # Mandatory value (4) for Premium Azure File Share NFS 4.1. Increasing require using NetApp NFS instead ($$$)
+      "noresvport", # ref. https://linux.die.net/man/5/nfs
+      "actimeo=10", # Data is changed quite often
+      "cto",        # Ensure data consistency at the cost of slower I/O
+    ]
+    persistent_volume_source {
+      csi {
+        driver  = "file.csi.azure.com"
+        fs_type = "ext4"
+        # `volumeHandle` must be unique on the cluster for this volume
+        volume_handle = "release-ci-jenkins-io-agents-data-storage"
+        read_only     = false
+        volume_attributes = {
+          protocol       = "nfs"
+          resourceGroup  = azurerm_storage_account.data_storage_jenkins_io.resource_group_name
+          shareName      = azurerm_storage_share.data_storage_jenkins_io.name
+          storageAccount = azurerm_storage_account.data_storage_jenkins_io.name
+        }
+        node_stage_secret_ref {
+          name      = kubernetes_secret.privatek8s_data_storage_jenkins_io_storage_account.metadata[0].name
+          namespace = kubernetes_secret.privatek8s_data_storage_jenkins_io_storage_account.metadata[0].namespace
+        }
+      }
+    }
+  }
+}
+resource "kubernetes_persistent_volume_claim" "privatek8s_release_ci_jenkins_io_agents_data_storage" {
+  provider = kubernetes.privatek8s
+  metadata {
+    name      = "data-storage-jenkins-io"
+    namespace = kubernetes_namespace.privatek8s["release-ci-jenkins-io-agents"].metadata[0].name
+  }
+  spec {
+    access_modes       = kubernetes_persistent_volume.privatek8s_release_ci_jenkins_io_agents_data_storage.spec[0].access_modes
+    volume_name        = kubernetes_persistent_volume.privatek8s_release_ci_jenkins_io_agents_data_storage.metadata[0].name
+    storage_class_name = kubernetes_persistent_volume.privatek8s_release_ci_jenkins_io_agents_data_storage.spec[0].storage_class_name
+    resources {
+      requests = {
+        storage = kubernetes_persistent_volume.privatek8s_release_ci_jenkins_io_agents_data_storage.spec[0].capacity.storage
+      }
+    }
+  }
+}
+### TODO: delete once migrated to the new NFS data-storage
+resource "kubernetes_secret" "privatek8s_core_packages" {
+  provider = kubernetes.privatek8s
+
+  wait_for_service_account_token = false
+
+  metadata {
+    name      = "core-packages"
+    namespace = kubernetes_namespace.privatek8s["release-ci-jenkins-io-agents"].metadata[0].name
+  }
+
+  data = {
+    azurestorageaccountname = azurerm_storage_account.get_jenkins_io.name
+    azurestorageaccountkey  = azurerm_storage_account.get_jenkins_io.primary_access_key
+  }
+
+  type = "Opaque"
+}
+locals {
+  privatek8s_core_packages = {
+    "binary" = {
+      share_name = azurerm_storage_share.get_jenkins_io.name,
+      size_in_gb = azurerm_storage_share.get_jenkins_io.quota,
+    },
+    "website" = {
+      share_name = azurerm_storage_share.get_jenkins_io_website.name,
+      size_in_gb = azurerm_storage_share.get_jenkins_io_website.quota,
+    },
+  }
+}
+resource "kubernetes_persistent_volume" "privatek8s_core_packages" {
+  provider = kubernetes.privatek8s
+
+  for_each = local.privatek8s_core_packages
+
+  metadata {
+    name = "${each.key}-core-packages"
+  }
+  spec {
+    capacity = {
+      storage = "${each.value["size_in_gb"]}Gi"
+    }
+    access_modes                     = ["ReadWriteMany"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = kubernetes_storage_class.privatek8s_statically_provisioned.id
+    mount_options = [
+      "dir_mode=0777",
+      "file_mode=0777",
+      "uid=1000",
+      "gid=1000",
+      "mfsymlinks",
+      "cache=strict", # Default on usual kernels but worth setting it explicitly
+      "nosharesock",  # Use new TCP connection for each CIFS mount (need more memory but avoid lost packets to create mount timeouts)
+      "nobrl",        # disable sending byte range lock requests to the server and for applications which have challenges with posix locks
+    ]
+    persistent_volume_source {
+      csi {
+        driver = "file.csi.azure.com"
+        # fs_type = "ext4"
+        # `volumeHandle` must be unique on the cluster for this volume
+        volume_handle = "${each.key}-core-packages"
+        read_only     = false
+        volume_attributes = {
+          resourceGroup = azurerm_resource_group.get_jenkins_io.name
+          shareName     = each.value["share_name"]
+        }
+        node_stage_secret_ref {
+          name      = kubernetes_secret.privatek8s_core_packages.metadata[0].name
+          namespace = kubernetes_secret.privatek8s_core_packages.metadata[0].namespace
+        }
+      }
+    }
+  }
+}
+resource "kubernetes_persistent_volume_claim" "privatek8s_core_packages" {
+  provider = kubernetes.privatek8s
+
+  for_each = local.privatek8s_core_packages
+
+  metadata {
+    name      = "${each.key}-core-packages"
+    namespace = kubernetes_secret.privatek8s_core_packages.metadata[0].namespace
+  }
+  spec {
+    access_modes       = kubernetes_persistent_volume.privatek8s_core_packages[each.key].spec[0].access_modes
+    volume_name        = kubernetes_persistent_volume.privatek8s_core_packages[each.key].metadata[0].name
+    storage_class_name = kubernetes_persistent_volume.privatek8s_core_packages[each.key].spec[0].storage_class_name
+    resources {
+      requests = {
+        storage = "${each.value["size_in_gb"]}Gi"
+      }
+    }
+  }
+}
+### End TODO: delete


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4767

In order to work with the future get.jenkins.io [with mirrorbits v0.6.0](https://github.com/jenkins-infra/helpdesk/issues/4764) and [NFS file system](https://github.com/jenkins-infra/helpdesk/issues/4767#issuecomment-3180139293), we need a PVC in `privatek8s`'s namespace where the [release.ci.jenkins.io Linux packaging agents](https://github.com/jenkins-infra/release/blob/master/PodTemplates.d/package-linux.yaml) are launched.

This is the goal of this PR.
Note: it also moves the set of PV/PVCs currently used into release.ci scope (easier to track and to cleanup once the move will be done)