### PR TITLE
fix(privatek8s-sponsored) correct RG name and Public IP subscription

### DIFF
--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -6,7 +6,6 @@
 # Used later by the load balancer deployed on the cluster
 # Use case is to allow incoming webhooks
 resource "azurerm_public_ip" "privatek8s_sponsored_public" {
-  provider            = azurerm.jenkins-sponsored
   name                = "public-privatek8s-sponsored"
   resource_group_name = azurerm_resource_group.prod_public_ips.name
   location            = var.location
@@ -15,7 +14,6 @@ resource "azurerm_public_ip" "privatek8s_sponsored_public" {
   tags                = local.default_tags
 }
 resource "azurerm_management_lock" "privatek8s_sponsored_public" {
-  provider   = azurerm.jenkins-sponsored
   name       = "privatek8s-sponsored-public"
   scope      = azurerm_public_ip.privatek8s_sponsored_public.id
   lock_level = "CanNotDelete"

--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -52,7 +52,7 @@ resource "azurerm_dns_a_record" "privatek8s_sponsored_private" {
 ########################################################################################################
 resource "azurerm_resource_group" "privatek8s_sponsored" {
   provider = azurerm.jenkins-sponsored
-  name     = local.aks_clusters["privatek8s-sponsored"].name
+  name     = "privatek8s-aks-sponsored"
   location = var.location
   tags     = local.default_tags
 }


### PR DESCRIPTION
This PR amends #1458 with the following changes:

- [Correct RG name to avoid collision with azure-net vnet RG](https://github.com/jenkins-infra/azure/pull/1459/commits/6850348e19f13110d764a0d7089f9cba5ae15afb) to fix https://github.com/jenkins-infra/azure/pull/1458/changes#r3280983761

- [Ensure public IP is on the same subscription as its RG to avoid HTTP/404 from Azure API](https://github.com/jenkins-infra/azure/pull/1459/commits/1f5ec91fb4e216b6ed1476bdb29fe0224fe7af97) to fix https://github.com/jenkins-infra/azure/pull/1458/changes#r3280876337

Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952