### PR TITLE
feat(ldap-jenkins-io) create new RG and storages with proper naming convention

### DIFF
--- a/ldap.jenkins.io.tf
+++ b/ldap.jenkins.io.tf
@@ -1,3 +1,58 @@
+resource "azurerm_resource_group" "ldap_jenkins_io" {
+  name     = "ldap-jenkins-io"
+  location = var.location
+  tags     = local.default_tags
+}
+
+resource "azurerm_managed_disk" "ldap_jenkins_io_data_new" {
+  name                = "ldap-jenkins-io-data"
+  location            = azurerm_resource_group.ldap_jenkins_io.location
+  resource_group_name = azurerm_resource_group.ldap_jenkins_io.name
+  # ZRS to ensure we can move service across AZs
+  # Standard because it is enough for LDAP's IOPS and I/O bandwidth
+  # Ref. https://azure.microsoft.com/en-us/pricing/details/managed-disks/
+  storage_account_type = "StandardSSD_ZRS"
+  create_option        = "Empty"
+  # LDAP data set is between 300 and 500 Mb
+  # Class E1 (4G) only allow 7800 paid transactions per hour, while LDAP may peak at 8500 sometimes so E2 it is
+  # Ref. https://azure.microsoft.com/en-us/pricing/details/managed-disks/
+  disk_size_gb = 8
+  tags         = local.default_tags
+}
+resource "azurerm_storage_account" "ldap_jenkins_io" {
+  name                              = "ldapjenkinsio"
+  resource_group_name               = azurerm_resource_group.ldap_jenkins_io.name
+  location                          = azurerm_resource_group.ldap_jenkins_io.location
+  account_tier                      = "Standard"
+  account_replication_type          = "ZRS"
+  account_kind                      = "StorageV2"
+  https_traffic_only_enabled        = true
+  min_tls_version                   = "TLS1_2" # default value, needed for tfsec
+  infrastructure_encryption_enabled = true     # LDAP data is sensitive, even if password are encrypted
+
+  network_rules {
+    default_action = "Deny"
+    virtual_network_subnet_ids = concat(
+      [
+        # Required for using the resource
+        data.azurerm_subnet.publick8s.id,
+      ],
+      # Required for managing the resource
+      local.app_subnets["infra.ci.jenkins.io"].agents,
+    )
+    bypass = ["AzureServices"]
+  }
+
+  tags = local.default_tags
+}
+resource "azurerm_storage_share" "ldap_jenkins_io_backups" {
+  name               = "ldap"
+  storage_account_id = azurerm_storage_account.ldap_jenkins_io.id
+  # Unless this is a Premium Storage, we only pay for the storage we consume
+  quota = 10
+}
+
+## TODO: remove the resources below
 resource "azurerm_resource_group" "ldap" {
   name     = "ldap"
   location = var.location
@@ -5,7 +60,11 @@ resource "azurerm_resource_group" "ldap" {
 }
 
 ## LDAP uses the following data disk for its `/var/lib/ldap` data directory
-resource "azurerm_managed_disk" "ldap_jenkins_io_data" {
+moved {
+  from = azurerm_managed_disk.ldap_jenkins_io_data
+  to   = azurerm_managed_disk.ldap_jenkins_io_data_old
+}
+resource "azurerm_managed_disk" "ldap_jenkins_io_data_old" {
   name                = "ldap-jenkins-io-data"
   location            = azurerm_resource_group.ldap.location
   resource_group_name = azurerm_resource_group.ldap.name

--- a/locals.tf
+++ b/locals.tf
@@ -263,9 +263,9 @@ locals {
       }
       azuredisk_volumes = {
         "ldap-jenkins-io" = {
-          disk_name  = "${azurerm_managed_disk.ldap_jenkins_io_data.name}",
-          disk_size  = "${azurerm_managed_disk.ldap_jenkins_io_data.disk_size_gb}",
-          disk_rg_id = "${azurerm_resource_group.ldap.id}",
+          disk_name  = "${azurerm_managed_disk.ldap_jenkins_io_data_new.name}",
+          disk_size  = "${azurerm_managed_disk.ldap_jenkins_io_data_new.disk_size_gb}",
+          disk_rg_id = "${azurerm_resource_group.ldap_jenkins_io.id}",
         }
         "weekly-ci-jenkins-io" = {
           disk_name  = "${azurerm_managed_disk.weekly_ci_jenkins_io.name}",

--- a/old_publick8s.tf
+++ b/old_publick8s.tf
@@ -621,7 +621,7 @@ resource "kubernetes_persistent_volume" "ldap_jenkins_io_data" {
   }
   spec {
     capacity = {
-      storage = "${azurerm_managed_disk.ldap_jenkins_io_data.disk_size_gb}Gi"
+      storage = "${azurerm_managed_disk.ldap_jenkins_io_data_old.disk_size_gb}Gi"
     }
     access_modes                     = ["ReadWriteOnce"]
     persistent_volume_reclaim_policy = "Retain"
@@ -629,7 +629,7 @@ resource "kubernetes_persistent_volume" "ldap_jenkins_io_data" {
     persistent_volume_source {
       csi {
         driver        = "disk.csi.azure.com"
-        volume_handle = azurerm_managed_disk.ldap_jenkins_io_data.id
+        volume_handle = azurerm_managed_disk.ldap_jenkins_io_data_old.id
       }
     }
   }
@@ -646,7 +646,7 @@ resource "kubernetes_persistent_volume_claim" "ldap_jenkins_io_data" {
     storage_class_name = kubernetes_storage_class.statically_provisionned_publick8s.id
     resources {
       requests = {
-        storage = "${azurerm_managed_disk.ldap_jenkins_io_data.disk_size_gb}Gi"
+        storage = "${azurerm_managed_disk.ldap_jenkins_io_data_old.disk_size_gb}Gi"
       }
     }
   }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4617

Same as https://github.com/jenkins-infra/azure/pull/1203 but for LDAP with:

- New RG, storage account, file share and disk with proper naming convention
- Storages are empty and will need to be populated twice (once for initial filling, second at migration time)
- Will need a subsequent PR for renaming thing (will be a chore) once resources are created