### PR TITLE
feat(privatek8s-sponsored) bump AKS to 1.34.7

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -60,7 +60,7 @@ locals {
     },
     "privatek8s-sponsored" = {
       name               = "privatek8s-sponsored",
-      kubernetes_version = "1.33.11",
+      kubernetes_version = "1.34.7",
       # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
       pod_cidr = "10.100.0.0/14", # 10.100.0.1 - 10.103.255.255
     },


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4908#issuecomment-4577634828

Version comes from Azure portal UI:

<img width="598" height="599" alt="Capture d’écran 2026-06-01 à 21 46 38" src="https://github.com/user-attachments/assets/e453a5bb-8be0-4bec-9699-b5d1994d11d2" />
