### PR TITLE
chore(all VMs) ignore user_data changes

### DIFF
--- a/agent-2.trusted.ci.jenkins.io.tf
+++ b/agent-2.trusted.ci.jenkins.io.tf
@@ -69,6 +69,15 @@ resource "azurerm_linux_virtual_machine" "agent_2_trusted_ci_jenkins_io_jenkins_
       azurerm_user_assigned_identity.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.id,
     ]
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignoring user_data in case we make changes to the tpl file (which could lead to destroying VMs inadvertently).
+      user_data,
+      # We don't want to re-create VMs when a new image is specified
+      source_image_reference,
+    ]
+  }
 }
 resource "azurerm_managed_disk" "agent_2_trusted_ci_jenkins_io_data_jenkins_sponsored" {
   provider             = azurerm.jenkins-sponsored

--- a/modules/azure-jenkinsinfra-controller/main.tf
+++ b/modules/azure-jenkinsinfra-controller/main.tf
@@ -163,6 +163,15 @@ resource "azurerm_linux_virtual_machine" "controller" {
     sku       = strcontains(var.controller_vm_size, "p") ? "22_04-lts-arm64" : "minimal-22_04-lts-gen2"
     version   = "latest"
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignoring user_data in case we make changes to the tpl file (which could lead to destroying VMs inadvertently).
+      user_data,
+      # We don't want to re-create VMs when a new image is specified
+      source_image_reference,
+    ]
+  }
 }
 resource "azurerm_virtual_machine_data_disk_attachment" "controller_data" {
   managed_disk_id    = azurerm_managed_disk.controller_data.id


### PR DESCRIPTION
We don't want to risk destroying VMs when an harmless change is pushed to the "common" `cloudinit.tftpl` file in jenkins-infra/shared-tools, but we want to always have an up to date cloud init template (when creating/recreating a VM) to benefit from latest changes.

This PR is a sustainable fix, but we can think of other techniques in the future (updatecli to retrieve the file from shared-tools so a PR would always be opened with a proper Terraform plan for instance)

----

Tested with the code in https://github.com/jenkins-infra/shared-tools/pull/175 which do not specify any change