### PR TITLE
feat(trusted.ci.jenkins.io) set up rules for ephemeral agents on the new NSG in sponsored virtual network

### DIFF
--- a/modules/azure-jenkinsinfra-azurevm-agents/main.tf
+++ b/modules/azure-jenkinsinfra-azurevm-agents/main.tf
@@ -32,6 +32,8 @@ data "azurerm_network_security_group" "vnet_common_nsg" {
   resource_group_name = data.azurerm_resource_group.ephemeral_agents_vnet.name
 }
 resource "azurerm_subnet_network_security_group_association" "ephemeral_agents" {
+  count = var.use_vnet_common_nsg ? 0 : 1
+
   subnet_id                 = data.azurerm_subnet.ephemeral_agents.id
   network_security_group_id = var.use_vnet_common_nsg ? data.azurerm_network_security_group.vnet_common_nsg[0].id : azurerm_network_security_group.ephemeral_agents[0].id
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -205,7 +205,7 @@ module "trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   ephemeral_agents_network_rg_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
   ephemeral_agents_network_name    = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.virtual_network_name
   ephemeral_agents_subnet_name     = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.name
-  nsg_rg_name                      = azurerm_resource_group.trusted_ci_jenkins_io_controller_jenkins_sponsored.name
+  use_vnet_common_nsg              = true
   controller_ips                   = compact([module.trusted_ci_jenkins_io.controller_public_ipv4])
   controller_service_principal_id  = module.trusted_ci_jenkins_io.controller_service_principal_id
   default_tags                     = local.default_tags


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

This PR does re-create the Network Security Rules in the new NSG (which moved to jenkins-infra/azure-net) migrated in the sponsored subscription, by enabling the new `jenkins-azurevm-agents` module feature `use_vnet_common_nsg` introduced in #1397 .

As the new NSG is not (yet) associated to the subnets, we don't want to delete the current NSG hosted in CDF. That's why the following resources had been removed from state (`terraform state rm xxx`) prior to applying the PR:

```
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_group.ephemeral_agents[0]
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_subnet_network_security_group_association.ephemeral_agents[0]

module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.allow_inbound_ssh_from_controller_to_ephemeral_agents
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.allow_inbound_ssh_from_privatevpn_to_ephemeral_agents
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.allow_outbound_hkp_tcp_from_ephemeral_agents_subnet_to_internet
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.allow_outbound_hkp_udp_from_ephemeral_agents_subnet_to_internet
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.allow_outbound_http_from_ephemeral_agents_to_internet
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.allow_outbound_jenkins_from_ephemeral_agents_to_controller
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.allow_outbound_ssh_from_ephemeral_agents_to_internet
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.deny_all_inbound_from_vnet_to_ephemeral_agents
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_internet
module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_network_security_rule.deny_all_outbound_from_ephemeral_agents_to_vnet

azurerm_network_security_rule.allow_in_https_from_trusted_vnet_to_acr
azurerm_network_security_rule.allow_out_https_from_trusted_vnet_to_acr
azurerm_network_security_rule.allow_out_many_from_trusted_agents_jenkins_sponsored_to_archive
```

----

IMPORTANT NOTES:

- Only the 2 first resources did strictly required a manual `terraform state rm xxx`. The others could have used a custom [`removed {}`](https://developer.hashicorp.com/terraform/language/state/remove) block. I chose to run all them at once with a shell loop command.
  - The 2 first resources are referencing a non existing index (`[0]`) due to the `count` parameter introduction. Terraform does not support removed blocks on dynamically defined resource sets.
- I caught a bug (missed adding a `count` attribute to conditionally create the NSG association) in the module. This bug was introduced in #1397 but had no impact on existing use cases.
  - Fixed by a separate commit in this PR: https://github.com/jenkins-infra/azure/pull/1399/changes/1149066e677239388cf9a2f6c8b3235314f329ba
- Required a (minor) hotfix for one NSG rule outside of the module: https://github.com/jenkins-infra/azure/pull/1400
