### PR TITLE
feat(trusted.ci.jenkins.io) instantiate a new controller VM in the sponsored subscription

### DIFF
--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -55,6 +55,51 @@ module "trusted_ci_jenkins_io" {
 }
 
 ####################################################################################
+## Resources for the Controller VM in the sponsored subscription
+####################################################################################
+module "trusted_ci_jenkins_io_sponsored" {
+  source = "./modules/azure-jenkinsinfra-controller"
+
+  providers = {
+    azurerm     = azurerm.jenkins-sponsored
+    azurerm.dns = azurerm
+    azuread     = azuread
+  }
+
+  service_fqdn                  = "trusted.ci.jenkins.io"
+  controller_fqdn               = "controller-sponsored.trusted.ci.jenkins.io"
+  controller_resourcegroup_name = "trusted-ci-jenkins-io-sponsored-controller"
+  use_vnet_common_nsg           = true
+  location                      = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.location
+  admin_username                = local.admin_username
+  admin_ssh_publickey           = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK6XtcUbbXwtvcTfjVv6vbowaKO2kIbhsQkGV6MQwMFe jenkins-infra-team@controller-sponsored.trusted.ci.jenkins.io"
+  controller_network_name       = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.name
+  controller_network_rg_name    = data.azurerm_virtual_network.trusted_ci_jenkins_io_sponsored.resource_group_name
+  controller_subnet_name        = data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_controller.name
+  controller_data_disk_size_gb  = 128
+  controller_vm_size            = "Standard_D2as_v6"
+  default_tags                  = local.default_tags
+
+  jenkins_infra_ips = {
+    ldap_ipv4         = azurerm_public_ip.publick8s_ips["publick8s-ldap-ipv4"].ip_address,
+    puppet_ipv4       = azurerm_public_ip.puppet_jenkins_io.ip_address,
+    privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes,
+  }
+
+  controller_service_principal_ids = [
+    data.azuread_service_principal.terraform_production.object_id,
+  ]
+  controller_packer_rg_ids = [
+    azurerm_resource_group.packer_images_sponsored["prod"].id,
+  ]
+
+  agent_ip_prefixes = concat(
+    data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.address_prefixes,
+    data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_permanent_agents.address_prefixes,
+  )
+}
+
+####################################################################################
 ## Common resources (endpoint, DNS, etc.) in the sponsored subscription
 ####################################################################################
 resource "azurerm_resource_group" "trusted_ci_jenkins_io_sponsored_commons" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4343922083

This PR instantiates a new VM for trusted.ci.jenkins.io controller with the following changes from the current VM:

- Disk with the "default" convention name
- RG set to custom value following the agents RG names in the sponsored subscription
- Switching to the Standard Dasv6 family (TPM, faster IOs, modern bootloader, quotas available, more memory due to CPU/memory ratio, no more noisy neighbourns)
- New SSH key for user `jenkins-infra-team`
- Use the "common" NSG from the virtual net
- Custom hostname: `controller-sponsored.trusted.ci.jenkins.io` to avoid collisions