### PR TITLE
feat!(trusted.ci.jenkins.io/sponsored-subscription) migrate ACR Private Endpoint and its Network Security rules to the commons subnet and Resource Group

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -66,6 +66,66 @@ resource "azurerm_resource_group" "trusted_ci_jenkins_io_sponsored_commons" {
   location = var.location
   tags     = local.default_tags
 }
+# Managed in jenkins-infra/azure-net with vnet and subnets
+data "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
+  provider = azurerm.jenkins-sponsored
+
+  name                = "trusted-ci-jenkins-io-sponsored-vnet"
+  resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
+}
+# Allow access to the private Azure Container Registry through an Azure Endpoint NIC
+module "trustedcijenkinsiosponsored_acr_pe" {
+  source = "./modules/azure-container-registry-private-links"
+
+  providers = {
+    azurerm     = azurerm.jenkins-sponsored
+    azurerm.acr = azurerm
+  }
+
+  name = "trustedcijenkinsiosponsored"
+
+  acr_name     = azurerm_container_registry.dockerhub_mirror.name
+  acr_location = azurerm_container_registry.dockerhub_mirror.location
+  acr_rg_name  = azurerm_container_registry.dockerhub_mirror.resource_group_name
+
+  subnet_name  = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.name
+  vnet_name    = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.name
+  vnet_rg_name = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.resource_group_name
+
+  default_tags = local.default_tags
+}
+
+## Allow access to/from ACR endpoint
+resource "azurerm_network_security_rule" "allow_out_https_from_trusted_vnet_to_acr" {
+  provider = azurerm.jenkins-sponsored
+
+  name                         = "allow-out-https-from-vnet-to-acr"
+  priority                     = 4051
+  direction                    = "Outbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "443"
+  source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.address_space
+  destination_address_prefixes = split(",", module.trustedcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses)
+  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
+  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
+}
+resource "azurerm_network_security_rule" "allow_in_https_from_trusted_vnet_to_acr" {
+  provider = azurerm.jenkins-sponsored
+
+  name                         = "allow-in-https-from-vnet-to-acr"
+  priority                     = 4051
+  direction                    = "Inbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "443"
+  source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.address_space
+  destination_address_prefixes = split(",", module.trustedcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses)
+  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
+  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
+}
 
 ####################################################################################
 ## Agents resources in the CDF subscription
@@ -197,14 +257,6 @@ resource "azurerm_role_assignment" "trusted_controller_vnet_jenkins_sponsored_re
   scope              = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.id
   role_definition_id = azurerm_role_definition.trusted_ci_jenkins_io_controller_vnet_sponsored_reader.role_definition_resource_id
   principal_id       = module.trusted_ci_jenkins_io.controller_service_principal_id
-}
-
-# Managed in jenkins-infra/azure-net with vnet and subnets
-data "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
-  provider = azurerm.jenkins-sponsored
-
-  name                = "trusted-ci-jenkins-io-sponsored-vnet"
-  resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
 }
 
 module "trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
@@ -407,58 +459,4 @@ resource "azurerm_private_endpoint" "publick8s_updates_jenkins_io_for_trustedci"
     private_dns_zone_ids = [module.trustedcijenkinsio_acr_pe.private_dns_zone_id]
   }
   tags = local.default_tags
-}
-
-# Allow access to the private Azure Container Registry through an Azure Endpoint NIC
-module "trustedcijenkinsiosponsored_acr_pe" {
-  source = "./modules/azure-container-registry-private-links"
-
-  providers = {
-    azurerm     = azurerm.jenkins-sponsored
-    azurerm.acr = azurerm
-  }
-
-  name = "trustedcijenkinsiosponsored"
-
-  acr_name     = azurerm_container_registry.dockerhub_mirror.name
-  acr_location = azurerm_container_registry.dockerhub_mirror.location
-  acr_rg_name  = azurerm_container_registry.dockerhub_mirror.resource_group_name
-
-  subnet_name  = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.name
-  vnet_name    = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.name
-  vnet_rg_name = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.resource_group_name
-
-  default_tags = local.default_tags
-}
-
-## Allow access to/from ACR endpoint
-resource "azurerm_network_security_rule" "allow_out_https_from_trusted_vnet_to_acr" {
-  provider = azurerm.jenkins-sponsored
-
-  name                         = "allow-out-https-from-vnet-to-acr"
-  priority                     = 4051
-  direction                    = "Outbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "443"
-  source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.address_space
-  destination_address_prefixes = split(",", module.trustedcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses)
-  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
-  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
-}
-resource "azurerm_network_security_rule" "allow_in_https_from_trusted_vnet_to_acr" {
-  provider = azurerm.jenkins-sponsored
-
-  name                         = "allow-in-https-from-vnet-to-acr"
-  priority                     = 4051
-  direction                    = "Inbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "443"
-  source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.address_space
-  destination_address_prefixes = split(",", module.trustedcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses)
-  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
-  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -73,7 +73,7 @@ data "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
   name                = "trusted-ci-jenkins-io-sponsored-vnet"
   resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
 }
-# Allow access to the private Azure Container Registry through an Azure Endpoint NIC
+# Allow access to the private Azure Container Registry through an Azure Private Endpoint NIC
 module "trustedcijenkinsiosponsored_acr_pe" {
   source = "./modules/azure-container-registry-private-links"
 
@@ -88,19 +88,18 @@ module "trustedcijenkinsiosponsored_acr_pe" {
   acr_location = azurerm_container_registry.dockerhub_mirror.location
   acr_rg_name  = azurerm_container_registry.dockerhub_mirror.resource_group_name
 
-  subnet_name  = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.name
+  subnet_name  = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_commons.name
   vnet_name    = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.name
   vnet_rg_name = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.resource_group_name
 
   default_tags = local.default_tags
 }
-
 ## Allow access to/from ACR endpoint
-resource "azurerm_network_security_rule" "allow_out_https_from_trusted_vnet_to_acr" {
+resource "azurerm_network_security_rule" "allow_out_https_from_trusted_sponsored_vnet_to_acr" {
   provider = azurerm.jenkins-sponsored
 
-  name                         = "allow-out-https-from-vnet-to-acr"
-  priority                     = 4051
+  name                         = "allow-out-https-from-sponsored-vnet-to-acr"
+  priority                     = 4052
   direction                    = "Outbound"
   access                       = "Allow"
   protocol                     = "Tcp"
@@ -108,14 +107,14 @@ resource "azurerm_network_security_rule" "allow_out_https_from_trusted_vnet_to_a
   destination_port_range       = "443"
   source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.address_space
   destination_address_prefixes = split(",", module.trustedcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses)
-  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
-  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
+  resource_group_name          = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.resource_group_name
+  network_security_group_name  = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.name
 }
-resource "azurerm_network_security_rule" "allow_in_https_from_trusted_vnet_to_acr" {
+resource "azurerm_network_security_rule" "allow_in_https_from_trusted_sponsored_vnet_to_acr" {
   provider = azurerm.jenkins-sponsored
 
-  name                         = "allow-in-https-from-vnet-to-acr"
-  priority                     = 4051
+  name                         = "allow-in-https-from-sponsored-vnet-to-acr"
+  priority                     = 4052
   direction                    = "Inbound"
   access                       = "Allow"
   protocol                     = "Tcp"
@@ -123,8 +122,8 @@ resource "azurerm_network_security_rule" "allow_in_https_from_trusted_vnet_to_ac
   destination_port_range       = "443"
   source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.address_space
   destination_address_prefixes = split(",", module.trustedcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses)
-  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
-  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
+  resource_group_name          = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.resource_group_name
+  network_security_group_name  = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.name
 }
 
 ####################################################################################

--- a/vnets.tf
+++ b/vnets.tf
@@ -136,6 +136,12 @@ data "azurerm_subnet" "trusted_ci_jenkins_io_sponsored_ephemeral_agents" {
   virtual_network_name = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.name
   resource_group_name  = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.resource_group_name
 }
+data "azurerm_subnet" "trusted_ci_jenkins_io_sponsored_commons" {
+  provider             = azurerm.jenkins-sponsored
+  name                 = "${data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.name}-commons"
+  virtual_network_name = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.name
+  resource_group_name  = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.resource_group_name
+}
 data "azurerm_subnet" "privatek8s_tier" {
   name                 = "privatek8s-tier"
   resource_group_name  = data.azurerm_resource_group.private.name


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4268303462

This PR re-create the following resources:
- The Private Endpoint used to reach the Azure Container Registry from trusted.ci.jenkins.io agents in the sponsored virtual network subnets. The new NIC for this endpoint will live in the "commons" subnet instead so we can dispose of the other subnets and avoid interferences during migrations/updates/cleanups
- The 2 NSG rules to allow request from/to the private endpoints:
  - Naming changed to shows it's "sponsored"
  - Priority changed to avoid "deploy time" error requiring 2 consecutive "apply"s
  - NSG and its RG are defined from the data source to remove dependency to the ephemeral (sponsored) module instanciation


⚠️ When this PR will be applied, the trusted.ci.jenkins.io ephemeral agents will loose connectivity to the private ACR. Not a blocker as their Docker Engine will fallback to the DockerHub (a bit slower and a bit of bandwidth).

Note: review should only be done on the second commit (https://github.com/jenkins-infra/azure/pull/1402/changes/92ed414b0567982b42392258db728b01c9fbeaa3) as the first one (https://github.com/jenkins-infra/azure/pull/1402/changes/f848f104144854f93ebe6e265a10a7e0ed575e5b) is only a formatting one (moving definitions in the file)