### PR TITLE
feat(publick8s): upgrade to Kubernetes 1.34

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -66,7 +66,7 @@ locals {
     },
     "publick8s" = {
       name               = "publick8s",
-      kubernetes_version = "1.33.5",
+      kubernetes_version = "1.34.7",
       # https://learn.microsoft.com/en-us/azure/aks/concepts-network-azure-cni-overlay#pods
       pod_cidrs = [
         "10.100.0.0/14",       # 10.100.0.1 - 10.103.255.255


### PR DESCRIPTION
This PR upgrades `publick8s` to Kubernetes 1.34.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4908#issuecomment-4603087452