### PR TITLE
chore(pipeline): use VM agent instead of container agent

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,4 +27,5 @@ terraform(
     ),
   ],
   publishReports: ['jenkins-infra-data-reports/azure.json'],
+  agentLabel: 'linux-arm64',
 )


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4908#issuecomment-4576945317


Fails with timeout to AKS clusters until https://github.com/jenkins-infra/azure/pull/1487 is deployed with success