### PR TITLE
 feat(trusted.ci.jenkins.io) migrate NSR rule for SSH from agents to archives.jenkins.io into the common Network Security Group

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -74,11 +74,11 @@ data "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
   resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
 }
 # Allow agents to access archives.jenkins.io for rsync-over-SSH
-resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_jenkins_sponsored_to_archive" {
+resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_sponsored_to_archives_jenkins_io" {
   provider = azurerm.jenkins-sponsored
 
-  name              = "allow-out-many-from-agents-jenkins-sponsored-to-archive"
-  priority          = 4070
+  name              = "allow-out-many-from-agents-sponsored-to-archives-jenkins-io"
+  priority          = 4071
   direction         = "Outbound"
   access            = "Allow"
   protocol          = "Tcp"
@@ -86,10 +86,13 @@ resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_jen
   destination_port_ranges = [
     "22", # SSH (for rsync)
   ]
-  source_address_prefixes     = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.address_prefixes
+  source_address_prefixes = concat(
+    data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.address_prefixes,
+    data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_permanent_agents.address_prefixes,
+  )
   destination_address_prefix  = local.external_services["archives.jenkins.io"]
-  resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
-  network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
+  resource_group_name         = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.resource_group_name
+  network_security_group_name = data.azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet.name
 }
 # Allow access to the private Azure Container Registry through an Azure Private Endpoint NIC
 module "trustedcijenkinsiosponsored_acr_pe" {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -73,6 +73,24 @@ data "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
   name                = "trusted-ci-jenkins-io-sponsored-vnet"
   resource_group_name = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.resource_group_name
 }
+# Allow agents to access archives.jenkins.io for rsync-over-SSH
+resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_jenkins_sponsored_to_archive" {
+  provider = azurerm.jenkins-sponsored
+
+  name              = "allow-out-many-from-agents-jenkins-sponsored-to-archive"
+  priority          = 4070
+  direction         = "Outbound"
+  access            = "Allow"
+  protocol          = "Tcp"
+  source_port_range = "*"
+  destination_port_ranges = [
+    "22", # SSH (for rsync)
+  ]
+  source_address_prefixes     = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.address_prefixes
+  destination_address_prefix  = local.external_services["archives.jenkins.io"]
+  resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
+  network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
+}
 # Allow access to the private Azure Container Registry through an Azure Private Endpoint NIC
 module "trustedcijenkinsiosponsored_acr_pe" {
   source = "./modules/azure-container-registry-private-links"
@@ -395,23 +413,6 @@ resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_to_
   destination_address_prefix  = local.external_services["archives.jenkins.io"]
   resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name
   network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
-}
-resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_jenkins_sponsored_to_archive" {
-  provider = azurerm.jenkins-sponsored
-
-  name              = "allow-out-many-from-agents-jenkins-sponsored-to-archive"
-  priority          = 4070
-  direction         = "Outbound"
-  access            = "Allow"
-  protocol          = "Tcp"
-  source_port_range = "*"
-  destination_port_ranges = [
-    "22", # SSH (for rsync)
-  ]
-  source_address_prefixes     = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.address_prefixes
-  destination_address_prefix  = local.external_services["archives.jenkins.io"]
-  resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
-  network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
 }
 ## Inbound Rules (different set of priorities than Outbound rules) ##
 resource "azurerm_network_security_rule" "allow_in_many_from_trusted_agents_to_uc" {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5070

This PR updates the Network Security Group (NSG) rule which allows ephemeral agents to reach archives.jenkins.io in DigitalOcean with SSH protocol:

- Naming change (both Terraform internal and Azure API resource)
- The rule is moved into the new "common" NSG introduced in https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840 (includes re-creation because Resource Group is also changed as part of this migration).
  - The goal is to decorrelate from subnet or RG specific to ephemeral or permanent agent to ease migrations in the future
- The priority is changed to avoid requiring 2 runs of the main build to fully apply
- The source addresses are changed to also include the permanent agent (required for https://github.com/jenkins-infra/helpdesk/issues/5067) along with the current ephemeral agents


Notes:
- The first commit (https://github.com/jenkins-infra/azure/pull/1410/changes/8e25c4a5f04d4e4a9c4d3b86bdc1a8dfe3b39214) does not need to be reviewed as it's only moving the code block without any change
- The second commit is important as it holds the changes leading to the expected destroy + add of the NSG rule: https://github.com/jenkins-infra/azure/pull/1410/changes/0063eef7ae0ead7ec48a040f21233b4ea164dbd2