### PR TITLE
fix(reports) allow access from trusted.ci agents

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -116,6 +116,12 @@ resource "local_file" "jenkins_infra_data_report" {
       },
       "namespace" = kubernetes_namespace.publick8s_namespaces["www-jenkins-io"].metadata[0].name,
     },
+    "reports.jenkins.io" = {
+      "data" = {
+        "pvc_name" = kubernetes_persistent_volume_claim.publick8s_azurefiles["reports-jenkins-io"].metadata[0].name,
+      },
+      "namespace" = kubernetes_namespace.publick8s_namespaces["reports-jenkins-io"].metadata[0].name,
+    },
     "publick8s" = {
       hostname           = azurerm_kubernetes_cluster.publick8s.fqdn,
       kubernetes_version = local.aks_clusters["publick8s"].kubernetes_version

--- a/reports.jenkins.io.tf
+++ b/reports.jenkins.io.tf
@@ -24,8 +24,10 @@ resource "azurerm_storage_account" "reports_jenkins_io" {
         # Required for using the resource
         data.azurerm_subnet.publick8s.id,
       ],
-      # Required for managing the resource
+      # Required for populating the resource from infra-reports
       local.app_subnets["infra.ci.jenkins.io"].agents,
+      # Required for populating the resource from coretaglib and RPU
+      local.app_subnets["trusted.ci.jenkins.io"].agents,
     )
     bypass = ["AzureServices"]
   }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4821#issuecomment-3372038800

We forgot to allow trusted.ci agents for reports storage