### PR TITLE
fix(release.ci/privatek8s-sponsored) allow access to agent resources (keyvaults/storage)

### DIFF
--- a/data-storage-jenkins-io.tf
+++ b/data-storage-jenkins-io.tf
@@ -29,12 +29,12 @@ resource "azurerm_storage_account" "data_storage_jenkins_io" {
       [
         # Required for using the resource
         data.azurerm_subnet.publick8s.id,
-        # Allows release.ci.jenkins.io agents to access the mount
-        data.azurerm_subnet.privatek8s_release_tier.id,
       ],
+      # Required for populating the resource from release.ci agents
+      local.app_subnets["release.ci.jenkins.io"].agents,
       # Required for managing the resource
       local.app_subnets["infra.ci.jenkins.io"].agents,
-      # Required for populating the resource
+      # Required for populating the resource from trusted.ci agents
       local.app_subnets["trusted.ci.jenkins.io"].agents,
     )
     bypass = ["Metrics", "Logging", "AzureServices"]

--- a/locals.tf
+++ b/locals.tf
@@ -335,14 +335,27 @@ locals {
 
   app_subnets = {
     "release.ci.jenkins.io" = {
-      "controller" = [data.azurerm_subnet.privatek8s_release_ci_controller_tier.id],
+      "controller" = [
+        # CDF subscription
+        data.azurerm_subnet.privatek8s_release_ci_controller_tier.id,
+        # Sponsored subscription
+        data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_controller.id,
+      ],
       "agents" = [
-        # Container agents
+        # CDF subscription
         data.azurerm_subnet.privatek8s_release_tier.id,
+        # Sponsored subscription
+        data.azurerm_subnet.privatek8s_sponsored_release_ci_jenkins_io_agents.id,
+
       ],
     },
     "infra.ci.jenkins.io" = {
-      "controller" = [data.azurerm_subnet.privatek8s_infra_ci_controller_tier.id],
+      "controller" = [
+        # CDF subscription
+        data.azurerm_subnet.privatek8s_infra_ci_controller_tier.id,
+        # Sponsored subscription
+        data.azurerm_subnet.privatek8s_sponsored_infra_ci_jenkins_io_controller.id,
+      ],
       "agents" = [
         # VM agents (Jenkins Sponsored subscription)
         data.azurerm_subnet.infra_ci_jenkins_io_sponsored_ephemeral_agents.id,


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

The acceptance tests jobs on release.ci.jenkins.io and infra.ci.jenkins.io are failing with access errors:

- NFS access from release.ci Linux package agents:

```
Warning  FailedMount       32s (x10 over 10m)  kubelet             MountVolume.MountDevice failed for volume "release-ci-jenkins-io-agents-data-storage" : rpc error: code = Internal desc = volume(data-storage#datastoragejenkinsio#data-storage-jenkins-io) mount datastoragejenkinsio.file.core.windows.net:/datastoragejenkinsio/data-storage-jenkins-io on /var/lib/kubelet/plugins/kubernetes.io/csi/file.csi.azure.com/b6009eb9e38c7df83b8704a9c44805c6aa792990a4bf1059c0720de2ec0f374a/globalmount failed with mount failed: exit status 32
```

- Keyvault access from release.ci agents:

```
+ az keyvault secret download --vault-name prodreleasecore --name jenkins-release-pgp-2026 --file jenkins-release.gpg --encoding base64
10:36:41  ERROR: (Forbidden) Client address is not authorized and caller is not a trusted service.
```

This PR fixes up #1458 were I forgot to set up the new agent subnets to the `local` collections to allow access to the NFS storage and Azure keyvault.

Note: 
- It also allows release.ci.jenkins.io agents in `privatek8s-sponsored` to publish to build.reports.jenkins.io
- It fixes the NFS (data storage) network access by adding the proper subnet collection for `release.ci`  to avoid the same mistake in the future