### PR TITLE
feat(builds.reports): allow cert.ci.jenkins.io agents to write build status reports

### DIFF
--- a/builds.reports.jenkins.io.tf
+++ b/builds.reports.jenkins.io.tf
@@ -29,6 +29,8 @@ resource "azurerm_storage_account" "builds_reports_jenkins_io" {
       local.app_subnets["release.ci.jenkins.io"].agents,
       # Required for populating the resource
       local.app_subnets["trusted.ci.jenkins.io"].agents,
+      # Required for populating the resource
+      local.app_subnets["cert.ci.jenkins.io"].agents,
     )
     bypass = ["AzureServices"]
   }

--- a/locals.tf
+++ b/locals.tf
@@ -352,6 +352,13 @@ locals {
         data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.id,
       ],
     },
+    "cert.ci.jenkins.io" = {
+      "controller" = [data.azurerm_subnet.cert_ci_jenkins_io_controller.id],
+      "agents" = [
+        # VM agents (Jenkins Sponsored subscription)
+        data.azurerm_subnet.cert_ci_jenkins_io_sponsored_ephemeral_agents.id,
+      ],
+    },
   }
 
   infra_ci_jenkins_io_fqdn                        = "infra.ci.jenkins.io"


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

`publishBuildStatusReport()` on cert.ci.jenkins.io agents fails with `403 AuthorizationFailure` when uploading to `builds.reports.jenkins.io`:

```
RESPONSE 403: 403 This request is not authorized to perform this operation.
ERROR CODE: AuthorizationFailure
```

The UAID (`cert-ci-jenkins-io-agents-sponsored`) already has the correct RBAC role (`Storage File Data Privileged Contributor`) on the `buildsreportsjenkinsio` storage account. However, the storage account firewall (`default_action = "Deny"`) only allows subnets for infra.ci, release.ci, and trusted.ci agents, cert.ci's agent subnet is not included, so requests are rejected at the network layer before RBAC is evaluated.

### Fix

- Add `cert.ci.jenkins.io` to `local.app_subnets` in `locals.tf`
- Add cert.ci agent subnet to the `builds.reports.jenkins.io` storage account network rules

### Testing

After apply, cert.ci agents should be able to reach the storage account and `azcopy copy` will succeed with the existing RBAC role assignment.

