### PR TITLE
feat(trusted.ci.jenkins.io) create resources for updates.jenkins.io mirrorbits CLI in the sponsored zone

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -131,6 +131,37 @@ data "azurerm_private_link_service" "publick8s_mirrorbitscli_updates_jenkins_io"
   name                = "publick8s-updates.jenkins.io"
   resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
 }
+resource "azurerm_private_endpoint" "publick8s_updates_jenkins_io_for_trustedci_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  name = "${data.azurerm_private_link_service.publick8s_mirrorbitscli_updates_jenkins_io.name}-for-trustedci-sponsored"
+
+  location            = var.location
+  resource_group_name = azurerm_resource_group.trusted_ci_jenkins_io_sponsored_commons.name
+  subnet_id           = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_commons.id
+
+  custom_network_interface_name = "${data.azurerm_private_link_service.publick8s_mirrorbitscli_updates_jenkins_io.name}-for-trustedci-sponsored"
+
+  private_service_connection {
+    name                           = "${data.azurerm_private_link_service.publick8s_mirrorbitscli_updates_jenkins_io.name}-for-trustedci-sponsored"
+    private_connection_resource_id = data.azurerm_private_link_service.publick8s_mirrorbitscli_updates_jenkins_io.id
+    is_manual_connection           = false
+  }
+  private_dns_zone_group {
+    name                 = module.trustedcijenkinsiosponsored_acr_pe.private_dns_zone_name
+    private_dns_zone_ids = [module.trustedcijenkinsiosponsored_acr_pe.private_dns_zone_id]
+  }
+  tags = local.default_tags
+}
+resource "azurerm_private_dns_a_record" "updates_jenkins_io_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  name                = "updates.jenkins.io"                                            # Expected full record name: updates.jenkins.io.privatelink.azurecr.io
+  zone_name           = module.trustedcijenkinsiosponsored_acr_pe.private_dns_zone_name # This existing zone already associated to the vnet
+  resource_group_name = azurerm_resource_group.trusted_ci_jenkins_io_sponsored_commons.name
+  ttl                 = 60
+  records             = [azurerm_private_endpoint.publick8s_updates_jenkins_io_for_trustedci_sponsored.private_service_connection[0].private_ip_address]
+}
 
 ####################################################################################
 ## Agents resources in the CDF subscription

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -58,7 +58,7 @@ module "trusted_ci_jenkins_io" {
 }
 
 ####################################################################################
-## Private network resources (endpoint, DNS, etc.)
+## Common resources (endpoint, DNS, etc.)
 ####################################################################################
 resource "azurerm_resource_group" "trusted_ci_jenkins_io_sponsored_commons" {
   provider = azurerm.jenkins-sponsored
@@ -124,6 +124,12 @@ resource "azurerm_network_security_rule" "allow_in_https_from_trusted_sponsored_
   destination_address_prefixes = split(",", module.trustedcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses)
   resource_group_name          = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.resource_group_name
   network_security_group_name  = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.name
+}
+## updates.jenkins.io's mirrorbits CLI Kubernetes Service (internal LB)
+data "azurerm_private_link_service" "publick8s_mirrorbitscli_updates_jenkins_io" {
+  # TODO: track with updatecli from https://github.com/jenkins-infra/kubernetes-management/config/publick8s_updates-jenkins-io.yaml
+  name                = "publick8s-updates.jenkins.io"
+  resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
 }
 
 ####################################################################################
@@ -431,13 +437,6 @@ resource "azurerm_private_dns_a_record" "updates_jenkins_io" {
   resource_group_name = module.trustedcijenkinsio_acr_pe.private_dns_zone_resource_group_name
   ttl                 = 60
   records             = [azurerm_private_endpoint.publick8s_updates_jenkins_io_for_trustedci.private_service_connection[0].private_ip_address]
-}
-
-## updates.jenkins.io's mirrorbits CLI Kubernetes Service (internal LB)
-data "azurerm_private_link_service" "publick8s_mirrorbitscli_updates_jenkins_io" {
-  # TODO: track with updatecli from https://github.com/jenkins-infra/kubernetes-management/config/publick8s_updates-jenkins-io.yaml
-  name                = "publick8s-updates.jenkins.io"
-  resource_group_name = azurerm_kubernetes_cluster.publick8s.node_resource_group
 }
 resource "azurerm_private_endpoint" "publick8s_updates_jenkins_io_for_trustedci" {
   name = "${data.azurerm_private_link_service.publick8s_mirrorbitscli_updates_jenkins_io.name}-for-trustedci"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4268303462 

This PR adds 2 new resources:

- A new Private Endpoint in the "commons" resource group
- The associated private DNS record in the ACR private DNS zone


Can be merged without any risk if the plan is OK (only new resources)