### PR TITLE
cleanup(locals) removed old references from publick8s-endless-ghoul cluster

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -28,13 +28,6 @@ locals {
   outbound_ips_infra_ci_jenkins_io = "20.57.120.46 52.179.141.53 172.210.200.59 20.10.193.4"
   # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
   outbound_ips_private_vpn_jenkins_io = "52.232.183.117"
-  # TODO: remove when publick8s will be changed to a "private" cluster
-  outbound_ips_publick8s_jenkins_io = [
-    "20.22.30.74",  # Outbound IPv4 of the cluster LB
-    "20.22.30.9",   # Outbound IPv4 of the cluster LB
-    "20.85.71.108", # Outbound IPv4 of the cluster LB
-    "20.7.192.189", # Outbound IP of the NAT gateway - https://github.com/jenkins-infra/azure-net/blob/7aa7fc5a8a39dd7bafee0e89c4fffe096692baa8/outputs.tf#L23-L25
-  ]
 
   admin_public_ips = {
     dduportal = ["89.84.210.161"],


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4617#issuecomment-3332342227