### PR TITLE
feat(weekly.ci,publick8s) set up a new RG and empty disk with proper naming convention

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -268,9 +268,9 @@ locals {
           disk_rg_id = "${azurerm_resource_group.ldap.id}",
         }
         "weekly-ci-jenkins-io" = {
-          disk_name  = "${azurerm_managed_disk.jenkins_weekly_data.name}",
-          disk_size  = "${azurerm_managed_disk.jenkins_weekly_data.disk_size_gb}",
-          disk_rg_id = "${azurerm_resource_group.weekly_ci_controller.id}",
+          disk_name  = "${azurerm_managed_disk.weekly_ci_jenkins_io.name}",
+          disk_size  = "${azurerm_managed_disk.weekly_ci_jenkins_io.disk_size_gb}",
+          disk_rg_id = "${azurerm_resource_group.weekly_ci_jenkins_io.id}",
         }
       }
     },

--- a/old_publick8s.tf
+++ b/old_publick8s.tf
@@ -901,3 +901,19 @@ resource "kubernetes_persistent_volume_claim" "www_jenkins_io" {
     }
   }
 }
+
+#### TODO: remove old resources below
+resource "azurerm_resource_group" "weekly_ci_controller" {
+  name     = "weekly-ci"
+  location = var.location
+}
+
+resource "azurerm_managed_disk" "jenkins_weekly_data" {
+  name                 = "jenkins-weekly-data"
+  location             = azurerm_resource_group.weekly_ci_controller.location
+  resource_group_name  = azurerm_resource_group.weekly_ci_controller.name
+  storage_account_type = "StandardSSD_ZRS"
+  create_option        = "Empty"
+  disk_size_gb         = 8
+  tags                 = local.default_tags
+}

--- a/publick8s.tf
+++ b/publick8s.tf
@@ -116,23 +116,6 @@ resource "azurerm_role_assignment" "publick8s_subnets_networkcontributor" {
   skip_service_principal_aad_check = true
 }
 
-# # Allow cluster to join NAT gateway. Required to manage Azure PLS through Kubernetes Services until old subnets are associated with the NAT gateway.
-# # TODO: uncomment if needed when creating the Kubernetes Service of type PLS
-# # resource "azurerm_role_definition" "publick8s_outbound_gateway" {
-# #   name  = "publick8s_outbount_gateway"
-# #   scope = data.azurerm_nat_gateway.publick8s_outbound.id
-# #   permissions {
-# #     actions = ["Microsoft.Network/natGateways/join/action"]
-# #   }
-# # }
-# # resource "azurerm_role_assignment" "publick8s_nat_gateway" {
-# #   scope                            = data.azurerm_nat_gateway.publick8s_outbound.id
-# #   role_definition_id               = azurerm_role_definition.publick8s_outbound_gateway.role_definition_resource_id
-# #   principal_id                     = azurerm_kubernetes_cluster.publick8s.identity[0].principal_id
-# #   skip_service_principal_aad_check = true
-# # }
-# ## End TODO remove
-
 # Each public load balancer used by this cluster is setup with a locked public IP.
 # Using a pre-determined public IP eases DNS setup and changes, but requires cluster to have the "Network Contributor" role on the IP.
 locals {

--- a/weekly.ci.jenkins.io.tf
+++ b/weekly.ci.jenkins.io.tf
@@ -1,12 +1,11 @@
-resource "azurerm_resource_group" "weekly_ci_controller" {
-  name     = "weekly-ci"
+resource "azurerm_resource_group" "weekly_ci_jenkins_io" {
+  name     = "weekly-ci-jenkins-io"
   location = var.location
 }
-
-resource "azurerm_managed_disk" "jenkins_weekly_data" {
-  name                 = "jenkins-weekly-data"
-  location             = azurerm_resource_group.weekly_ci_controller.location
-  resource_group_name  = azurerm_resource_group.weekly_ci_controller.name
+resource "azurerm_managed_disk" "weekly_ci_jenkins_io" {
+  name                 = "weekly-ci-jenkins-io"
+  location             = azurerm_resource_group.weekly_ci_jenkins_io.location
+  resource_group_name  = azurerm_resource_group.weekly_ci_jenkins_io.name
   storage_account_type = "StandardSSD_ZRS"
   create_option        = "Empty"
   disk_size_gb         = 8


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4617

This PR creates a new RG and a new disk for weekly.ci.jenkins.io:

- The new disk is empty, and will be populated twice: once with the initial data from old cluster `publick8s-endless-ghoul` and an second time at migration time.
- This is a process to ensure we can fully start the service in the new `publick8s` cluster without putting the old service (which is production until we migrate). We'll use this process (if it is working as expected) for LDAP (which also uses a disk)
- Only the new cluster will use this disk, instead of the old one: it will recreate permissions, PV and PVC of course.