### PR TITLE
feat(infra.ci,release.ci,privatek8s-sponsored) add required resources for infra.ci and release.ci in the sponsored subscription

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -90,18 +90,6 @@ module "cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
     privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 }
-moved {
-  from = module.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup["257e10fb-5356-4c9a-91fc-c340fca2291a"]
-  to   = module.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup[0]
-}
-moved {
-  from = module.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents["257e10fb-5356-4c9a-91fc-c340fca2291a"]
-  to   = module.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents[0]
-}
-moved {
-  from = module.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_network_contributor_in_ephemeral_agent_resourcegroup["257e10fb-5356-4c9a-91fc-c340fca2291a"]
-  to   = module.cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_network_contributor_in_ephemeral_agent_resourcegroup[0]
-}
 resource "azurerm_resource_group" "cert_ci_jenkins_io_controller_jenkins_sponsored" {
   provider = azurerm.jenkins-sponsored
   name     = module.cert_ci_jenkins_io.controller_resourcegroup_name # Same name on both subscriptions

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -1,87 +1,11 @@
-# This resource group hosts resources used for agents only managed by terraform or administrators
-# such as NSG for agents subnet (we don't want azure-vm-agents jenkins plugin to access this RG)
+###################################################################################
+# Ressources for infra.ci.jenkins.io in the CDF subscription
+###################################################################################
 resource "azurerm_resource_group" "infra_ci_jenkins_io_controller" {
   name     = "infra-ci-jenkins-io-controller"
   location = var.location
   tags     = local.default_tags
 }
-resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io_controller" {
-  location            = azurerm_resource_group.infra_ci_jenkins_io_controller.location
-  name                = "infracijenkinsiocontroller"
-  resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller.name
-}
-
-# Required to allow azcopy sync of contributors.jenkins.io File Share
-module "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
-
-  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
-  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url       = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_id              = azurerm_storage_share.contributors_jenkins_io.id
-  storage_account_id         = azurerm_storage_account.contributors_jenkins_io.id
-  default_tags               = local.default_tags
-}
-
-# Required to allow azcopy sync of docs.jenkins.io File Share
-module "infraci_docsjenkinsio_fileshare_serviceprincipal_writer" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
-
-  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
-  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url       = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_id              = azurerm_storage_share.docs_jenkins_io.id
-  storage_account_id         = azurerm_storage_account.docs_jenkins_io.id
-  default_tags               = local.default_tags
-}
-
-# Required to allow azcopy sync of stats.jenkins.io File Share
-module "infraci_statsjenkinsio_fileshare_serviceprincipal_writer" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
-
-  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
-  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url       = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_id              = azurerm_storage_share.stats_jenkins_io.id
-  storage_account_id         = azurerm_storage_account.stats_jenkins_io.id
-  default_tags               = local.default_tags
-}
-
-# Required to allow azcopy sync to the reports.jenkins.io File Share
-module "infraci_reportsjenkinsio_fileshare_serviceprincipal_writer" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
-
-  service_fqdn               = "infraci-reportsjenkinsio-fileshare_serviceprincipal_writer"
-  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url       = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_reportsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_id              = azurerm_storage_share.reports_jenkins_io.id
-  storage_account_id         = azurerm_storage_account.reports_jenkins_io.id
-  default_tags               = local.default_tags
-}
-
-resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer_sponsored" {
-  scope                = azurerm_resource_group.packer_images_sponsored["prod"].id
-  role_definition_name = "Reader"
-  principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id
-}
-
-# Required to allow azcopy sync of plugins.jenkins.io File Share
-module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
-  source = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
-
-  service_fqdn               = "infraci-pluginsjenkinsio-fileshare_serviceprincipal_writer"
-  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
-  active_directory_url       = "https://github.com/jenkins-infra/azure"
-  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.end_date
-  file_share_id              = azurerm_storage_share.plugins_jenkins_io.id
-  storage_account_id         = azurerm_storage_account.plugins_jenkins_io.id
-  default_tags               = local.default_tags
-}
-
 resource "azurerm_managed_disk" "infra_ci_jenkins_io_data" {
   name                 = "infra-ci-jenkins-io-data"
   location             = azurerm_resource_group.infra_ci_jenkins_io_controller.location
@@ -91,7 +15,17 @@ resource "azurerm_managed_disk" "infra_ci_jenkins_io_data" {
   disk_size_gb         = 64
   tags                 = local.default_tags
 }
-
+resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io_controller" {
+  location            = azurerm_resource_group.infra_ci_jenkins_io_controller.location
+  name                = "infracijenkinsiocontroller"
+  resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller.name
+}
+# Azure VM agents requires controller to read the resource group where VM images are stored
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_allow_packer_sponsored" {
+  scope                = azurerm_resource_group.packer_images_sponsored["prod"].id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id
+}
 # Required to allow AKS CSI driver to access the Azure disk
 resource "azurerm_role_definition" "infra_ci_jenkins_io_controller_disk_reader" {
   name  = "ReadInfraCIDisk"
@@ -109,14 +43,62 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_disk_reader" 
   role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
 }
-resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_sponsored_disk_reader" {
-  provider           = azurerm.jenkins-sponsored
-  scope              = azurerm_resource_group.infra_ci_jenkins_io_controller.id
-  role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
-  principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
+# Required to allow azcopy sync of contributors.jenkins.io File Share
+module "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer" {
+  source                     = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.contributors_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.contributors_jenkins_io.id
+  default_tags               = local.default_tags
+}
+# Required to allow azcopy sync of docs.jenkins.io File Share
+module "infraci_docsjenkinsio_fileshare_serviceprincipal_writer" {
+  source                     = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_docsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.docs_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.docs_jenkins_io.id
+  default_tags               = local.default_tags
+}
+# Required to allow azcopy sync of stats.jenkins.io File Share
+module "infraci_statsjenkinsio_fileshare_serviceprincipal_writer" {
+  source                     = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+  service_fqdn               = "infra-ci-jenkins-io-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.stats_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.stats_jenkins_io.id
+  default_tags               = local.default_tags
+}
+# Required to allow azcopy sync to the reports.jenkins.io File Share
+module "infraci_reportsjenkinsio_fileshare_serviceprincipal_writer" {
+  source                     = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+  service_fqdn               = "infraci-reportsjenkinsio-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_reportsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.reports_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.reports_jenkins_io.id
+  default_tags               = local.default_tags
+}
+# Required to allow azcopy sync of plugins.jenkins.io File Share
+module "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer" {
+  source                     = "./.shared-tools/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer"
+  service_fqdn               = "infraci-pluginsjenkinsio-fileshare_serviceprincipal_writer"
+  active_directory_owners    = [data.azuread_service_principal.terraform_production.object_id]
+  active_directory_url       = "https://github.com/jenkins-infra/azure"
+  service_principal_end_date = local.end_dates.infra_ci_jenkins_io.infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer.end_date
+  file_share_id              = azurerm_storage_share.plugins_jenkins_io.id
+  storage_account_id         = azurerm_storage_account.plugins_jenkins_io.id
+  default_tags               = local.default_tags
 }
 
-# TODO: cleanup the 3 resources below on infraci.jenkins.io-agents-2 cleanup (using the same UAID)
 ## Identity assigned to agents workloads (allowing them to reach resources without any Azure credential)
 resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io_agents" {
   location            = var.location
@@ -135,8 +117,7 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_agents_write_buildsrepor
   role_definition_name = "Storage File Data Privileged Contributor"
   principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents.principal_id
 }
-
-# Azure SP for updatecli with minimum rights
+# Resources for updatecli jobs in infra.ci.jenkins.io
 resource "azurerm_resource_group" "updatecli_infra_ci_jenkins_io" {
   name     = "updatecli-infra-ci-jenkins-io"
   location = var.location
@@ -175,7 +156,6 @@ resource "azuread_application_password" "updatecli_infra_ci_jenkins_io" {
   display_name   = "updatecli_infra.ci.jenkins.io-tf-managed"
   end_date       = "2026-06-09T00:00:00Z"
 }
-
 resource "azurerm_role_definition" "vm_images_reader" {
   name  = "ReadVMImages"
   scope = azurerm_resource_group.updatecli_infra_ci_jenkins_io.id
@@ -184,39 +164,106 @@ resource "azurerm_role_definition" "vm_images_reader" {
     actions = ["Microsoft.Compute/images/read"]
   }
 }
-
 resource "azurerm_role_assignment" "updatecli_infra_ci_jenkins_io_allow_images_list" {
   scope              = azurerm_resource_group.updatecli_infra_ci_jenkins_io.id
   role_definition_id = azurerm_role_definition.vm_images_reader.role_definition_resource_id
   principal_id       = azuread_service_principal.updatecli_infra_ci_jenkins_io.object_id
 }
+###################################################################################
+# Ressources for infra.ci.jenkins.io in the sponsored subscription
+###################################################################################
+# Resources for the controller (e.g. moving the controller implies moving these)
+resource "azurerm_resource_group" "infra_ci_jenkins_io_controller_sponsored" {
+  provider = azurerm.jenkins-sponsored
 
-## Jenkins Sponsored
-# This resource group hosts resources used for agents only managed by terraform or administrators such as UAID, PE or NSG
+  name     = "infra-ci-jenkins-io-controller-sponsored"
+  location = var.location
+  tags     = local.default_tags
+}
+resource "azurerm_managed_disk" "infra_ci_jenkins_io_data_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  name                 = "infra-ci-jenkins-io-data-sponsored"
+  location             = azurerm_resource_group.infra_ci_jenkins_io_controller_sponsored.location
+  resource_group_name  = azurerm_resource_group.infra_ci_jenkins_io_controller_sponsored.name
+  storage_account_type = "StandardSSD_ZRS"
+  create_option        = "Empty"
+  disk_size_gb         = 64
+  tags                 = local.default_tags
+}
+# Required to allow AKS CSI driver to access the Azure disk
+resource "azurerm_role_definition" "infra_ci_jenkins_io_controller_disk_reader_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  name  = "ReadInfraCIDiskSponsored"
+  scope = azurerm_resource_group.infra_ci_jenkins_io_controller_sponsored.id
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/disks/write",
+    ]
+  }
+}
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_disk_reader_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  scope              = azurerm_resource_group.infra_ci_jenkins_io_controller_sponsored.id
+  role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_disk_reader_sponsored.role_definition_resource_id
+  principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
+}
+# Allow to setup Azure permissions for the controller
+resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io_controller_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  location            = azurerm_resource_group.infra_ci_jenkins_io_controller_sponsored.location
+  name                = "infracijenkinsiocontrollersponsored"
+  resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_controller_sponsored.name
+}
+# Azure VM agents requires controller to read the resource group where VM images are stored
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_sponsored_allow_packer_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  scope                = azurerm_resource_group.packer_images_sponsored["prod"].id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller_sponsored.principal_id
+}
+
+# Resources used by both controller and agents indifferently
 resource "azurerm_resource_group" "infra_ci_jenkins_io_sponsored_commons" {
   provider = azurerm.jenkins-sponsored
+
   name     = "infra-ci-jenkins-io-sponsored-commons"
   location = var.location
   tags     = local.default_tags
 }
-
 ## Identity assigned to agents workloads (allowing them to reach resources without any Azure credential)
 resource "azurerm_user_assigned_identity" "infra_ci_jenkins_io_agents_jenkins_sponsored" {
-  provider            = azurerm.jenkins-sponsored
+  provider = azurerm.jenkins-sponsored
+
   location            = var.location
   name                = "infra-ci-jenkins-io-sponsored-agents"
   resource_group_name = azurerm_resource_group.infra_ci_jenkins_io_sponsored_commons.name
 }
 # The Controller identity must be able to operate this identity to assign it to VM agents - https://plugins.jenkins.io/azure-vm-agents/#plugin-content-roles-required-by-feature
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_operate_agents_identity_jenkins_sponsored" {
-  provider             = azurerm.jenkins-sponsored
+  provider = azurerm.jenkins-sponsored
+
   scope                = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents_jenkins_sponsored.id
   role_definition_name = "Managed Identity Operator"
   principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id
 }
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_sponsored_operate_agents_identity_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  scope                = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents_jenkins_sponsored.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller_sponsored.principal_id
+}
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_agents_jenkins_sponsored_write_buildsreports_share" {
   provider = azurerm.jenkins-sponsored
-  scope    = azurerm_storage_account.builds_reports_jenkins_io.id
+
+  scope = azurerm_storage_account.builds_reports_jenkins_io.id
   # Allow writing
   role_definition_name = "Storage File Data Privileged Contributor"
   principal_id         = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents_jenkins_sponsored.principal_id
@@ -225,20 +272,28 @@ resource "azurerm_role_assignment" "infra_ci_jenkins_io_agents_jenkins_sponsored
 # Required to allow controller to check for subnets inside the virtual network
 resource "azurerm_role_definition" "infra_ci_jenkins_io_controller_vnet_sponsored_reader" {
   provider = azurerm.jenkins-sponsored
-  name     = "read-infra-ci-jenkins-io-vnet-sponsored"
-  scope    = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsored.id
+
+  name  = "read-infra-ci-jenkins-io-vnet-sponsored"
+  scope = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsored.id
 
   permissions {
     actions = ["Microsoft.Network/virtualNetworks/read"]
   }
 }
 resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_vnet_sponsored_reader" {
-  provider           = azurerm.jenkins-sponsored
+  provider = azurerm.jenkins-sponsored
+
   scope              = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsored.id
   role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_vnet_sponsored_reader.role_definition_resource_id
   principal_id       = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id
 }
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_controller_sponsored_vnet_sponsored_reader" {
+  provider = azurerm.jenkins-sponsored
 
+  scope              = data.azurerm_virtual_network.infra_ci_jenkins_io_sponsored.id
+  role_definition_id = azurerm_role_definition.infra_ci_jenkins_io_controller_vnet_sponsored_reader.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.infra_ci_jenkins_io_controller_sponsored.principal_id
+}
 module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   source = "./modules/azure-jenkinsinfra-azurevm-agents"
 
@@ -252,9 +307,16 @@ module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   ephemeral_agents_network_name    = data.azurerm_subnet.infra_ci_jenkins_io_sponsored_ephemeral_agents.virtual_network_name
   ephemeral_agents_subnet_name     = data.azurerm_subnet.infra_ci_jenkins_io_sponsored_ephemeral_agents.name
   nsg_rg_name                      = azurerm_resource_group.infra_ci_jenkins_io_sponsored_commons.name
-  controller_ips                   = data.azurerm_subnet.privatek8s_infra_ci_controller_tier.address_prefixes # Pod IPs: controller IP may change in the pods IP subnet
-  controller_service_principal_ids = [azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id]
-  storage_account_name             = "infraciagentssponso" # Max 24 chars
+  controller_ips = concat(
+    data.azurerm_subnet.privatek8s_infra_ci_controller_tier.address_prefixes,                 # Controller pod requests are using SNAT (changing internal outbound IPs) to reach the other subnet
+    data.azurerm_subnet.privatek8s_sponsored_infra_ci_jenkins_io_controller.address_prefixes, # Controller pod requests are using SNAT (changing internal outbound IPs) to reach the other subnet
+  )
+  controller_service_principal_ids = [
+    azurerm_user_assigned_identity.infra_ci_jenkins_io_controller_sponsored.principal_id,
+    azurerm_user_assigned_identity.infra_ci_jenkins_io_controller.principal_id,
+  ]
+  storage_account_name = "infraciagentssponso" # Max 24 chars
+
 
   default_tags = local.default_tags
 

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -324,18 +324,6 @@ module "infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
     privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 }
-moved {
-  from = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup["f84875cc-d0bd-4d94-b237-99f7669a655a"]
-  to   = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup[0]
-}
-moved {
-  from = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents["f84875cc-d0bd-4d94-b237-99f7669a655a"]
-  to   = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents[0]
-}
-moved {
-  from = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_network_contributor_in_ephemeral_agent_resourcegroup["f84875cc-d0bd-4d94-b237-99f7669a655a"]
-  to   = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_network_contributor_in_ephemeral_agent_resourcegroup[0]
-}
 # Allow infra.ci sponsored ephemeral agents to reach packer VMs with SSH on aws
 resource "azurerm_network_security_rule" "allow_outbound_ssh_from_infraci_agents_jenkins_sponsored_to_aws_packer" {
   provider               = azurerm.jenkins-sponsored

--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -1,3 +1,6 @@
+###################################################################################
+# Ressources for release.ci.jenkins.io in the CDF subscription
+###################################################################################
 resource "azurerm_resource_group" "release_ci_jenkins_io_controller" {
   name     = "release-ci-jenkins-io-controller"
   location = var.location
@@ -34,22 +37,10 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_disk_reader
   role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
   principal_id       = azurerm_kubernetes_cluster.privatek8s.identity[0].principal_id
 }
-resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_sponsored_disk_reader" {
-  provider           = azurerm.jenkins-sponsored
-  scope              = azurerm_resource_group.release_ci_jenkins_io_controller.id
-  role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_disk_reader.role_definition_resource_id
-  principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
-}
 resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents" {
   location            = var.location
   name                = "release-ci-jenkins-io-agents"
   resource_group_name = azurerm_kubernetes_cluster.privatek8s.resource_group_name
-}
-resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents_sponsored" {
-  provider            = azurerm.jenkins-sponsored
-  location            = var.location
-  name                = "release-ci-jenkins-io-agents-sponsored"
-  resource_group_name = azurerm_kubernetes_cluster.privatek8s_sponsored.resource_group_name
 }
 resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_buildsreports_share" {
   scope = azurerm_storage_account.builds_reports_jenkins_io.id
@@ -57,7 +48,7 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_b
   role_definition_name = "Storage File Data Privileged Contributor"
   principal_id         = azurerm_user_assigned_identity.release_ci_jenkins_io_agents.principal_id
 }
-
+## Core Releases KeyVault
 resource "azurerm_resource_group" "prodreleasecore" {
   name     = "prodreleasecore"
   location = var.location
@@ -109,4 +100,72 @@ resource "azurerm_key_vault" "prodreleasecore" {
       "List",
     ]
   }
+}
+###################################################################################
+# Ressources for release.ci.jenkins.io sponsored subscription
+###################################################################################
+resource "azurerm_resource_group" "release_ci_jenkins_io_controller_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  name     = "release-ci-jenkins-io-controller-sponsored"
+  location = var.location
+  tags     = local.default_tags
+}
+resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_controller_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  location            = azurerm_resource_group.release_ci_jenkins_io_controller_sponsored.location
+  name                = "releasecijenkinsiocontrollersponsored"
+  resource_group_name = azurerm_resource_group.release_ci_jenkins_io_controller_sponsored.name
+}
+resource "azurerm_managed_disk" "release_ci_jenkins_io_data_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  name                 = "release-ci-jenkins-io-data-sponsored"
+  location             = azurerm_resource_group.release_ci_jenkins_io_controller_sponsored.location
+  resource_group_name  = azurerm_resource_group.release_ci_jenkins_io_controller_sponsored.name
+  storage_account_type = "StandardSSD_ZRS"
+  create_option        = "Empty"
+  disk_size_gb         = 64
+  tags                 = local.default_tags
+}
+# Required to allow AKS CSI driver to access the Azure disk
+resource "azurerm_role_definition" "release_ci_jenkins_io_controller_disk_reader_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  name  = "ReadReleaseCIDiskSponsored"
+  scope = azurerm_resource_group.release_ci_jenkins_io_controller_sponsored.id
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/disks/write",
+    ]
+  }
+}
+moved {
+  from = azurerm_role_assignment.infra_ci_jenkins_io_controller_sponsored_disk_reader
+  to   = azurerm_role_assignment.release_ci_jenkins_io_controller_disk_reader_sponsored
+}
+resource "azurerm_role_assignment" "release_ci_jenkins_io_controller_disk_reader_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  scope              = azurerm_resource_group.release_ci_jenkins_io_controller_sponsored.id
+  role_definition_id = azurerm_role_definition.release_ci_jenkins_io_controller_disk_reader_sponsored.role_definition_resource_id
+  principal_id       = azurerm_kubernetes_cluster.privatek8s_sponsored.identity[0].principal_id
+}
+resource "azurerm_user_assigned_identity" "release_ci_jenkins_io_agents_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  location            = var.location
+  name                = "release-ci-jenkins-io-agents-sponsored"
+  resource_group_name = azurerm_kubernetes_cluster.privatek8s_sponsored.resource_group_name
+}
+resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_buildsreports_share_sponsored" {
+  provider = azurerm.jenkins-sponsored
+
+  scope = azurerm_storage_account.builds_reports_jenkins_io.id
+  # Allow writing
+  role_definition_name = "Storage File Data Privileged Contributor"
+  principal_id         = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsored.principal_id
 }

--- a/trusted.ci.jenkins.io.tf
+++ b/trusted.ci.jenkins.io.tf
@@ -282,18 +282,6 @@ module "trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
     privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 }
-moved {
-  from = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup["f20710fa-1a96-40a3-bbce-4548d4bec5a0"]
-  to   = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_contributor_in_ephemeral_agent_resourcegroup[0]
-}
-moved {
-  from = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents["f20710fa-1a96-40a3-bbce-4548d4bec5a0"]
-  to   = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_io_manage_net_interfaces_subnet_ephemeral_agents[0]
-}
-moved {
-  from = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_network_contributor_in_ephemeral_agent_resourcegroup["f20710fa-1a96-40a3-bbce-4548d4bec5a0"]
-  to   = module.trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored.azurerm_role_assignment.controller_network_contributor_in_ephemeral_agent_resourcegroup[0]
-}
 resource "azurerm_role_assignment" "trusted_ci_jenkins_io_azurevm_agents_jenkins_sponsored_write_reports_share" {
   provider = azurerm.jenkins-sponsored
   scope    = azurerm_storage_account.reports_jenkins_io.id


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

Follows up #1458 (and its fixes from #1459 up to #1467 )

Requires azurevmagents module update to support many controller Azure IDs (#1469)

Along with the Terraform plan, I've opened #1471 in advance to check the impact of the removal  of CDF resources to ensure we don't forget anything here.

Blocked by #1469 and #1473 

Blocks #1474 