### PR TITLE
fix: recreate ACR private endpoint

### DIFF
--- a/private.tf
+++ b/private.tf
@@ -1,0 +1,21 @@
+# Allow access to the private Azure Container Registry through an Azure Endpoint NIC
+module "private_acr_pe" {
+  source = "./modules/azure-container-registry-private-links"
+
+  providers = {
+    azurerm     = azurerm
+    azurerm.acr = azurerm
+  }
+
+  name = "private"
+
+  acr_name     = azurerm_container_registry.dockerhub_mirror.name
+  acr_location = azurerm_container_registry.dockerhub_mirror.location
+  acr_rg_name  = azurerm_container_registry.dockerhub_mirror.resource_group_name
+
+  subnet_name  = data.azurerm_subnet.private_vnet_data_tier.name
+  vnet_name    = data.azurerm_virtual_network.private.name
+  vnet_rg_name = data.azurerm_virtual_network.private.resource_group_name
+
+  default_tags = local.default_tags
+}


### PR DESCRIPTION
This change recreates the ACR PE (removed in https://github.com/jenkins-infra/azure/pull/1481) in the `private` vnet RG so ACR can be used by our VPN VM to pull private images.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5091