### PR TITLE
feat(modules/azure-jenkinsinfra-controller) allow customization of the VM name/hostname with the optional variable `controller_fqdn`

### DIFF
--- a/modules/azure-jenkinsinfra-controller/locals.tf
+++ b/modules/azure-jenkinsinfra-controller/locals.tf
@@ -3,6 +3,6 @@ locals {
   service_short_name          = trimprefix(trimprefix(var.service_fqdn, var.dns_zone), ".")
   service_short_stripped_name = replace(local.service_short_name, ".", "-")
   service_stripped_name       = replace(var.service_fqdn, ".", "-")
-  controller_fqdn             = "controller.${var.service_fqdn}"
+  controller_fqdn             = var.controller_fqdn == "" ? "controller.${var.service_fqdn}" : var.controller_fqdn
   controller_principal_id     = var.controller_service_principal_end_date == "" ? data.azurerm_virtual_machine.controller.identity[0].principal_id : azuread_service_principal.controller[0].object_id
 }

--- a/modules/azure-jenkinsinfra-controller/variables.tf
+++ b/modules/azure-jenkinsinfra-controller/variables.tf
@@ -50,6 +50,11 @@ variable "service_custom_name" {
   description = "Custom Service Display Name"
   default     = ""
 }
+variable "controller_fqdn" {
+  type        = string
+  description = "Provides a custom controller VM FQDN instead of the default 'controller.var.service_fqdn'."
+  default     = ""
+}
 variable "is_public" {
   type    = bool
   default = false


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4343922083

- Expecting no changes with the current setup
- Tested by setting the `controller_fqdn` variable to `controller-sponsored.trusted.ci.jenkins.io` and running a local plan, look good:

```shell
# ...

# module.trusted_ci_jenkins_io.azurerm_linux_virtual_machine.controller must be replaced

~ computer_name = "controller.trusted.ci.jenkins.io" -> "controller-sponsored.trusted.ci.jenkins.io" # forces replacement
~ name          = "controller.trusted.ci.jenkins.io" -> "controller-sponsored.trusted.ci.jenkins.io" # forces replacement

# ...
```
