### PR TITLE
chore(agent.trusted.ci): create new resource group in Sponsored subscription

### DIFF
--- a/agent.trusted.ci.jenkins.io.tf
+++ b/agent.trusted.ci.jenkins.io.tf
@@ -1,9 +1,9 @@
 ####################################################################################
 ## Resources for the permanent agent VM
 ####################################################################################
-resource "azurerm_resource_group" "permanent_agents_trusted_ci_jenkins_io_sponsored" {
+resource "azurerm_resource_group" "trusted_ci_jenkins_io_permanent_agents_jenkins_sponsored" {
   provider = azurerm.jenkins-sponsored
-  name     = "trusted-ci-jenkins-io-permanent-agents"
+  name     = "trusted-ci-jenkins-io-sponsored-permanent-agents"
   location = var.location
   tags     = local.default_tags
 }

--- a/agent.trusted.ci.jenkins.io.tf
+++ b/agent.trusted.ci.jenkins.io.tf
@@ -1,6 +1,13 @@
 ####################################################################################
 ## Resources for the permanent agent VM
 ####################################################################################
+resource "azurerm_resource_group" "permanent_agents_trusted_ci_jenkins_io_sponsored" {
+  provider = azurerm.jenkins-sponsored
+  name     = "trusted-ci-jenkins-io-permanent-agents"
+  location = var.location
+  tags     = local.default_tags
+}
+
 resource "azurerm_resource_group" "permanent_agents_trusted_ci_jenkins_io" {
   name     = "permanent-agents-trusted-ci-jenkins-io"
   location = var.location


### PR DESCRIPTION
This change creates the new RG that will be used to try out `dummy` resources migration via the Azure Portal, before proceeding to the permanent agent migration.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5067