### PR TITLE
feat(trusted.ci.jenkins.io) allow the new sponsored VM to manage the DNS zone

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -8,7 +8,7 @@ module "cert_ci_jenkins_io_letsencrypt" {
   zone_name        = "cert.ci.jenkins.io"
   dns_rg_name      = data.azurerm_resource_group.proddns_jenkinsio.name
   parent_zone_name = data.azurerm_dns_zone.jenkinsio.name
-  principal_id     = module.cert_ci_jenkins_io.controller_service_principal_id
+  principal_ids    = [module.cert_ci_jenkins_io.controller_service_principal_id]
 }
 module "cert_ci_jenkins_io" {
   source = "./modules/azure-jenkinsinfra-controller"

--- a/modules/azure-letsencrypt-dns/main.tf
+++ b/modules/azure-letsencrypt-dns/main.tf
@@ -19,17 +19,20 @@ resource "azurerm_dns_ns_record" "custom_zone_parent_records" {
 ## Permissions assigned to the VM System Identity to allow renewal: only allow reading the dnszone and only allow managing the ACME TXT record
 ## Ref. https://go-acme.github.io/lego/dns/azuredns/index.html#azure-managed-identity-with-azure-workload
 resource "azurerm_role_assignment" "custom_zone_read" {
+  count                = length(var.principal_ids)
   scope                = azurerm_dns_zone.custom_zone.id
   role_definition_name = "Reader"
-  principal_id         = var.principal_id
+  principal_id         = var.principal_ids[count.index]
 }
 resource "azurerm_role_assignment" "custom_zone_manage_acme_assets_txt_record" {
+  count                = length(var.principal_ids)
   scope                = "${azurerm_dns_zone.custom_zone.id}/TXT/_acme-challenge.assets"
   role_definition_name = "DNS Zone Contributor"
-  principal_id         = var.principal_id
+  principal_id         = var.principal_ids[count.index]
 }
 resource "azurerm_role_assignment" "custom_zone_manage_acme_txt_record" {
+  count                = length(var.principal_ids)
   scope                = "${azurerm_dns_zone.custom_zone.id}/TXT/_acme-challenge"
   role_definition_name = "DNS Zone Contributor"
-  principal_id         = var.principal_id
+  principal_id         = var.principal_ids[count.index]
 }

--- a/modules/azure-letsencrypt-dns/moved.tf
+++ b/modules/azure-letsencrypt-dns/moved.tf
@@ -1,0 +1,14 @@
+moved {
+  from = azurerm_role_assignment.custom_zone_read
+  to   = azurerm_role_assignment.custom_zone_read[0]
+}
+
+moved {
+  from = azurerm_role_assignment.custom_zone_manage_acme_assets_txt_record
+  to   = azurerm_role_assignment.custom_zone_manage_acme_assets_txt_record[0]
+}
+
+moved {
+  from = azurerm_role_assignment.custom_zone_manage_acme_txt_record
+  to   = azurerm_role_assignment.custom_zone_manage_acme_txt_record[0]
+}

--- a/modules/azure-letsencrypt-dns/variables.tf
+++ b/modules/azure-letsencrypt-dns/variables.tf
@@ -8,9 +8,9 @@ variable "zone_name" {
   description = "Name of the DNS zone handling the Let's Encrypt renewal"
 }
 
-variable "principal_id" {
-  type        = string
-  description = "ID of the Identity used to manage DNS records for Let's Encrypt (usually the Service Principal ID)"
+variable "principal_ids" {
+  type        = list(string)
+  description = "List of the Principal IDs (Identities) used to manage DNS records for Let's Encrypt (usually the Service Principal ID)"
 }
 
 variable "dns_rg_name" {

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -8,7 +8,10 @@ module "trusted_ci_jenkins_io_letsencrypt" {
   zone_name        = "trusted.ci.jenkins.io"
   dns_rg_name      = data.azurerm_resource_group.proddns_jenkinsio.name
   parent_zone_name = data.azurerm_dns_zone.jenkinsio.name
-  principal_id     = module.trusted_ci_jenkins_io.controller_service_principal_id
+  principal_ids = [
+    module.trusted_ci_jenkins_io.controller_service_principal_id,
+    module.trusted_ci_jenkins_io_sponsored.controller_service_principal_id,
+  ]
 }
 module "trusted_ci_jenkins_io" {
   source = "./modules/azure-jenkinsinfra-controller"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4343922083

This PR allows the new controller-sponsored.trusted.ci.jenkins.io VM to manage the DNS zone for `trusted.ci.jenkins.io` to allow `certbot` to request certificates using DNS validation.

It introduces a change in the `azure-letsencrypt-dns` module to allow passing a list of `principal_id`s instead of only one.
The change adds a set of `moved` block to manage transparently the existing VM permissions (3 for cert.ci and 3 for trusted.ci).

As such, the new VM adds 3 new permissions.

It should solve the current `certbot` error when calling the `certonly` subcommand during the Puppet initial bootstrap:

```
2026-05-02 07:44:33,281:DEBUG:certbot_dns_multi._internal.dns_multi:Cleanup error was
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/certbot/_internal/auth_handler.py", line 84, in handle_authorizations
    resps = self.auth.perform(achalls)
  File "/usr/local/lib/python3.10/dist-packages/certbot_dns_multi/_internal/dns_multi.py", line 97, in perform
    LegoClient.present(
  File "/usr/local/lib/python3.10/dist-packages/certbot_dns_multi/_internal/dns_multi.py", line 169, in present
    LegoClient._raise_for_response(
  File "/usr/local/lib/python3.10/dist-packages/certbot_dns_multi/_internal/dns_multi.py", line 201, in _raise_for_response
    raise errors.PluginError(resp["error"])
certbot.errors.PluginError: azuredns: could not find zone (from discovery): trusted.ci.jenkins.io
```