### PR TITLE
fix(privatek8s-sponsored) use latest AKS patch for 1.33.X, enable automatic nodes upgrade and fix system pool zone

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -66,7 +66,7 @@ locals {
     },
     "privatek8s-sponsored" = {
       name               = "privatek8s-sponsored",
-      kubernetes_version = "1.33.5",
+      kubernetes_version = "1.33.11",
       # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
       pod_cidr = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
     },

--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -70,6 +70,8 @@ resource "azurerm_kubernetes_cluster" "privatek8s_sponsored" {
   role_based_access_control_enabled   = true
   oidc_issuer_enabled                 = true
   workload_identity_enabled           = true
+  automatic_upgrade_channel           = "node-image"
+  node_os_upgrade_channel             = "NodeImage"
 
   image_cleaner_interval_hours = 48
 

--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -107,7 +107,7 @@ resource "azurerm_kubernetes_cluster" "privatek8s_sponsored" {
     max_count            = 3 # for upgrade
     vnet_subnet_id       = data.azurerm_subnet.privatek8s_sponsored_app.id
     tags                 = local.default_tags
-    zones                = [1, 2] # Many zones to ensure it is always able to provide machines in the region. Note: Zone 3 is not allowed for system pool.
+    zones                = [2, 3] # Many zones to ensure it is always able to provide machines in the region. Note: Zone 3 is not allowed for system pool.
   }
 
   tags = local.default_tags


### PR DESCRIPTION
This PR amends #1458 with the following changes:

- [Use latest 1.33.x patch version and setup automatic node OS upgrade](https://github.com/jenkins-infra/azure/pull/1460/changes/f508d87e1c1fac6dc3b43f9e70be38f4b6cb632c) to fix https://github.com/jenkins-infra/azure/pull/1458/changes#r3281869896

- [Set system node pool to use zones 2 and 3](https://github.com/jenkins-infra/azure/pull/1460/changes/b15bd303bdc55940612a9b71ae58697f3c088e61) to fix https://github.com/jenkins-infra/azure/pull/1458/changes#r3281828443
  - Note: trying 2 zones to have HA. But not sure if it will work since the error message only mentions zone 2.

Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952