### PR TITLE
fix(privatek8s-sponsored) set system node pool to only use the Zone `2`

### DIFF
--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -103,11 +103,11 @@ resource "azurerm_kubernetes_cluster" "privatek8s_sponsored" {
     orchestrator_version = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
     kubelet_disk_type    = "OS"
     auto_scaling_enabled = true
-    min_count            = 2 # for best practices
-    max_count            = 3 # for upgrade
+    min_count            = 2
+    max_count            = 3
     vnet_subnet_id       = data.azurerm_subnet.privatek8s_sponsored_app.id
     tags                 = local.default_tags
-    zones                = [2, 3] # Many zones to ensure it is always able to provide machines in the region. Note: Zone 3 is not allowed for system pool.
+    zones                = [2] # Only one zone available - ref. https://github.com/jenkins-infra/azure/pull/1460/changes#r3281970045
   }
 
   tags = local.default_tags
@@ -128,7 +128,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_linuxpool"
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 3
-  zones                 = [2] # Only one zone available - ref. https://github.com/jenkins-infra/azure/pull/1460/changes#r3281970045
+  zones                 = [1, 2]
   vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_app.id
 
   lifecycle {


### PR DESCRIPTION
Revert "fix(privatek8s-sponsored) set system node pool to only use the Zone 2 (#1461)"

This reverts commit 92311032e65f38cebe0e3997928ba50d2a93a65f (PR #1461) as I mistakenly changed zones of another node pool

Goal is to fix https://github.com/jenkins-infra/azure/pull/1458#discussion_r3281828443

Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952