### PR TITLE
hotfix(trusted.ci.jenkins.io) ensure private DNS record is in the same RG as its private DNS zone

### DIFF
--- a/dummy2.trusted.ci.jenkins.io.tf
+++ b/dummy2.trusted.ci.jenkins.io.tf
@@ -75,11 +75,11 @@ resource "azurerm_managed_disk" "dummy_trusted_ci_jenkins_io_data_moved" {
   name                 = "dummy-trusted-ci-jenkins-io-data"
   location             = azurerm_resource_group.trusted_ci_jenkins_io_permanent_agents_jenkins_sponsored.location
   resource_group_name  = azurerm_resource_group.trusted_ci_jenkins_io_permanent_agents_jenkins_sponsored.name
-  zone                 = 2  # forcing the new data disk zone instead of azurerm_linux_virtual_machine.dummy2_trusted_ci_jenkins_io.zone
+  zone                 = 2 # forcing the new data disk zone instead of azurerm_linux_virtual_machine.dummy2_trusted_ci_jenkins_io.zone
   storage_account_type = "PremiumV2_LRS"
   create_option        = "Empty"
   disk_size_gb         = "580"
-  tags = local.default_tags
+  tags                 = local.default_tags
 }
 
 ## Commented out as it fails due to zone mismatch between VM and disk

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -156,9 +156,10 @@ resource "azurerm_private_endpoint" "publick8s_updates_jenkins_io_for_trustedci_
 resource "azurerm_private_dns_a_record" "updates_jenkins_io_sponsored" {
   provider = azurerm.jenkins-sponsored
 
-  name                = "updates.jenkins.io"                                            # Expected full record name: updates.jenkins.io.privatelink.azurecr.io
-  zone_name           = module.trustedcijenkinsiosponsored_acr_pe.private_dns_zone_name # This existing zone already associated to the vnet
-  resource_group_name = azurerm_resource_group.trusted_ci_jenkins_io_sponsored_commons.name
+  name      = "updates.jenkins.io"                                            # Expected full record name: updates.jenkins.io.privatelink.azurecr.io
+  zone_name = module.trustedcijenkinsiosponsored_acr_pe.private_dns_zone_name # This existing zone already associated to the vnet
+  # Must be the same as the private zone (otherwise: 404 when applying)
+  resource_group_name = module.trustedcijenkinsiosponsored_acr_pe.private_dns_zone_resource_group_name
   ttl                 = 60
   records             = [azurerm_private_endpoint.publick8s_updates_jenkins_io_for_trustedci_sponsored.private_service_connection[0].private_ip_address]
 }


### PR DESCRIPTION
This PR is a hot fix for https://github.com/jenkins-infra/azure/pull/1407#issuecomment-4278439762

Related to https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

Note: 

- Terraform format includes  a non functionnal change on `dummy.trusted.ci`
- Added a comment to explain the constraint on the RG