### PR TITLE
fix(privatek8s-sponsored) correct node pool zones following Azure API errors

### DIFF
--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -128,7 +128,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_linuxpool"
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 3
-  zones                 = [1, 2]
+  zones                 = [2] # https://github.com/jenkins-infra/azure/pull/1458/changes#r3282193453
   vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_app.id
 
   lifecycle {
@@ -153,7 +153,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_infra_ci_j
   auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 2
-  zones                 = [2, 3]
+  zones                 = [1, 2] # https://github.com/jenkins-infra/azure/pull/1458/changes#r3282196193
   vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_infra_ci_jenkins_io_controller.id
 
   node_taints = [
@@ -182,7 +182,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_release_ci
   auto_scaling_enabled  = true
   min_count             = 1
   max_count             = 2
-  zones                 = [2, 3]
+  zones                 = [1, 2] # https://github.com/jenkins-infra/azure/pull/1458/changes#r3282199055
   vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_controller.id
 
   node_taints = [
@@ -211,7 +211,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_release_ci
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 3
-  zones                 = [1, 2]
+  zones                 = [2] # https://github.com/jenkins-infra/azure/pull/1458/changes#r3282201958
   vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_agents.id
   node_taints = [
     "jenkins=release.ci.jenkins.io:NoSchedule",
@@ -240,7 +240,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_release_ci
   auto_scaling_enabled  = true
   min_count             = 0
   max_count             = 3
-  zones                 = [1, 2]
+  zones                 = [2] # https://github.com/jenkins-infra/azure/pull/1458/changes#r3282188706
   vnet_subnet_id        = data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_agents.id
   node_taints = [
     "os=windows:NoSchedule",


### PR DESCRIPTION
- Amends #1458 (see per line comments)
- Yes it's frustrating to pay for HA but only being served a single zone because not enough capacity

Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952