### PR TITLE
chore(dummy): reimport resources into state

### DIFF
--- a/dummy.trusted.ci.jenkins.io.tf
+++ b/dummy.trusted.ci.jenkins.io.tf
@@ -1,45 +1,113 @@
 ####################################################################################
 ## Resources for the permanent agent VM
 ####################################################################################
-removed {
-  from = azurerm_network_interface.dummy_trusted_ci_jenkins_io
+resource "azurerm_network_interface" "dummy_trusted_ci_jenkins_io" {
+  name                = "dummy-trusted-ci-jenkins-io"
+  location            = azurerm_resource_group.permanent_agents_trusted_ci_jenkins_io.location
+  resource_group_name = azurerm_resource_group.permanent_agents_trusted_ci_jenkins_io.name
+  tags                = local.default_tags
 
-  lifecycle {
-    destroy = false
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = data.azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.id
+    private_ip_address_allocation = "Dynamic"
   }
 }
-removed {
-  from = azurerm_linux_virtual_machine.dummy_trusted_ci_jenkins_io
+resource "azurerm_linux_virtual_machine" "dummy_trusted_ci_jenkins_io" {
+  name                            = "dummy.trusted.ci.jenkins.io"
+  resource_group_name             = azurerm_resource_group.permanent_agents_trusted_ci_jenkins_io.name
+  location                        = azurerm_resource_group.permanent_agents_trusted_ci_jenkins_io.location
+  tags                            = local.default_tags
+  size                            = "Standard_B2s"
+  admin_username                  = local.admin_username
+  zone                            = "1" # We need a zonale deployment to attach a Premium_SSD_v2 data disk
+  disable_password_authentication = true
+  network_interface_ids = [
+    azurerm_network_interface.dummy_trusted_ci_jenkins_io.id,
+  ]
 
-  lifecycle {
-    destroy = false
+  admin_ssh_key {
+    username   = local.admin_username
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5K7Ro7jBl5Kc68RdzG6EXHstIBFSxO5Da8SQJSMeCbb4cHTYuBBH8jNsAFcnkN64kEu+YhmlxaWEVEIrPgfGfs13ZL7v9p+Nt76tsz6gnVdAy2zCz607pAWe7p4bBn6T9zdZcBSnvjawO+8t/5ue4ngcfAjanN5OsOgLeD6yqVyP8YTERjW78jvp2TFrIYmgWMI5ES1ln32PQmRZwc1eAOsyGJW/YIBdOxaSkZ41qUvb9b3dCorGuCovpSK2EeNphjLPpVX/NRpVY4YlDqAcTCdLdDrEeVqkiA/VDCYNhudZTDa8f1iHwBE/GEtlKmoO6dxJ5LAkRk3RIVHYrmI6XXSw5l0tHhW5D12MNwzUfDxQEzBpGK5iSfOBt5zJ5OiI9ftnsq/GV7vCXfvMVGDLUC551P5/s/wM70QmHwhlGQNLNeJxRTvd6tL11bof3K+29ivFYUmpU17iVxYOWhkNY86WyngHU6Ux0zaczF3H6H0tpg1Ca/cFO428AVPw/RTJpcAe6OVKq5zwARNApQ/p6fJKUAdXap+PpQGZlQhPLkUbwtFXGTrpX9ePTcdzryCYjgrZouvy4ZMzruJiIbFUH8mRY3xVREVaIsJakruvgw3b14oQgcB4BwYVBBqi62xIvbRzAv7Su9t2jK6OR2z3sM/hLJRqIJ5oILMORa7XqrQ== smerle@MacBook-Pro-de-Stephane.local"
+  }
+
+  user_data = base64encode(
+    templatefile("./.shared-tools/terraform/cloudinit.tftpl", {
+      hostname       = "dummy.trusted.ci.jenkins.io",
+      admin_username = local.admin_username,
+      }
+  ))
+  computer_name = "dummy.trusted.ci.jenkins.io"
+
+  # Encrypt all disks (ephemeral, temp dirs and data volumes) - https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell
+  encryption_at_host_enabled = true
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "StandardSSD_LRS"
+    disk_size_gb         = "32" # Minimum size with Ubuntu base image
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-minimal-jammy"
+    sku       = "minimal-22_04-lts-gen2"
+    version   = "latest"
+  }
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.id,
+      azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.id,
+    ]
   }
 }
-removed {
-  from = azurerm_managed_disk.dummy_trusted_ci_jenkins_io_data
+resource "azurerm_managed_disk" "dummy_trusted_ci_jenkins_io_data" {
+  name                 = "dummy-trusted-ci-jenkins-io-data"
+  location             = azurerm_resource_group.permanent_agents_trusted_ci_jenkins_io.location
+  resource_group_name  = azurerm_resource_group.permanent_agents_trusted_ci_jenkins_io.name
+  zone                 = azurerm_linux_virtual_machine.dummy_trusted_ci_jenkins_io.zone
+  storage_account_type = "PremiumV2_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "580"
 
-  lifecycle {
-    destroy = false
-  }
+  tags = local.default_tags
 }
-removed {
-  from = azurerm_virtual_machine_data_disk_attachment.dummy_trusted_ci_jenkins_io_data
-
-  lifecycle {
-    destroy = false
-  }
+resource "azurerm_virtual_machine_data_disk_attachment" "dummy_trusted_ci_jenkins_io_data" {
+  managed_disk_id    = azurerm_managed_disk.dummy_trusted_ci_jenkins_io_data.id
+  virtual_machine_id = azurerm_linux_virtual_machine.dummy_trusted_ci_jenkins_io.id
+  lun                = "20"
+  caching            = "None" # Caching not supported with "PremiumV2_LRS"
 }
-removed {
-  from = azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_dummy_agent
 
-  lifecycle {
-    destroy = false
-  }
+####################################################################################
+## Network Security Group and rules
+####################################################################################
+
+resource "azurerm_network_security_rule" "allow_inbound_ssh_from_controller_to_dummy_agent" {
+  name                   = "allow-inbound-ssh-from-controller-to-dummy-agent"
+  priority               = 3601
+  direction              = "Inbound"
+  access                 = "Allow"
+  protocol               = "Tcp"
+  source_port_range      = "*"
+  destination_port_range = "22"
+  source_address_prefix  = module.trusted_ci_jenkins_io.controller_private_ipv4
+  destination_address_prefixes = [
+    azurerm_linux_virtual_machine.dummy_trusted_ci_jenkins_io.private_ip_address,
+  ]
+  resource_group_name         = module.trusted_ci_jenkins_io.controller_resourcegroup_name
+  network_security_group_name = module.trusted_ci_jenkins_io.controller_nsg_name
 }
-removed {
-  from = azurerm_dns_a_record.trusted_dummy_agent
 
-  lifecycle {
-    destroy = false
-  }
+####################################################################################
+## Public DNS records
+####################################################################################
+resource "azurerm_dns_a_record" "trusted_dummy_agent" {
+  name                = "dummy"
+  zone_name           = module.trusted_ci_jenkins_io_letsencrypt.zone_name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  records             = [azurerm_linux_virtual_machine.dummy_trusted_ci_jenkins_io.private_ip_address]
 }

--- a/dummy.trusted.ci.jenkins.io.tf
+++ b/dummy.trusted.ci.jenkins.io.tf
@@ -1,6 +1,30 @@
 ####################################################################################
 ## Resources for the permanent agent VM
 ####################################################################################
+import {
+  to = azurerm_network_interface.dummy_trusted_ci_jenkins_io
+  id = "dummy-trusted-ci-jenkins-io"
+}
+import {
+  to = azurerm_linux_virtual_machine.dummy_trusted_ci_jenkins_io
+  id = "dummy.trusted.ci.jenkins.io"
+}
+# No import for dummy_trusted_ci_jenkins_io_data, moved to new sponsored RG
+# It will be recreated
+
+# No import for azurerm_virtual_machine_data_disk_attachment.dummy_trusted_ci_jenkins_io_data:
+# - No Azure ID in the original terraform to be referenced to
+# - Attachment to be created from scratch as related to a disk that will be recreated anyway cf comment above
+
+import {
+  to = azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_dummy_agent
+  id = "allow-inbound-ssh-from-controller-to-dummy-agent"
+}
+import {
+  to = azurerm_dns_a_record.trusted_dummy_agent
+  id = "dummy"
+}
+
 resource "azurerm_network_interface" "dummy_trusted_ci_jenkins_io" {
   name                = "dummy-trusted-ci-jenkins-io"
   location            = azurerm_resource_group.permanent_agents_trusted_ci_jenkins_io.location

--- a/dummy.trusted.ci.jenkins.io.tf
+++ b/dummy.trusted.ci.jenkins.io.tf
@@ -18,7 +18,9 @@ import {
 
 import {
   to = azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_dummy_agent
-  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/PERMANENT-AGENTS-TRUSTED-CI-JENKINS-IO/providers/Microsoft.Compute/disks/dummy.trusted.ci.jenkins.io_OsDisk_1_bdad993e4ab740868c4cc84802f1f74e"
+  # NSG resource id from Portal JSON view:
+  #     /subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/jenkinsinfra-trusted-ci-controller/providers/Microsoft.Network/networkSecurityGroups/controller.trusted.ci.jenkins.io
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/jenkinsinfra-trusted-ci-controller/providers/Microsoft.Network/networkSecurityGroups/controller.trusted.ci.jenkins.io/securityRules/allow-inbound-ssh-from-controller-to-dummy-agent"
 }
 # FTR, we shouldn't have removed this resource from state as not in the permament agent RG
 import {

--- a/dummy.trusted.ci.jenkins.io.tf
+++ b/dummy.trusted.ci.jenkins.io.tf
@@ -3,11 +3,11 @@
 ####################################################################################
 import {
   to = azurerm_network_interface.dummy_trusted_ci_jenkins_io
-  id = "dummy-trusted-ci-jenkins-io"
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/permanent-agents-trusted-ci-jenkins-io/providers/Microsoft.Network/networkInterfaces/dummy-trusted-ci-jenkins-io"
 }
 import {
   to = azurerm_linux_virtual_machine.dummy_trusted_ci_jenkins_io
-  id = "dummy.trusted.ci.jenkins.io"
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/permanent-agents-trusted-ci-jenkins-io/providers/Microsoft.Compute/virtualMachines/dummy.trusted.ci.jenkins.io"
 }
 # No import for dummy_trusted_ci_jenkins_io_data, moved to new sponsored RG
 # It will be recreated
@@ -18,11 +18,14 @@ import {
 
 import {
   to = azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_dummy_agent
-  id = "allow-inbound-ssh-from-controller-to-dummy-agent"
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/PERMANENT-AGENTS-TRUSTED-CI-JENKINS-IO/providers/Microsoft.Compute/disks/dummy.trusted.ci.jenkins.io_OsDisk_1_bdad993e4ab740868c4cc84802f1f74e"
 }
+# FTR, we shouldn't have removed this resource from state as not in the permament agent RG
 import {
   to = azurerm_dns_a_record.trusted_dummy_agent
-  id = "dummy"
+  # DNS zone resource id from Portal JSON view:
+  #     /subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/proddns_jenkinsio/providers/Microsoft.Network/dnszones/trusted.ci.jenkins.io
+  id = "/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/proddns_jenkinsio/providers/Microsoft.Network/dnsZones/trusted.ci.jenkins.io/A/dummy"
 }
 
 resource "azurerm_network_interface" "dummy_trusted_ci_jenkins_io" {


### PR DESCRIPTION
This change re`import`s resources removed from terraform state in #1393, except the data disk which I moved to the sponsored subscription via Azure Portal, a new one will be recreated.
Similarily, the disk attachment hasn't been `import`ed as the corresponding disk will be a new one.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5067