### PR TITLE
hotfix(privatek8s-sponsored) create Windows 2022 Node Pool with a supported zone, family size and disk

### DIFF
--- a/privatek8s-sponsored.tf
+++ b/privatek8s-sponsored.tf
@@ -235,12 +235,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "privatek8s_sponsored_release_ci
   #
   # Last solution stop using Windows Node Pool in favor of Azure VM agents.
   #####
-  vm_size = "Standard_D4s_v3" # Generation 1 VM
+  vm_size = "Standard_D8s_v3" # Generation 1 VM
   upgrade_settings {
     max_surge = "10%"
   }
   os_disk_type          = "Ephemeral"
-  os_disk_size_gb       = 32 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv3-series?tabs=sizestoragelocal
+  os_disk_size_gb       = 64 # Ref. Cache storage size at https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dsv3-series?tabs=sizestoragelocal
   orchestrator_version  = local.aks_clusters["privatek8s-sponsored"].kubernetes_version
   kubernetes_cluster_id = azurerm_kubernetes_cluster.privatek8s_sponsored.id
   os_type               = "Windows"


### PR DESCRIPTION
Amends #1458, #1464 and #1466

Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

Checked quotas and availability prior to this change:

<img width="1918" height="851" alt="Capture d’écran 2026-05-21 à 18 39 39" src="https://github.com/user-attachments/assets/0b807862-4df2-4a14-9198-1a25cd6b9f18" />
<img width="1650" height="252" alt="Capture d’écran 2026-05-21 à 18 54 46" src="https://github.com/user-attachments/assets/33ac863e-a44f-417e-8646-c92e2fc1407f" />

Applied manually with success and scaled to "1 manual node" to ensure we have enough quota and the setup is correct:

<img width="1634" height="59" alt="Capture d’écran 2026-05-21 à 19 02 43" src="https://github.com/user-attachments/assets/3f3721e2-46cb-4a3a-8ea5-a4f570c1da26" />


Expecting the node pool to be changed by this PR from "Manual - 1 node" to "Autoscale - 0 nodes"



