### PR TITLE
chore(publick8s) bump patch version of AKS (1.32.6 -> 1.32.7)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -72,7 +72,7 @@ locals {
     },
     "publick8s" = {
       name               = "publick8s",
-      kubernetes_version = "1.32.6",
+      kubernetes_version = "1.32.7",
       # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
       pod_cidrs = [
         "10.100.0.0/14",       # 10.100.0.1 - 10.103.255.255


### PR DESCRIPTION
Following https://github.com/jenkins-infra/helpdesk/issues/4617

This PR bumps the `publick8s` cluster version (patch only) as a preliminary to https://github.com/jenkins-infra/helpdesk/issues/4817 with 2 goals:

- Ensure that the cluster is good (after the unexpected outage described in https://github.com/jenkins-infra/helpdesk/issues/4813 which we don't want to reproduce)
- Ensure that we'll have the same (latest) Kubernetes 1.32.x available version with the new other clusters to be upgraded

----

Expected change: all nodes will be re-created. Expecting a LDAP restart