### PR TITLE
fix(modules/azure-jenkinsinfra-controller) ensure role definitions have discriminated names to avoid name conflicts over subscriptions

### DIFF
--- a/modules/azure-jenkinsinfra-controller/locals.tf
+++ b/modules/azure-jenkinsinfra-controller/locals.tf
@@ -1,5 +1,4 @@
 locals {
-  service_custom_name         = var.service_custom_name != "" ? var.service_custom_name : var.service_fqdn
   service_short_name          = trimprefix(trimprefix(var.service_fqdn, var.dns_zone), ".")
   service_short_stripped_name = replace(local.service_short_name, ".", "-")
   service_stripped_name       = replace(var.service_fqdn, ".", "-")

--- a/modules/azure-jenkinsinfra-controller/main.tf
+++ b/modules/azure-jenkinsinfra-controller/main.tf
@@ -361,7 +361,7 @@ resource "azurerm_network_security_rule" "deny_all_inbound_to_controller" {
 ####################################################################################
 resource "azuread_application" "controller" {
   count        = var.controller_service_principal_end_date == "" ? 0 : 1
-  display_name = local.service_custom_name
+  display_name = local.controller_fqdn
   owners       = var.controller_service_principal_ids
   tags         = [for key, value in var.default_tags : "${key}:${value}"]
   required_resource_access {
@@ -396,7 +396,7 @@ resource "azurerm_role_assignment" "controller_read_packer_prod_images" {
   depends_on           = [azurerm_linux_virtual_machine.controller]
 }
 resource "azurerm_role_definition" "controller_vnet_reader" {
-  name  = "Read-${local.service_custom_name}-VNET"
+  name  = "Read-${local.controller_fqdn}-VNET"
   scope = data.azurerm_virtual_network.controller.id
 
   permissions {

--- a/modules/azure-jenkinsinfra-controller/variables.tf
+++ b/modules/azure-jenkinsinfra-controller/variables.tf
@@ -45,11 +45,6 @@ variable "controller_service_principal_end_date" {
 }
 
 ### Optionals variables
-variable "service_custom_name" {
-  type        = string
-  description = "Custom Service Display Name"
-  default     = ""
-}
 variable "controller_fqdn" {
   type        = string
   description = "Provides a custom controller VM FQDN instead of the default 'controller.var.service_fqdn'."


### PR DESCRIPTION


The goal of this change is to fix https://github.com/jenkins-infra/azure/commit/ab0463168cce7d1aba9b1a9d2cb68b5599d9c0cf#r183931769

Fixup of #1428

Related to https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4343922083