### PR TITLE
cleanup: fix depreciation messages and remove unused directives

### DIFF
--- a/dockerhub-mirror.tf
+++ b/dockerhub-mirror.tf
@@ -107,7 +107,7 @@ resource "azurerm_key_vault" "dockerhub_mirror" {
   tenant_id                       = data.azurerm_client_config.current.tenant_id
   soft_delete_retention_days      = 7
   purge_protection_enabled        = false
-  enable_rbac_authorization       = true
+  rbac_authorization_enabled      = true
   enabled_for_deployment          = true
   enabled_for_disk_encryption     = true
   enabled_for_template_deployment = true

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -330,7 +330,7 @@ resource "azurerm_key_vault" "infra_ci_jenkins_io_vault" {
   enabled_for_disk_encryption     = true
   soft_delete_retention_days      = 90
   purge_protection_enabled        = false
-  enable_rbac_authorization       = false
+  rbac_authorization_enabled      = false
   enabled_for_deployment          = false
   enabled_for_template_deployment = false
   # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"

--- a/javadoc.jenkins.io.tf
+++ b/javadoc.jenkins.io.tf
@@ -73,10 +73,6 @@ resource "kubernetes_persistent_volume_claim" "javadoc_jenkins_io" {
 }
 
 ### TODO Remove below
-moved {
-  from = azurerm_resource_group.javadoc_jenkins_io
-  to   = azurerm_resource_group.javadocjenkinsio
-}
 resource "azurerm_resource_group" "javadocjenkinsio" {
   name     = "javadocjenkinsio"
   location = var.location

--- a/providers.tf
+++ b/providers.tf
@@ -30,14 +30,6 @@ provider "kubernetes" {
 }
 
 provider "kubernetes" {
-  alias                  = "cijenkinsio_agents_1"
-  host                   = local.aks_clusters_outputs.cijenkinsio_agents_1.cluster_hostname
-  client_certificate     = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_certificate)
-  client_key             = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.client_key)
-  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.cijenkinsio_agents_1.kube_config.0.cluster_ca_certificate)
-}
-
-provider "kubernetes" {
   alias                  = "infracijenkinsio_agents_2"
   host                   = local.aks_clusters_outputs.infracijenkinsio_agents_2.cluster_hostname
   client_certificate     = base64decode(azurerm_kubernetes_cluster.infracijenkinsio_agents_2.kube_config.0.client_certificate)

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -47,10 +47,6 @@ resource "azurerm_dns_a_record" "private_publick8s" {
 }
 
 #trivy:ignore:azure-container-logging #trivy:ignore:azure-container-limit-authorized-ips
-moved {
-  from = azurerm_kubernetes_cluster.new_publick8s
-  to   = azurerm_kubernetes_cluster.publick8s
-}
 resource "azurerm_kubernetes_cluster" "publick8s" {
   name     = local.aks_clusters["publick8s"].name
   location = azurerm_resource_group.publick8s.location

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -61,7 +61,7 @@ resource "azurerm_key_vault" "prodreleasecore" {
   enabled_for_disk_encryption     = false
   soft_delete_retention_days      = 90
   purge_protection_enabled        = false
-  enable_rbac_authorization       = false
+  rbac_authorization_enabled      = false
   enabled_for_deployment          = false
   enabled_for_template_deployment = false
   # Adding a network rule with `public_network_access_enabled` set to `true` (default) selects the option "Enabled from selected virtual networks and IP addresses"


### PR DESCRIPTION
Cleaning up things discovered along the way while working on #1187 #1188 #1190 and #1191.

No resources changes expected: it is only Terraform code cleanup (deleting `moved` block` already applied, removing unused provider, fixing `azurerm` provider depreciation messages