### PR TITLE
hotfix(vnets) remove non-existent (anymore) RG `infra-ci-jenkins-io`

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -11,9 +11,6 @@ data "azurerm_resource_group" "public" {
 data "azurerm_resource_group" "private" {
   name = "private"
 }
-data "azurerm_resource_group" "infra_ci_jenkins_io" {
-  name = "infra-ci-jenkins-io"
-}
 data "azurerm_resource_group" "infra_ci_jenkins_io_sponsored" {
   provider = azurerm.jenkins-sponsored
   name     = "infra-ci-jenkins-io-sponsored"


### PR DESCRIPTION
Following https://github.com/jenkins-infra/azure-net/pull/513, the resource group `infra-ci-jenkins-io` does not exist anymore.

Fixup of #1382 where we missed it because we forgot that we don't have the controller subnet in this RG (infra.ci.jenkins.io is running in an AKS controller, contrary to trusted.ci or cert.ci).

Related to https://github.com/jenkins-infra/helpdesk/issues/5042

It fixes the following error we see on the `main` branch and PRs:

```
11:12:01  Error: "Resource Group (Subscription: \"****\"\nResource Group Name: \"infra-ci-jenkins-io\")" was not found
11:12:01  
11:12:01    with data.azurerm_resource_group.infra_ci_jenkins_io,
11:12:01    on vnets.tf line 14, in data "azurerm_resource_group" "infra_ci_jenkins_io":
11:12:01    14: data "azurerm_resource_group" "infra_ci_jenkins_io" {
