### PR TITLE
hotfix(dummy2.trusted.ci.jenkins.io) remove invalid disk attachment

### DIFF
--- a/dummy2.trusted.ci.jenkins.io.tf
+++ b/dummy2.trusted.ci.jenkins.io.tf
@@ -82,13 +82,14 @@ resource "azurerm_managed_disk" "dummy_trusted_ci_jenkins_io_data_moved" {
   tags = local.default_tags
 }
 
-resource "azurerm_virtual_machine_data_disk_attachment" "dummy2_trusted_ci_jenkins_io_data" {
-  provider           = azurerm.jenkins-sponsored
-  managed_disk_id    = azurerm_managed_disk.dummy_trusted_ci_jenkins_io_data_moved.id
-  virtual_machine_id = azurerm_linux_virtual_machine.dummy2_trusted_ci_jenkins_io.id
-  lun                = "20"
-  caching            = "None" # Caching not supported with "PremiumV2_LRS"
-}
+## Commented out as it fails due to zone mismatch between VM and disk
+#resource "azurerm_virtual_machine_data_disk_attachment" "dummy2_trusted_ci_jenkins_io_data" {
+#  provider           = azurerm.jenkins-sponsored
+#  managed_disk_id    = azurerm_managed_disk.dummy_trusted_ci_jenkins_io_data_moved.id
+#  virtual_machine_id = azurerm_linux_virtual_machine.dummy2_trusted_ci_jenkins_io.id
+#  lun                = "20"
+#  caching            = "None" # Caching not supported with "PremiumV2_LRS"
+#}
 
 # No NSG
 


### PR DESCRIPTION
Fixup of #1404 which failed with the following error:

```
Error: updating Virtual Machine (Subscription: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
Resource Group Name: "trusted-ci-jenkins-io-sponsored-permanent-agents"
Virtual Machine Name: "dummy2.trusted.ci.jenkins.io") with Disk "dummy-trusted-ci-jenkins-io-data": performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: BadRequest: Disk /subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/TRUSTED-CI-JENKINS-IO-SPONSORED-PERMANENT-AGENTS/providers/Microsoft.Compute/disks/dummy-trusted-ci-jenkins-io-data cannot be attached to the VM because it is not in the same zone as the VM. VM zone: '1'. Disk zone: '2'.
  with azurerm_virtual_machine_data_disk_attachment.dummy2_trusted_ci_jenkins_io_data,
  on dummy2.trusted.ci.jenkins.io.tf line 85, in resource "azurerm_virtual_machine_data_disk_attachment" "dummy2_trusted_ci_jenkins_io_data":
  85: resource "azurerm_virtual_machine_data_disk_attachment" "dummy2_trusted_ci_jenkins_io_data" {
```