### PR TITLE
chore(updatecli) add terraform_output keys for credential rotation values and reference it in the manifest

### DIFF
--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
@@ -67,6 +67,10 @@ actions:
         > You'll have to ensure that `{{ $val.secret }}` is updated with this new password
         > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.
 
+        The new password value, once the PR is merged and deployed, can be retrieved with:
+        ```
+        terraform output -raw {{ $val.terraform_output }}
+        ```
         If you don't, the build of {{ $val.service }} on infra.ci.jenkins.io won't be able to update the website content anymore.
       labels:
         - terraform

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -12,22 +12,27 @@ end_dates:
       end_date: "2026-08-09T00:00:00Z"
       service: "contributors.jenkins.io"
       secret: "CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+      terraform_output: "infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer_application_client_password"
     infraci_docsjenkinsio_fileshare_serviceprincipal_writer:
       end_date: "2026-08-31T00:00:00Z"
       service: "docs.jenkins.io"
       secret: "DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+      terraform_output: "infraci_docsjenkinsio_fileshare_serviceprincipal_writer_application_client_password"
     infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer:
       end_date: "2026-08-09T00:00:00Z"
       service: "plugins.jenkins.io"
       secret: "INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_PASSWORD"
+      terraform_output: "infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer_application_client_password"
     infraci_statsjenkinsio_fileshare_serviceprincipal_writer:
       end_date: "2026-08-09T00:00:00Z"
       service: "stats.jenkins.io"
       secret: "STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+      terraform_output: "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_application_client_password"
     infraci_reportsjenkinsio_fileshare_serviceprincipal_writer:
       end_date: "2026-06-09T00:00:00Z"
       service: "reports.jenkins.io"
       secret: "REPORTS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET"
+      terraform_output: "infraci_reportsjenkinsio_fileshare_serviceprincipal_writer_application_client_password"
 updatecli_end_dates:
   infra.ci.jenkins.io:
     custom_hcl_key: resource.azuread_application_password.updatecli_infra_ci_jenkins_io.end_date


### PR DESCRIPTION
Ref: 
- jenkins-infra/helpdesk#5170

When rotating file share service principal credentials, the auto-generated PR body doesn't specify how to retrieve the new password from Terraform after merging. This caused issues during the docs.jenkins.io rotation (jenkins-infra/helpdesk#5120).

- Added `terraform_output` key to each `end_dates.infra_ci_jenkins_io` entry
- `fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl`: Updated PR description template to include `terraform output` command along with the key to retrieve the password



