### PR TITLE
feat: create privatek8s azurerm (e.g. non kubernetes) resources

### DIFF
--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -109,6 +109,12 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_disk_reader" 
   role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
 }
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_sponsored_disk_reader" {
+  provider           = azurerm.jenkins-sponsored
+  scope              = azurerm_resource_group.infra_ci_jenkins_io_controller.id
+  role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
+  principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
+}
 
 # TODO: cleanup the 3 resources below on infraci.jenkins.io-agents-2 cleanup (using the same UAID)
 ## Identity assigned to agents workloads (allowing them to reach resources without any Azure credential)
@@ -333,6 +339,7 @@ resource "azurerm_network_security_rule" "allow_outbound_winrm_https_from_infrac
 }
 
 # Allow infra.ci sponsored ephemeral agents to reach privatek8s cluster
+# TODO: remove as azureVM uses SSH launcher now
 resource "azurerm_network_security_rule" "allow_outbound_https_from_infraci_ephemeral_agents_jenkins_sponsored_to_privatek8s" {
   provider               = azurerm.jenkins-sponsored
   name                   = "allow-outbound-https-from-infraci-agents-jenkins-sponsored-to-privatek8s"

--- a/locals.tf
+++ b/locals.tf
@@ -64,6 +64,12 @@ locals {
       # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
       pod_cidr = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
     },
+    "privatek8s-sponsored" = {
+      name               = "privatek8s-sponsored",
+      kubernetes_version = "1.33.5",
+      # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
+      pod_cidr = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
+    },
     "publick8s" = {
       name               = "publick8s",
       kubernetes_version = "1.33.5",
@@ -316,6 +322,9 @@ locals {
     },
     "privatek8s" = {
       cluster_hostname = "https://${azurerm_kubernetes_cluster.privatek8s.fqdn}:443", # Cannot use the kubeconfig host as it provides a private DNS name
+    },
+    "privatek8s-sponsored" = {
+      cluster_hostname = "https://${azurerm_kubernetes_cluster.privatek8s_sponsored.fqdn}:443", # Cannot use the kubeconfig host as it provides a private DNS name
     },
     "publick8s" = {
       cluster_hostname = "https://${azurerm_kubernetes_cluster.publick8s.fqdn}:443", # Cannot use the kubeconfig host as it provides a private DNS name

--- a/outputs.tf
+++ b/outputs.tf
@@ -144,6 +144,18 @@ resource "local_file" "jenkins_infra_data_report" {
         "ipv4" = azurerm_dns_a_record.privatek8s_private.records,
       }
     },
+    "privatek8s-sponsored" = {
+      hostname           = local.aks_clusters_outputs["privatek8s-sponsored"].cluster_hostname,
+      kubernetes_version = local.aks_clusters["privatek8s-sponsored"].kubernetes_version,
+      # Outbound IPs are in azure-net (NAT gateway outbound IPs
+      public_inbound_lb = {
+        "public_ip_name"    = azurerm_public_ip.privatek8s_sponsored_public.name,
+        "public_ip_rg_name" = azurerm_public_ip.privatek8s_sponsored_public.resource_group_name,
+      }
+      private_inbound_ips = {
+        "ipv4" = azurerm_dns_a_record.privatek8s_sponsored_private.records,
+      }
+    },
     "dockerhubmirror.azurecr.io" = {
       "private_ip_addresses" = module.certcijenkinsiosponsored_acr_pe.private_endpoint_nic_ip_addresses,
     },

--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -1,0 +1,283 @@
+########################################################################################################
+# Resources in other Resource Groups ("RG") in the CDF subscription
+# which lifecycle are not bound directly to the cluster and its RG.
+########################################################################################################
+
+# Used later by the load balancer deployed on the cluster
+# Use case is to allow incoming webhooks
+resource "azurerm_public_ip" "privatek8s_sponsored_public" {
+  provider            = azurerm.jenkins-sponsored
+  name                = "public-privatek8s-sponsored"
+  resource_group_name = azurerm_resource_group.prod_public_ips.name
+  location            = var.location
+  allocation_method   = "Static"
+  sku                 = "Standard" # Needed to fix the error "PublicIPAndLBSkuDoNotMatch"
+  tags                = local.default_tags
+}
+resource "azurerm_management_lock" "privatek8s_sponsored_public" {
+  provider   = azurerm.jenkins-sponsored
+  name       = "privatek8s-sponsored-public"
+  scope      = azurerm_public_ip.privatek8s_sponsored_public.id
+  lock_level = "CanNotDelete"
+  notes      = "Locked because this is a sensitive resource that should not be removed when privatek8s-sponsored is removed"
+}
+resource "azurerm_dns_a_record" "privatek8s_sponsored_public" {
+  # same provider as the DNS zone
+  name                = "public.privatek8s-sponsored"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 300
+  records             = [azurerm_public_ip.privatek8s_sponsored_public.ip_address]
+  tags                = local.default_tags
+}
+
+resource "azurerm_dns_a_record" "privatek8s_sponsored_private" {
+  # same provider as the DNS zone
+  name                = "private.privatek8s-sponsored"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 300
+  records = [
+    # Let's specify an IP at the end of the range to have low probability of being used
+    cidrhost(
+      data.azurerm_subnet.privatek8s_sponsored_commons.address_prefixes[0],
+      -2,
+    )
+  ]
+  tags = local.default_tags
+}
+
+########################################################################################################
+# AzureRM resources related to the cluster in the sponsored subscription
+########################################################################################################
+resource "azurerm_resource_group" "privatek8s_sponsored" {
+  provider = azurerm.jenkins-sponsored
+  name     = local.aks_clusters["privatek8s-sponsored"].name
+  location = var.location
+  tags     = local.default_tags
+}
+resource "azurerm_kubernetes_cluster" "privatek8s_sponsored" {
+  provider = azurerm.jenkins-sponsored
+  name     = local.aks_clusters["privatek8s-sponsored"].name
+  sku_tier = "Standard"
+  ## Private cluster requires network setup to allow API access from:
+  # - infra.ci.jenkins.io agents (for both terraform job agents and kubernetes-management agents)
+  # - private.vpn.jenkins.io to allow admin management (either Azure UI or kube tools from admin machines)
+  private_cluster_enabled             = true
+  private_cluster_public_fqdn_enabled = true
+  dns_prefix                          = replace(local.aks_clusters["privatek8s-sponsored"].name, "-", "") # Avoid hyphens in this DNS host
+  location                            = azurerm_resource_group.privatek8s_sponsored.location
+  resource_group_name                 = azurerm_resource_group.privatek8s_sponsored.name
+  kubernetes_version                  = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
+  role_based_access_control_enabled   = true
+  oidc_issuer_enabled                 = true
+  workload_identity_enabled           = true
+
+  image_cleaner_interval_hours = 48
+
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    network_policy      = "azure"
+    outbound_type       = "userAssignedNATGateway"
+    load_balancer_sku   = "standard" # Required to customize the outbound type
+    pod_cidr            = local.aks_clusters["privatek8s-sponsored"].pod_cidr
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  default_node_pool {
+    name                         = "syspool"
+    only_critical_addons_enabled = true                # This property is the only valid way to add the "CriticalAddonsOnly=true:NoSchedule" taint to the default node pool
+    vm_size                      = "Standard_D2ads_v7" # At least 2 vCPUS as per AKS best practises
+
+    temporary_name_for_rotation = "syspooltemp"
+    upgrade_settings {
+      max_surge = "10%"
+    }
+    os_sku               = "AzureLinux"
+    os_disk_type         = "Ephemeral"
+    os_disk_size_gb      = 110 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/sizes/general-purpose/dadsv7-series?tabs=sizestoragelocal (depends on the instance size)
+    orchestrator_version = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
+    kubelet_disk_type    = "OS"
+    auto_scaling_enabled = true
+    min_count            = 2 # for best practices
+    max_count            = 3 # for upgrade
+    vnet_subnet_id       = data.azurerm_subnet.privatek8s_sponsored_app.id
+    tags                 = local.default_tags
+    zones                = [1, 2] # Many zones to ensure it is always able to provide machines in the region. Note: Zone 3 is not allowed for system pool.
+  }
+
+  tags = local.default_tags
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_linuxpool" {
+  provider = azurerm.jenkins-sponsored
+  name     = "linuxpool" # 12 char. max on Linux, only letters and numbers
+  vm_size  = "Standard_D4ads_v7"
+  upgrade_settings {
+    max_surge = "10%"
+  }
+  os_disk_type          = "Ephemeral"
+  os_sku                = "AzureLinux"
+  os_disk_size_gb       = 220 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/sizes/general-purpose/dadsv7-series?tabs=sizestoragelocal
+  orchestrator_version  = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s_sponsored.id
+  auto_scaling_enabled  = true
+  min_count             = 0
+  max_count             = 3
+  zones                 = [1, 2]
+  vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_app.id
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_infra_ci_jenkins_io_controller" {
+  provider = azurerm.jenkins-sponsored
+  name     = "infracictrl" # 12 char. max on Linux, only letters and numbers
+  vm_size  = "Standard_D4pds_v6"
+  upgrade_settings {
+    max_surge = "10%"
+  }
+  os_sku                = "AzureLinux"
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 220 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/sizes/general-purpose/dpdsv6-series?tabs=sizestoragelocal
+  orchestrator_version  = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s_sponsored.id
+  auto_scaling_enabled  = true
+  min_count             = 1
+  max_count             = 2
+  zones                 = [2, 3]
+  vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_infra_ci_jenkins_io_controller.id
+
+  node_taints = [
+    "jenkins=infra.ci.jenkins.io:NoSchedule",
+    "jenkins-component=controller:NoSchedule"
+  ]
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_release_ci_jenkins_io_controller" {
+  provider = azurerm.jenkins-sponsored
+  name     = "releacictrl" # 12 char. max on Linux, only letters and numbers
+  vm_size  = "Standard_D4pds_v6"
+  upgrade_settings {
+    max_surge = "10%"
+  }
+  os_sku                = "AzureLinux"
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 220 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/sizes/general-purpose/dpdsv6-series?tabs=sizestoragelocal
+  orchestrator_version  = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s_sponsored.id
+  auto_scaling_enabled  = true
+  min_count             = 1
+  max_count             = 2
+  zones                 = [2, 3]
+  vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_controller.id
+
+  node_taints = [
+    "jenkins=release.ci.jenkins.io:NoSchedule",
+    "jenkins-component=controller:NoSchedule"
+  ]
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_release_ci_jenkins_io_agents_linux" {
+  provider = azurerm.jenkins-sponsored
+  name     = "releacilinux" # 12 char. max on Linux, only letters and numbers
+  vm_size  = "Standard_D8ads_v7"
+  upgrade_settings {
+    max_surge = "10%"
+  }
+  os_sku                = "AzureLinux"
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 440 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/sizes/general-purpose/dadsv7-series?tabs=sizestoragelocal
+  orchestrator_version  = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s_sponsored.id
+  auto_scaling_enabled  = true
+  min_count             = 0
+  max_count             = 3
+  zones                 = [1, 2]
+  vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_agents.id
+  node_taints = [
+    "jenkins=release.ci.jenkins.io:NoSchedule",
+  ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_release_ci_jenkins_io_agents_windows_2022" {
+  provider = azurerm.jenkins-sponsored
+  name     = "w2022" # 6 char. max on Windows, only letters and numbers
+  vm_size  = "Standard_D4ads_v7"
+  upgrade_settings {
+    max_surge = "10%"
+  }
+  os_disk_type          = "Ephemeral"
+  os_disk_size_gb       = 220 # Ref. Cache storage size at https://learn.microsoft.com/fr-fr/azure/virtual-machines/sizes/general-purpose/dadsv7-series?tabs=sizestoragelocal
+  orchestrator_version  = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s_sponsored.id
+  os_type               = "Windows"
+  os_sku                = "Windows2022"
+  auto_scaling_enabled  = true
+  min_count             = 0
+  max_count             = 3
+  zones                 = [1, 2]
+  vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_agents.id
+  node_taints = [
+    "os=windows:NoSchedule",
+    "jenkins=release.ci.jenkins.io:NoSchedule",
+    "version=windows2022:NoSchedule",
+  ]
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  tags = local.default_tags
+}
+
+# Allow cluster to manage network resources in the privatek8s_tier subnet
+# It is used for managing the LBs of the public and private ingress controllers
+resource "azurerm_role_assignment" "privatek8s_sponsored_subnets_networkcontributor" {
+  provider = azurerm.jenkins-sponsored
+  for_each = toset([
+    data.azurerm_subnet.privatek8s_sponsored_app.id,
+    data.azurerm_subnet.privatek8s_sponsored_infra_ci_jenkins_io_controller.id,
+    data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_agents.id,
+    data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_controller.id,
+
+  ])
+  scope                            = each.key
+  role_definition_name             = "Network Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}
+
+# Allow cluster to manage the public IP privatek8s-sponsored
+# It is used for managing the public IP of the LB of the public ingress controller
+resource "azurerm_role_assignment" "privatek8s_sponsored_publicip_networkcontributor" {
+  provider                         = azurerm.jenkins-sponsored
+  scope                            = azurerm_public_ip.privatek8s_sponsored_public.id
+  role_definition_name             = "Network Contributor"
+  principal_id                     = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
+  skip_service_principal_aad_check = true
+}

--- a/providers.tf
+++ b/providers.tf
@@ -21,6 +21,14 @@ provider "kubernetes" {
 }
 
 provider "kubernetes" {
+  alias                  = "privatek8s-sponsored"
+  host                   = local.aks_clusters_outputs.privatek8s_sponsored.cluster_hostname
+  client_certificate     = base64decode(azurerm_kubernetes_cluster.privatek8s_sponsored.kube_config.0.client_certificate)
+  client_key             = base64decode(azurerm_kubernetes_cluster.privatek8s_sponsored.kube_config.0.client_key)
+  cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.privatek8s_sponsored.kube_config.0.cluster_ca_certificate)
+}
+
+provider "kubernetes" {
   alias                  = "publick8s"
   host                   = local.aks_clusters_outputs.publick8s.cluster_hostname
   client_certificate     = base64decode(azurerm_kubernetes_cluster.publick8s.kube_config.0.client_certificate)

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -34,10 +34,22 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_disk_reader
   role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
 }
+resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_sponsored_disk_reader" {
+  provider           = azurerm.jenkins-sponsored
+  scope              = azurerm_resource_group.release_ci_jenkins_io_controller.id
+  role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
+  principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
+}
 resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents" {
   location            = var.location
   name                = "release-ci-jenkins-io-agents"
   resource_group_name = azurerm_kubernetes_cluster.privatek8s.resource_group_name
+}
+resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents_sponsored" {
+  provider            = azurerm.jenkins-sponsored
+  location            = var.location
+  name                = "release-ci-jenkins-io-agents-sponsored"
+  resource_group_name = azurerm_kubernetes_cluster.privatek8s_sponsored.resource_group_name
 }
 resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_buildsreports_share" {
   scope = azurerm_storage_account.builds_reports_jenkins_io.id

--- a/vnets.tf
+++ b/vnets.tf
@@ -26,6 +26,10 @@ data "azurerm_resource_group" "trusted_ci_jenkins_io_sponsored" {
   provider = azurerm.jenkins-sponsored
   name     = "trusted-ci-jenkins-io-sponsored"
 }
+data "azurerm_resource_group" "privatek8s_sponsored" {
+  provider = azurerm.jenkins-sponsored
+  name     = "privatek8s-sponsored"
+}
 
 ################################################################################
 ## Virtual Networks
@@ -62,6 +66,11 @@ data "azurerm_virtual_network" "trusted_ci_jenkins_io_sponsored" {
   provider            = azurerm.jenkins-sponsored
   name                = "${data.azurerm_resource_group.trusted_ci_jenkins_io_sponsored.name}-vnet"
   resource_group_name = data.azurerm_resource_group.trusted_ci_jenkins_io_sponsored.name
+}
+data "azurerm_virtual_network" "privatek8s_sponsored" {
+  provider            = azurerm.jenkins-sponsored
+  name                = "${data.azurerm_resource_group.privatek8s_sponsored.name}-vnet"
+  resource_group_name = data.azurerm_resource_group.privatek8s_sponsored.name
 }
 
 ################################################################################
@@ -151,4 +160,34 @@ data "azurerm_subnet" "privatek8s_release_ci_controller_tier" {
   name                 = "privatek8s-releaseci-ctrl-tier"
   resource_group_name  = data.azurerm_resource_group.private.name
   virtual_network_name = data.azurerm_virtual_network.private.name
+}
+data "azurerm_subnet" "privatek8s_sponsored_commons" {
+  provider             = azurerm.jenkins-sponsored
+  name                 = "privatek8s-sponsored-commons"
+  resource_group_name  = data.azurerm_virtual_network.privatek8s_sponsored.resource_group_name
+  virtual_network_name = data.azurerm_virtual_network.privatek8s_sponsored.name
+}
+data "azurerm_subnet" "privatek8s_sponsored_app" {
+  provider             = azurerm.jenkins-sponsored
+  name                 = "privatek8s-sponsored-app"
+  resource_group_name  = data.azurerm_virtual_network.privatek8s_sponsored.resource_group_name
+  virtual_network_name = data.azurerm_virtual_network.privatek8s_sponsored.name
+}
+data "azurerm_subnet" "privatek8s_sponsored_release_ci_jenkins_io_controller" {
+  provider             = azurerm.jenkins-sponsored
+  name                 = "privatek8s-sponsored-release-ci-jenkins-io-controller"
+  resource_group_name  = data.azurerm_virtual_network.privatek8s_sponsored.resource_group_name
+  virtual_network_name = data.azurerm_virtual_network.privatek8s_sponsored.name
+}
+data "azurerm_subnet" "privatek8s_sponsored_release_ci_jenkins_io_agents" {
+  provider             = azurerm.jenkins-sponsored
+  name                 = "privatek8s-sponsored-release-ci-jenkins-io-agents"
+  resource_group_name  = data.azurerm_virtual_network.privatek8s_sponsored.resource_group_name
+  virtual_network_name = data.azurerm_virtual_network.privatek8s_sponsored.name
+}
+data "azurerm_subnet" "privatek8s_sponsored_infra_ci_jenkins_io_controller" {
+  provider             = azurerm.jenkins-sponsored
+  name                 = "privatek8s-sponsored-infra-ci-jenkins-io-controller"
+  resource_group_name  = data.azurerm_virtual_network.privatek8s_sponsored.resource_group_name
+  virtual_network_name = data.azurerm_virtual_network.privatek8s_sponsored.name
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

Notes:

- Added the kubernetes provider, so reverting PRs will be easier when decomissioning
- Already set up the required permissions for infra.ci and release.ci controllers
- Trying to create the public IP and its lock in the sponsored subscription (parent existing RG is in the CDF subscription but I assume the resources should be in the same subscription as the LB which will use it). Might need to revisit eventually
- Added a few comments around subscriptions and naming constraints in Azure API