### PR TITLE
 feat(trusted.ci.jenkins.io) reference the new NSG which will be used for all subnets of the `trusted-ci-jenkins-io-sponsored-vnet` virtual network

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -185,6 +185,15 @@ resource "azurerm_role_assignment" "trusted_controller_vnet_jenkins_sponsored_re
   role_definition_id = azurerm_role_definition.trusted_ci_jenkins_io_controller_vnet_sponsored_reader.role_definition_resource_id
   principal_id       = module.trusted_ci_jenkins_io.controller_service_principal_id
 }
+
+# Managed in jenkins-infra/azure-net with vnet and subnets
+data "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
+  provider = azurerm.jenkins-sponsored
+
+  name                = "trusted-ci-jenkins-io-sponsored-vnet"
+  resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
+}
+
 module "trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   providers = {
     azurerm = azurerm.jenkins-sponsored


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

Follows up https://github.com/jenkins-infra/azure-net/pull/516

I chose to make this a really simple PR to avoid stepping on @lemeurherve toes for now and to keep the change readable and easy to review