### PR TITLE
feat(modules/azure-jenkinsinfra-controller) allow creating DNS record in the public zone even for private controllers

### DIFF
--- a/modules/azure-jenkinsinfra-controller/locals.tf
+++ b/modules/azure-jenkinsinfra-controller/locals.tf
@@ -6,4 +6,11 @@ locals {
   controller_principal_id     = var.controller_service_principal_end_date == "" ? data.azurerm_virtual_machine.controller.identity[0].principal_id : azuread_service_principal.controller[0].object_id
   nsg_name                    = var.use_vnet_common_nsg ? data.azurerm_network_security_group.vnet_common_nsg[0].name : azurerm_network_security_group.controller[0].name
   nsg_rg_name                 = var.use_vnet_common_nsg ? data.azurerm_network_security_group.vnet_common_nsg[0].resource_group_name : azurerm_network_security_group.controller[0].resource_group_name
+  nsg_rule_name_discriminator = var.use_vnet_common_nsg ? replace(local.controller_fqdn, ".jenkins.io", ".jio") : "${local.service_short_stripped_name}-controller"
+  controller_inbound_ipv4_list = compact(flatten([
+    [for ip in azurerm_linux_virtual_machine.controller.private_ip_addresses :
+      ip if can(cidrnetmask("${ip}/32"))
+    ],
+    var.is_public ? azurerm_public_ip.controller[0].ip_address : "",
+  ]))
 }

--- a/modules/azure-jenkinsinfra-controller/main.tf
+++ b/modules/azure-jenkinsinfra-controller/main.tf
@@ -56,7 +56,7 @@ resource "azurerm_management_lock" "controller_publicipv6" {
   notes      = "Locked because this is a sensitive resource that should not be removed"
 }
 data "azurerm_dns_zone" "controller" {
-  count               = var.is_public && var.dns_zone_name != "" ? 1 : 0
+  count               = var.dns_zone_name != "" ? 1 : 0
   provider            = azurerm.dns
   name                = var.dns_zone_name
   resource_group_name = var.dns_resourcegroup_name
@@ -64,22 +64,14 @@ data "azurerm_dns_zone" "controller" {
 resource "azurerm_dns_a_record" "controller" {
   count               = length(data.azurerm_dns_zone.controller)
   provider            = azurerm.dns
-  name                = trimsuffix(trimsuffix(local.controller_fqdn, var.dns_zone), ".")
-  zone_name           = var.dns_zone_name
-  resource_group_name = var.dns_resourcegroup_name
+  name                = trimsuffix(trimsuffix(local.controller_fqdn, data.azurerm_dns_zone.controller[0].name), ".")
+  zone_name           = data.azurerm_dns_zone.controller[0].name
+  resource_group_name = data.azurerm_dns_zone.controller[0].resource_group_name
   ttl                 = 60
-  records             = [azurerm_public_ip.controller[0].ip_address]
-  tags                = var.default_tags
-}
-resource "azurerm_dns_a_record" "private_controller" {
-  count               = length(data.azurerm_dns_zone.controller)
-  provider            = azurerm.dns
-  name                = "private.${azurerm_dns_a_record.controller[0].name}"
-  zone_name           = var.dns_zone_name
-  resource_group_name = var.dns_resourcegroup_name
-  ttl                 = 60
-  records             = [azurerm_network_interface.controller.private_ip_address]
-  tags                = var.default_tags
+  records = [
+    var.is_public ? azurerm_public_ip.controller[0].ip_address : azurerm_network_interface.controller.private_ip_address,
+  ]
+  tags = var.default_tags
 }
 resource "azurerm_network_interface" "controller" {
   name                = local.controller_fqdn
@@ -201,15 +193,6 @@ data "azurerm_network_security_group" "vnet_common_nsg" {
   resource_group_name = data.azurerm_virtual_network.controller.resource_group_name
 }
 
-locals {
-  nsg_rule_name_discriminator = var.use_vnet_common_nsg ? replace(local.controller_fqdn, ".jenkins.io", ".jio") : "${local.service_short_stripped_name}-controller"
-  controller_inbound_ipv4_list = compact(flatten([
-    [for ip in azurerm_linux_virtual_machine.controller.private_ip_addresses :
-      ip if can(cidrnetmask("${ip}/32"))
-    ],
-    var.is_public ? azurerm_public_ip.controller[0].ip_address : "",
-  ]))
-}
 ## Outbound Rules (different set of priorities than Inbound rules) ##
 resource "azurerm_network_security_rule" "allow_outbound_ssh_from_controller_to_agents" {
   name                         = "allow-outbound-ssh-from-${local.nsg_rule_name_discriminator}-to-agents"

--- a/modules/azure-jenkinsinfra-controller/outputs.tf
+++ b/modules/azure-jenkinsinfra-controller/outputs.tf
@@ -14,12 +14,8 @@ output "controller_private_ipv4" {
   value = azurerm_linux_virtual_machine.controller.private_ip_address
 }
 
-output "controller_public_fqdn" {
-  value = length(azurerm_dns_a_record.controller) == 1 ? azurerm_dns_a_record.controller[0].fqdn : var.service_fqdn
-}
-
-output "controller_private_fqdn" {
-  value = length(azurerm_dns_a_record.private_controller) == 1 ? azurerm_dns_a_record.private_controller[0].fqdn : var.service_fqdn
+output "controller_fqdn" {
+  value = local.controller_fqdn
 }
 
 output "service_fqdn" {


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4343922083, it appeared we are missing DNS `A` record resolving to our private controller IPv4. 

That the module was designed for ci.jenkins.io which is public. Back in that time, we were setting up our `/etc/hosts`. But since then, we've defined Letsencrypt for private controller using their own DNS zones: we can safely follow the AKS pattern of public DNS records resolving to private IUPv4 routed through VPN.

This change allows (if applied by setting `var.dns_zone_name` and `var.dns_resourcegroup_name`) for each controller to get a public DNS `A` record resolving to its private IPv4 (VPN routed).

No changes expected for this first PR: will create record on a subsequent PR.

