### PR TITLE
chore: remove applied 'moved' blocks and bump shared-tools to latest

### DIFF
--- a/dockerhub-mirror.tf
+++ b/dockerhub-mirror.tf
@@ -110,11 +110,6 @@ resource "azurerm_container_registry_cache_rule" "mirror_cache_rules" {
 }
 
 #### Allow provided Principal IDs to push images to the registry
-# id obtained with `terraform state list | grep push_to_acr`
-moved {
-  from = azurerm_role_assignment.push_to_acr["4b7d8dbc-c30d-43ca-8112-fd8be2cca3b0"]
-  to   = azurerm_role_assignment.push_to_acr[0]
-}
 resource "azurerm_role_assignment" "push_to_acr" {
   count                            = var.terratest ? 0 : 1
   principal_id                     = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents_jenkins_sponsored.principal_id

--- a/modules/azure-jenkinsinfra-azurevm-agents/main.tf
+++ b/modules/azure-jenkinsinfra-azurevm-agents/main.tf
@@ -17,10 +17,6 @@ data "azurerm_subnet" "ephemeral_agents" {
 ####################################################################################
 ## Network Security Group and rules
 ####################################################################################
-moved {
-  from = azurerm_network_security_group.ephemeral_agents
-  to   = azurerm_network_security_group.ephemeral_agents[0]
-}
 resource "azurerm_network_security_group" "ephemeral_agents" {
   count = var.use_vnet_common_nsg ? 0 : 1
 


### PR DESCRIPTION
Following up https://github.com/jenkins-infra/azure/pull/1396, https://github.com/jenkins-infra/azure/pull/1397 and https://github.com/jenkins-infra/azure/pull/1366/changes.

Also bumps shared-tools to get latest version

Expecting no changes