### PR TITLE
fix(trusted.ci.jenkins.io): add `agent-2.trusted.ci.jenkins.io` IP to agent IP prefixes

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -51,6 +51,7 @@ module "trusted_ci_jenkins_io" {
   agent_ip_prefixes = concat(
     data.azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.address_prefixes,
     data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.address_prefixes,
+    data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_permanent_agents.address_prefixes,
     [
       azurerm_linux_virtual_machine.agent_trusted_ci_jenkins_io.private_ip_address
     ],


### PR DESCRIPTION
This change will result in an update of trusted.ci controller's `allow-outbound-ssh-from-trusted-ci-jenkins-io-controller-to-agents` NSG rule to include the IP address of the new permanent agent, to allow connecting to this agent from the controller with SSH.

Follow-up of:
- #1414 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5067