### PR TITLE
cleanup(trusted.ci.jenkins.io) remove ephemeral agents resources in the CDF subscription

### DIFF
--- a/agent.trusted.ci.jenkins.io.tf
+++ b/agent.trusted.ci.jenkins.io.tf
@@ -70,7 +70,6 @@ resource "azurerm_linux_virtual_machine" "agent_trusted_ci_jenkins_io" {
   identity {
     type = "UserAssigned"
     identity_ids = [
-      azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.id,
       azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.id,
     ]
   }

--- a/dummy.trusted.ci.jenkins.io.tf
+++ b/dummy.trusted.ci.jenkins.io.tf
@@ -87,7 +87,6 @@ resource "azurerm_linux_virtual_machine" "dummy_trusted_ci_jenkins_io" {
   identity {
     type = "UserAssigned"
     identity_ids = [
-      azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.id,
       azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.id,
     ]
   }

--- a/dummy2.trusted.ci.jenkins.io.tf
+++ b/dummy2.trusted.ci.jenkins.io.tf
@@ -60,7 +60,6 @@ resource "azurerm_linux_virtual_machine" "dummy2_trusted_ci_jenkins_io" {
   identity {
     type = "UserAssigned"
     identity_ids = [
-      azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.id,
       azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.id,
     ]
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -52,14 +52,6 @@ resource "local_file" "jenkins_infra_data_report" {
       }
     },
     "trusted.ci.jenkins.io" = {
-      "agents_azure_vms" = {
-        "resource_group_name"         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_resource_group_name,
-        "network_resource_group_name" = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_rg_name,
-        "virtual_network_name"        = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_network_name,
-        "sub_network_name"            = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_subnet_name,
-        "storage_account_name"        = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_storage_account_name,
-        "user_assigned_identity"      = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.id,
-      },
       "agents_azure_vms_jenkins_sponsored" = {
         "resource_group_name"         = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_resource_group_name,
         "network_resource_group_name" = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_network_rg_name,

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -310,127 +310,26 @@ resource "azurerm_role_assignment" "trusted_controller_vnet_jenkins_sponsored_re
 }
 
 ####################################################################################
-## Agents resources in the CDF subscription
+## Public DNS records in the CDF subscription
 ####################################################################################
-module "trusted_ci_jenkins_io_azurevm_agents" {
-  source = "./modules/azure-jenkinsinfra-azurevm-agents"
-
-  service_fqdn                     = module.trusted_ci_jenkins_io.service_fqdn
-  service_short_stripped_name      = module.trusted_ci_jenkins_io.service_short_stripped_name
-  ephemeral_agents_network_rg_name = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.resource_group_name
-  ephemeral_agents_network_name    = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.virtual_network_name
-  ephemeral_agents_subnet_name     = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.name
-  nsg_rg_name                      = module.trusted_ci_jenkins_io.controller_resourcegroup_name
-  controller_ips                   = compact([module.trusted_ci_jenkins_io.controller_public_ipv4])
-  controller_service_principal_id  = module.trusted_ci_jenkins_io.controller_service_principal_id
-  default_tags                     = local.default_tags
-  jenkins_infra_ips = {
-    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
-  }
+resource "azurerm_dns_a_record" "trusted_ci_controller" {
+  name                = "@"
+  zone_name           = module.trusted_ci_jenkins_io_letsencrypt.zone_name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  records             = [module.trusted_ci_jenkins_io.controller_private_ipv4]
 }
-# Required to allow controller to check for subnets inside the agents virtual network
-resource "azurerm_role_definition" "trusted_ci_jenkins_io_controller_vnet_reader" {
-  name  = "Read-trusted-ci-jenkins-io-VNET"
-  scope = data.azurerm_virtual_network.trusted_ci_jenkins_io.id
-
-  permissions {
-    actions = ["Microsoft.Network/virtualNetworks/read"]
-  }
-}
-resource "azurerm_role_assignment" "trusted_controller_ephemeral_agents_vnet_reader" {
-  scope              = data.azurerm_virtual_network.trusted_ci_jenkins_io.id
-  role_definition_id = azurerm_role_definition.trusted_ci_jenkins_io_controller_vnet_reader.role_definition_resource_id
-  principal_id       = module.trusted_ci_jenkins_io.controller_service_principal_id
-}
-# Allow controller to manage agents without requiring credentials (requires on the VM User Assign Identity)
-resource "azurerm_user_assigned_identity" "trusted_ci_jenkins_io_azurevm_agents_jenkins" {
-  location            = data.azurerm_virtual_network.trusted_ci_jenkins_io.location
-  name                = "trusted-ci-jenkins-io-agents"
-  resource_group_name = module.trusted_ci_jenkins_io.controller_resourcegroup_name
-}
-# The Controller identity must be able to operate this identity to assign it to VM agents - https://plugins.jenkins.io/azure-vm-agents/#plugin-content-roles-required-by-feature
-resource "azurerm_role_assignment" "trusted_ci_jenkins_io_manage_agent_uaid" {
-  scope                = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.id
-  role_definition_name = "Managed Identity Operator"
-  principal_id         = module.trusted_ci_jenkins_io.controller_service_principal_id
-}
-resource "azurerm_role_assignment" "trusted_ci_jenkins_io_azurevm_agents_jenkins_write_buildsreports_share" {
-  scope = azurerm_storage_account.builds_reports_jenkins_io.id
-  # Allow writing
-  role_definition_name = "Storage File Data Privileged Contributor"
-  principal_id         = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.principal_id
-}
-resource "azurerm_role_assignment" "trusted_ci_jenkins_io_azurevm_agents_jenkins_write_reports_share" {
-  scope = azurerm_storage_account.reports_jenkins_io.id
-  # Allow writing
-  role_definition_name = "Storage File Data Privileged Contributor"
-  principal_id         = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.principal_id
-}
-
-resource "azurerm_role_assignment" "trusted_ci_jenkins_io_azurevm_agents_jenkins_write_javadoc_share" {
-  scope = azurerm_storage_account.javadoc_jenkins_io.id
-  # Allow writing
-  role_definition_name = "Storage File Data Privileged Contributor"
-  principal_id         = azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins.principal_id
+resource "azurerm_dns_a_record" "assets_trusted_ci_controller" {
+  name                = "assets"
+  zone_name           = module.trusted_ci_jenkins_io_letsencrypt.zone_name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  records             = [module.trusted_ci_jenkins_io.controller_private_ipv4]
 }
 
 ####################################################################################
-## Network Security Group and rules in the CDF subscription
+## Private network resources (endpoint, DNS, etc.) in the CDF subscription
 ####################################################################################
-## Outbound Rules (different set of priorities than Inbound rules) ##
-resource "azurerm_network_security_rule" "allow_out_from_trusted_all_to_uc" {
-  name              = "allow-out-from-trusted-all-to-uc"
-  priority          = 4050
-  direction         = "Outbound"
-  access            = "Allow"
-  protocol          = "Tcp"
-  source_port_range = "*"
-  destination_port_ranges = [
-    "3390", # mirrorbits CLI (content)
-  ]
-  source_address_prefixes = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes
-  destination_address_prefixes = [
-    # Update Center (mirrorbits CLI)
-    azurerm_private_endpoint.publick8s_updates_jenkins_io_for_trustedci.private_service_connection[0].private_ip_address,
-  ]
-  resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name
-  network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
-}
-resource "azurerm_network_security_rule" "allow_out_many_from_trusted_agents_to_archive" {
-  name              = "allow-out-many-from-agents-to-archive"
-  priority          = 4060
-  direction         = "Outbound"
-  access            = "Allow"
-  protocol          = "Tcp"
-  source_port_range = "*"
-  destination_port_ranges = [
-    "22", # SSH (for rsync)
-  ]
-  source_address_prefixes     = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes
-  destination_address_prefix  = local.external_services["archives.jenkins.io"]
-  resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name
-  network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
-}
-## Inbound Rules (different set of priorities than Outbound rules) ##
-resource "azurerm_network_security_rule" "allow_in_many_from_trusted_agents_to_uc" {
-  name              = "allow-in-many-from-trusted-agents-to-uc"
-  priority          = 4050
-  direction         = "Inbound"
-  access            = "Allow"
-  protocol          = "Tcp"
-  source_port_range = "*"
-  destination_port_ranges = [
-    "3390", # mirrorbits CLI (content)
-  ]
-  source_address_prefixes = data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes
-  destination_address_prefixes = [
-    # Update Center (mirrorbits CLI)
-    azurerm_private_endpoint.publick8s_updates_jenkins_io_for_trustedci.private_service_connection[0].private_ip_address,
-  ]
-  resource_group_name         = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name
-  network_security_group_name = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
-}
-
 # Allow access to the private Azure Container Registry through an Azure Endpoint NIC
 module "trustedcijenkinsio_acr_pe" {
   source = "./modules/azure-container-registry-private-links"
@@ -452,56 +351,6 @@ module "trustedcijenkinsio_acr_pe" {
 
   default_tags = local.default_tags
 }
-
-## Allow access to/from ACR endpoint
-resource "azurerm_network_security_rule" "allow_out_https_from_trusted_to_acr" {
-  name                         = "allow-out-https-from-vnet-to-acr"
-  priority                     = 4051
-  direction                    = "Outbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "443"
-  source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io.address_space
-  destination_address_prefixes = split(",", module.trustedcijenkinsio_acr_pe.private_endpoint_nic_ip_addresses)
-  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name
-  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
-}
-resource "azurerm_network_security_rule" "allow_in_https_from_trusted_to_acr" {
-  name                         = "allow-in-https-from-vnet-to-acr"
-  priority                     = 4051
-  direction                    = "Inbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "443"
-  source_address_prefixes      = data.azurerm_virtual_network.trusted_ci_jenkins_io.address_space
-  destination_address_prefixes = split(",", module.trustedcijenkinsio_acr_pe.private_endpoint_nic_ip_addresses)
-  resource_group_name          = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_rg_name
-  network_security_group_name  = module.trusted_ci_jenkins_io_azurevm_agents.ephemeral_agents_nsg_name
-}
-
-####################################################################################
-## Public DNS records in the CDF subscription
-####################################################################################
-resource "azurerm_dns_a_record" "trusted_ci_controller" {
-  name                = "@"
-  zone_name           = module.trusted_ci_jenkins_io_letsencrypt.zone_name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  records             = [module.trusted_ci_jenkins_io.controller_private_ipv4]
-}
-resource "azurerm_dns_a_record" "assets_trusted_ci_controller" {
-  name                = "assets"
-  zone_name           = module.trusted_ci_jenkins_io_letsencrypt.zone_name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  records             = [module.trusted_ci_jenkins_io.controller_private_ipv4]
-}
-
-####################################################################################
-## Private network resources (endpoint, DNS, etc.) in the CDF subscription
-####################################################################################
 resource "azurerm_private_dns_a_record" "updates_jenkins_io" {
   name                = "updates.jenkins.io" # Full expected record name: updates.jenkins.io.privatelink.azurecr.io
   zone_name           = module.trustedcijenkinsio_acr_pe.private_dns_zone_name


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5015 but blocked by https://github.com/jenkins-infra/helpdesk/issues/5067 and https://github.com/jenkins-infra/helpdesk/issues/5070.

This PR removes all the trusted.ci.jenkins.io resources used for ephemeral agents in the CDF subscription (for https://github.com/jenkins-infra/helpdesk/issues/5015).

It was mandatory to finish https://github.com/jenkins-infra/helpdesk/issues/5070 and https://github.com/jenkins-infra/helpdesk/issues/5067 first to ensure this cleanup wasn't breaking anything.