### PR TITLE
feat!(modules/azure-jenkinsinfra-azurevm-agents) allow using common NSG from Virtual Network Resource Group with same name

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -136,7 +136,7 @@ module "cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   ephemeral_agents_network_rg_name = data.azurerm_subnet.cert_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
   ephemeral_agents_network_name    = data.azurerm_subnet.cert_ci_jenkins_io_sponsored_ephemeral_agents.virtual_network_name
   ephemeral_agents_subnet_name     = data.azurerm_subnet.cert_ci_jenkins_io_sponsored_ephemeral_agents.name
-  controller_rg_name               = azurerm_resource_group.cert_ci_jenkins_io_controller_jenkins_sponsored.name
+  nsg_rg_name                      = azurerm_resource_group.cert_ci_jenkins_io_controller_jenkins_sponsored.name
   controller_ips                   = compact([module.cert_ci_jenkins_io.controller_public_ipv4])
   controller_service_principal_id  = module.cert_ci_jenkins_io.controller_service_principal_id
   default_tags                     = local.default_tags

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -245,7 +245,7 @@ module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   ephemeral_agents_network_rg_name = data.azurerm_subnet.infra_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
   ephemeral_agents_network_name    = data.azurerm_subnet.infra_ci_jenkins_io_sponsored_ephemeral_agents.virtual_network_name
   ephemeral_agents_subnet_name     = data.azurerm_subnet.infra_ci_jenkins_io_sponsored_ephemeral_agents.name
-  controller_rg_name               = azurerm_resource_group.infra_ci_jenkins_io_sponsored_commons.name
+  nsg_rg_name                      = azurerm_resource_group.infra_ci_jenkins_io_sponsored_commons.name
   controller_ips                   = data.azurerm_subnet.privatek8s_infra_ci_controller_tier.address_prefixes # Pod IPs: controller IP may change in the pods IP subnet
   controller_service_principal_id  = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id
   storage_account_name             = "infraciagentssponso" # Max 24 chars

--- a/modules/azure-jenkinsinfra-azurevm-agents/locals.tf
+++ b/modules/azure-jenkinsinfra-azurevm-agents/locals.tf
@@ -9,4 +9,7 @@ locals {
       "162.213.33.8", "162.213.33.9", # keyserver.ubuntu.com
     ]
   }
+
+  nsg_name    = var.use_vnet_common_nsg ? data.azurerm_network_security_group.vnet_common_nsg[0].name : azurerm_network_security_group.ephemeral_agents[0].name
+  nsg_rg_name = var.use_vnet_common_nsg ? data.azurerm_network_security_group.vnet_common_nsg[0].resource_group_name : azurerm_network_security_group.ephemeral_agents[0].resource_group_name
 }

--- a/modules/azure-jenkinsinfra-azurevm-agents/main.tf
+++ b/modules/azure-jenkinsinfra-azurevm-agents/main.tf
@@ -17,16 +17,27 @@ data "azurerm_subnet" "ephemeral_agents" {
 ####################################################################################
 ## Network Security Group and rules
 ####################################################################################
-### Ephemeral Agents
+moved {
+  from = azurerm_network_security_group.ephemeral_agents
+  to   = azurerm_network_security_group.ephemeral_agents[0]
+}
 resource "azurerm_network_security_group" "ephemeral_agents" {
+  count = var.use_vnet_common_nsg ? 0 : 1
+
   name                = "${var.service_fqdn}-ephemeralagents"
   location            = data.azurerm_resource_group.ephemeral_agents_vnet.location
-  resource_group_name = var.controller_rg_name
+  resource_group_name = var.nsg_rg_name
   tags                = var.default_tags
+}
+data "azurerm_network_security_group" "vnet_common_nsg" {
+  count = var.use_vnet_common_nsg ? 1 : 0
+
+  name                = data.azurerm_virtual_network.ephemeral_agents.name
+  resource_group_name = data.azurerm_resource_group.ephemeral_agents_vnet.name
 }
 resource "azurerm_subnet_network_security_group_association" "ephemeral_agents" {
   subnet_id                 = data.azurerm_subnet.ephemeral_agents.id
-  network_security_group_id = azurerm_network_security_group.ephemeral_agents.id
+  network_security_group_id = var.use_vnet_common_nsg ? data.azurerm_network_security_group.vnet_common_nsg[0].id : azurerm_network_security_group.ephemeral_agents[0].id
 }
 ## Outbound Rules (different set of priorities than Inbound rules) ##
 resource "azurerm_network_security_rule" "allow_outbound_hkp_udp_from_ephemeral_agents_subnet_to_internet" {
@@ -41,8 +52,8 @@ resource "azurerm_network_security_rule" "allow_outbound_hkp_udp_from_ephemeral_
     "11371", # HKP (OpenPGP KeyServer) - https://github.com/jenkins-infra/helpdesk/issues/3664
   ]
   destination_address_prefixes = local.external_service_ips["gpg_keyserver"]
-  resource_group_name          = var.controller_rg_name
-  network_security_group_name  = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name          = local.nsg_rg_name
+  network_security_group_name  = local.nsg_name
 }
 resource "azurerm_network_security_rule" "allow_outbound_hkp_tcp_from_ephemeral_agents_subnet_to_internet" {
   name                    = "allow-outbound-hkp-tcp-from-${var.service_short_stripped_name}_ephemeral_agents-to-internet"
@@ -56,8 +67,8 @@ resource "azurerm_network_security_rule" "allow_outbound_hkp_tcp_from_ephemeral_
     "11371", # HKP (OpenPGP KeyServer) - https://github.com/jenkins-infra/helpdesk/issues/3664
   ]
   destination_address_prefixes = local.external_service_ips["gpg_keyserver"]
-  resource_group_name          = var.controller_rg_name
-  network_security_group_name  = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name          = local.nsg_rg_name
+  network_security_group_name  = local.nsg_name
 }
 resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ephemeral_agents_to_internet" {
   name                    = "allow-outbound-ssh-from-${var.service_short_stripped_name}_ephemeral_agents-to-internet"
@@ -73,8 +84,8 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ephemeral_agen
     for ip in split(" ", local.github_destination_address_prefixes) : ip
     if can(cidrnetmask(ip))
   ]
-  resource_group_name         = var.controller_rg_name
-  network_security_group_name = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name         = local.nsg_rg_name
+  network_security_group_name = local.nsg_name
 }
 resource "azurerm_network_security_rule" "allow_outbound_jenkins_from_ephemeral_agents_to_controller" {
   name                    = "allow-outbound-jenkins-from-${var.service_short_stripped_name}-agents"
@@ -90,8 +101,8 @@ resource "azurerm_network_security_rule" "allow_outbound_jenkins_from_ephemeral_
     "50000", # Direct TCP Inbound protocol
   ]
   destination_address_prefixes = compact(var.controller_ips)
-  resource_group_name          = var.controller_rg_name
-  network_security_group_name  = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name          = local.nsg_rg_name
+  network_security_group_name  = local.nsg_name
 }
 resource "azurerm_network_security_rule" "allow_outbound_http_from_ephemeral_agents_to_internet" {
   name                    = "allow-outbound-http-from-${var.service_short_stripped_name}_ephemeral_agents-to-internet"
@@ -106,8 +117,8 @@ resource "azurerm_network_security_rule" "allow_outbound_http_from_ephemeral_age
     "443", # HTTPS
   ]
   destination_address_prefix  = "Internet"
-  resource_group_name         = var.controller_rg_name
-  network_security_group_name = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name         = local.nsg_rg_name
+  network_security_group_name = local.nsg_name
 }
 resource "azurerm_network_security_rule" "deny_all_outbound_from_ephemeral_agents_to_internet" {
   name                        = "deny-all-outbound-from-${var.service_short_stripped_name}_ephemeral_agents-to-internet"
@@ -119,8 +130,8 @@ resource "azurerm_network_security_rule" "deny_all_outbound_from_ephemeral_agent
   destination_port_range      = "*"
   source_address_prefixes     = data.azurerm_subnet.ephemeral_agents.address_prefixes
   destination_address_prefix  = "Internet"
-  resource_group_name         = var.controller_rg_name
-  network_security_group_name = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name         = local.nsg_rg_name
+  network_security_group_name = local.nsg_name
 }
 # This rule overrides an Azure-Default rule. its priority must be < 65000.
 resource "azurerm_network_security_rule" "deny_all_outbound_from_ephemeral_agents_to_vnet" {
@@ -133,8 +144,8 @@ resource "azurerm_network_security_rule" "deny_all_outbound_from_ephemeral_agent
   destination_port_range      = "*"
   source_address_prefixes     = data.azurerm_subnet.ephemeral_agents.address_prefixes
   destination_address_prefix  = "VirtualNetwork"
-  resource_group_name         = var.controller_rg_name
-  network_security_group_name = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name         = local.nsg_rg_name
+  network_security_group_name = local.nsg_name
 }
 
 ## Inbound Rules (different set of priorities than Outbound rules) ##
@@ -148,8 +159,8 @@ resource "azurerm_network_security_rule" "allow_inbound_ssh_from_privatevpn_to_e
   destination_port_range      = "22"
   source_address_prefixes     = var.jenkins_infra_ips.privatevpn_subnet
   destination_address_prefix  = "VirtualNetwork"
-  resource_group_name         = var.controller_rg_name
-  network_security_group_name = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name         = local.nsg_rg_name
+  network_security_group_name = local.nsg_name
 }
 resource "azurerm_network_security_rule" "allow_inbound_ssh_from_controller_to_ephemeral_agents" {
   name                         = "allow-inbound-ssh-from-${var.service_short_stripped_name}-controller-to-ephemeral-agents"
@@ -161,8 +172,8 @@ resource "azurerm_network_security_rule" "allow_inbound_ssh_from_controller_to_e
   source_address_prefixes      = var.controller_ips
   destination_port_range       = "22" # SSH
   destination_address_prefixes = data.azurerm_subnet.ephemeral_agents.address_prefixes
-  resource_group_name          = var.controller_rg_name
-  network_security_group_name  = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name          = local.nsg_rg_name
+  network_security_group_name  = local.nsg_name
 }
 # This rule overrides an Azure-Default rule. its priority must be < 65000
 resource "azurerm_network_security_rule" "deny_all_inbound_from_vnet_to_ephemeral_agents" {
@@ -175,8 +186,8 @@ resource "azurerm_network_security_rule" "deny_all_inbound_from_vnet_to_ephemera
   destination_port_range       = "*"
   source_address_prefix        = "*"
   destination_address_prefixes = data.azurerm_subnet.ephemeral_agents.address_prefixes
-  resource_group_name          = var.controller_rg_name
-  network_security_group_name  = azurerm_network_security_group.ephemeral_agents.name
+  resource_group_name          = local.nsg_rg_name
+  network_security_group_name  = local.nsg_name
 }
 
 ####################################################################################

--- a/modules/azure-jenkinsinfra-azurevm-agents/outputs.tf
+++ b/modules/azure-jenkinsinfra-azurevm-agents/outputs.tf
@@ -1,9 +1,9 @@
 output "ephemeral_agents_nsg_rg_name" {
-  value = azurerm_network_security_group.ephemeral_agents.resource_group_name
+  value = local.nsg_rg_name
 }
 
 output "ephemeral_agents_nsg_name" {
-  value = azurerm_network_security_group.ephemeral_agents.name
+  value = local.nsg_name
 }
 
 output "ephemeral_agents_resource_group_name" {

--- a/modules/azure-jenkinsinfra-azurevm-agents/variables.tf
+++ b/modules/azure-jenkinsinfra-azurevm-agents/variables.tf
@@ -15,9 +15,10 @@ variable "ephemeral_agents_network_rg_name" {
   type = string
 }
 
-# Required for NSG (can't be on the vnet RGs neither on agent RGs both for permissions reasons)
-variable "controller_rg_name" {
-  type = string
+variable "nsg_rg_name" {
+  type        = string
+  description = "Name of the Resource Group where to create the Network Security Group (unneeded if var.use_vnet_common_nsg is true)."
+  default     = ""
 }
 
 variable "ephemeral_agents_subnet_name" {
@@ -58,4 +59,10 @@ variable "additional_identities" {
   type        = list(string)
   description = "A list of Azure identity IDs, in addition to controller_service_principal_id, which can manage Azure VM agents."
   default     = []
+}
+
+variable "use_vnet_common_nsg" {
+  type        = bool
+  description = "Should we use the Network Security Group ('NSG') located in the same Resource Group as the provided Virtual Network and with the same name (convention)?"
+  default     = false
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -65,7 +65,7 @@ module "trusted_ci_jenkins_io_azurevm_agents" {
   ephemeral_agents_network_rg_name = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.resource_group_name
   ephemeral_agents_network_name    = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.virtual_network_name
   ephemeral_agents_subnet_name     = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.name
-  controller_rg_name               = module.trusted_ci_jenkins_io.controller_resourcegroup_name
+  nsg_rg_name                      = module.trusted_ci_jenkins_io.controller_resourcegroup_name
   controller_ips                   = compact([module.trusted_ci_jenkins_io.controller_public_ipv4])
   controller_service_principal_id  = module.trusted_ci_jenkins_io.controller_service_principal_id
   default_tags                     = local.default_tags
@@ -205,7 +205,7 @@ module "trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   ephemeral_agents_network_rg_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
   ephemeral_agents_network_name    = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.virtual_network_name
   ephemeral_agents_subnet_name     = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.name
-  controller_rg_name               = azurerm_resource_group.trusted_ci_jenkins_io_controller_jenkins_sponsored.name
+  nsg_rg_name                      = azurerm_resource_group.trusted_ci_jenkins_io_controller_jenkins_sponsored.name
   controller_ips                   = compact([module.trusted_ci_jenkins_io.controller_public_ipv4])
   controller_service_principal_id  = module.trusted_ci_jenkins_io.controller_service_principal_id
   default_tags                     = local.default_tags


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

This PR introduces a new input variable on the module `azure-jenkinsinfra-azurevm-agents`: `use_vnet_common_nsg` which defaults to false (opt-in).

This input tells the module to use an existing NSG, in the resource group of the provided virtual network, with the same name as the provided virtual network. It is a convention to ensure we stay coherent.
If we need a custom name, we'll change this new input from a boolean to a string, but does not seem useful for now.

It will allow migrating our NSGs with as less impact as possible.

BREAKING: the input parameter `controller_rg_name` is renamed to `nsg_rg_name` as it's its only usage.
