### PR TITLE
fix(dockerhub-mirror) use existing private DNS zone for trusted.ci 

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -106,6 +106,7 @@ resource "azurerm_dns_a_record" "cert_ci_jenkins_io" {
 
 ## Allow access to/from ACR endpoint
 resource "azurerm_network_security_rule" "allow_out_https_from_cert_agents_to_acr" {
+  count                   = var.terratest ? 0 : 1
   name                    = "allow-out-https-from-agents-to-acr"
   priority                = 4050
   direction               = "Outbound"
@@ -123,6 +124,7 @@ resource "azurerm_network_security_rule" "allow_out_https_from_cert_agents_to_ac
   network_security_group_name = module.cert_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
 }
 resource "azurerm_network_security_rule" "allow_in_https_from_cert_agents_to_acr" {
+  count                   = var.terratest ? 0 : 1
   name                    = "allow-in-https-from-agents-to-acr"
   priority                = 4050
   direction               = "Inbound"

--- a/dockerhub-mirror.tf
+++ b/dockerhub-mirror.tf
@@ -75,7 +75,7 @@ resource "azurerm_private_endpoint" "dockerhub_mirror" {
 }
 
 resource "azurerm_private_dns_zone" "dockerhub_mirror" {
-  for_each = { for key, value in local.acr_private_links : key => value if !can(value["private_dns_zone_id"]) }
+  for_each = var.terratest ? {} : { for key, value in local.acr_private_links : key => value if !can(value["private_dns_zone_id"]) }
 
   # Conventional and static name required by Azure (otherwise automatic record creation does not work)
   name = "privatelink.azurecr.io"
@@ -87,7 +87,7 @@ resource "azurerm_private_dns_zone" "dockerhub_mirror" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dockerhub_mirror" {
-  for_each = { for key, value in local.acr_private_links : key => value if !can(value["private_dns_zone_id"]) }
+  for_each = var.terratest ? {} : { for key, value in local.acr_private_links : key => value if !can(value["private_dns_zone_id"]) }
 
   name = "privatelink.azurecr.io"
   # Private DNS zone name is static: we can only have one per RG

--- a/dockerhub-mirror.tf
+++ b/dockerhub-mirror.tf
@@ -49,7 +49,7 @@ locals {
 }
 
 resource "azurerm_private_endpoint" "dockerhub_mirror" {
-  for_each = local.acr_private_links
+  for_each = var.terratest ? {} : local.acr_private_links
 
   name = "acr-${each.key}"
 

--- a/dockerhub-mirror.tf
+++ b/dockerhub-mirror.tf
@@ -21,13 +21,13 @@ locals {
   acr_private_links = {
     "certcijenkinsio" = {
       "subnet_id" = data.azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.id,
-      "vnet_id"   = data.azurerm_virtual_network.cert_ci_jenkins_io.id
-      "rg_name"   = data.azurerm_virtual_network.cert_ci_jenkins_io.resource_group_name
+      "vnet_id"   = data.azurerm_virtual_network.cert_ci_jenkins_io.id,
+      "rg_name"   = data.azurerm_virtual_network.cert_ci_jenkins_io.resource_group_name,
     },
     "infracijenkinsio" = {
       "subnet_id" = data.azurerm_subnet.infra_ci_jenkins_io_ephemeral_agents.id,
-      "vnet_id"   = data.azurerm_virtual_network.infra_ci_jenkins_io.id
-      "rg_name"   = data.azurerm_virtual_network.infra_ci_jenkins_io.resource_group_name
+      "vnet_id"   = data.azurerm_virtual_network.infra_ci_jenkins_io.id,
+      "rg_name"   = data.azurerm_virtual_network.infra_ci_jenkins_io.resource_group_name,
     },
     "publick8s" = {
       "subnet_id" = data.azurerm_subnet.publick8s_tier.id,
@@ -40,9 +40,10 @@ locals {
       "rg_name"   = data.azurerm_resource_group.private.name,
     },
     "trustedcijenkinsio" = {
-      "subnet_id" = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,
-      "vnet_id"   = data.azurerm_virtual_network.trusted_ci_jenkins_io.id
-      "rg_name"   = data.azurerm_virtual_network.trusted_ci_jenkins_io.resource_group_name
+      "subnet_id"           = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.id,
+      "vnet_id"             = data.azurerm_virtual_network.trusted_ci_jenkins_io.id,
+      "rg_name"             = data.azurerm_virtual_network.trusted_ci_jenkins_io.resource_group_name,
+      "private_dns_zone_id" = azurerm_private_dns_zone.trusted_ci_jenkins_io.id,
     },
   }
 }
@@ -65,14 +66,16 @@ resource "azurerm_private_endpoint" "dockerhub_mirror" {
     is_manual_connection           = false
   }
   private_dns_zone_group {
-    name                 = "privatelink.azurecr.io"
-    private_dns_zone_ids = [azurerm_private_dns_zone.dockerhub_mirror[each.key].id]
+    name = "privatelink.azurecr.io"
+    private_dns_zone_ids = [
+      (can(each.value["private_dns_zone_id"]) ? each.value["private_dns_zone_id"] : azurerm_private_dns_zone.dockerhub_mirror[each.key].id),
+    ]
   }
   tags = local.default_tags
 }
 
 resource "azurerm_private_dns_zone" "dockerhub_mirror" {
-  for_each = local.acr_private_links
+  for_each = { for key, value in local.acr_private_links : key => value if !can(value["private_dns_zone_id"]) }
 
   # Conventional and static name required by Azure (otherwise automatic record creation does not work)
   name = "privatelink.azurecr.io"
@@ -84,7 +87,7 @@ resource "azurerm_private_dns_zone" "dockerhub_mirror" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dockerhub_mirror" {
-  for_each = local.acr_private_links
+  for_each = { for key, value in local.acr_private_links : key => value if !can(value["private_dns_zone_id"]) }
 
   name = "privatelink.azurecr.io"
   # Private DNS zone name is static: we can only have one per RG

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -204,6 +204,7 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_disk_reader" 
 
 ## Allow access to/from ACR endpoint
 resource "azurerm_network_security_rule" "allow_out_https_from_infra_ephemeral_agents_to_acr" {
+  count                  = var.terratest ? 0 : 1
   name                   = "allow-out-https-from-ephemeral-agents-to-acr"
   priority               = 4050
   direction              = "Outbound"
@@ -224,6 +225,7 @@ resource "azurerm_network_security_rule" "allow_out_https_from_infra_ephemeral_a
   network_security_group_name = module.infra_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
 }
 resource "azurerm_network_security_rule" "allow_in_https_from_infra_ephemeral_agents_to_acr" {
+  count                  = var.terratest ? 0 : 1
   name                   = "allow-in-https-from-ephemeral-agents-to-acr"
   priority               = 4050
   direction              = "Inbound"


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/azure/pull/1171#issuecomment-3199486226

Note: terratest are annoying here as they show the weakness of terraform plan on an empty platform when a lot of "dynamic" loops are used. As such, we do not "add" some resources when running in terratest to avoid errors.

This PR also adds NSG rules for trusted <-> ACR (missing in #1171)