### PR TITLE
Revert "feat(builds.reports): allow cert.ci.jenkins.io agents to write build status reports"

### DIFF
--- a/builds.reports.jenkins.io.tf
+++ b/builds.reports.jenkins.io.tf
@@ -29,8 +29,6 @@ resource "azurerm_storage_account" "builds_reports_jenkins_io" {
       local.app_subnets["release.ci.jenkins.io"].agents,
       # Required for populating the resource
       local.app_subnets["trusted.ci.jenkins.io"].agents,
-      # Required for populating the resource
-      local.app_subnets["cert.ci.jenkins.io"].agents,
     )
     bypass = ["AzureServices"]
   }

--- a/locals.tf
+++ b/locals.tf
@@ -352,13 +352,6 @@ locals {
         data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.id,
       ],
     },
-    "cert.ci.jenkins.io" = {
-      "controller" = [data.azurerm_subnet.cert_ci_jenkins_io_controller.id],
-      "agents" = [
-        # VM agents (Jenkins Sponsored subscription)
-        data.azurerm_subnet.cert_ci_jenkins_io_sponsored_ephemeral_agents.id,
-      ],
-    },
   }
 
   infra_ci_jenkins_io_fqdn                        = "infra.ci.jenkins.io"


### PR DESCRIPTION
Reverts jenkins-infra/azure#1422

Ref. https://github.com/jenkins-infra/azure/pull/1422#issuecomment-4307835551


We'll need a Private Endpoint to the builds.reports storage to access it from Sweden:

https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview

> The private-link resource can be deployed in a different region than the one for the virtual network and private endpoint.