### PR TITLE
chore(updatecli) add terraform output reference to infra.ci credential rotation PR templates

### DIFF
--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
@@ -67,7 +67,9 @@ actions:
         > You'll have to ensure that `{{ $val.secret }}` is updated with this new password
         > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.
 
-        If you don't, the build of {{ $val.service }} on infra.ci.jenkins.io won't be able to update the website content anymore.
+        The new password value, once the PR is merged and deployed, can be retrieved with:
+        ```
+        terraform output -raw {{ $val.terraform_output }}
       labels:
         - terraform
         - "{{ $val.service }}"


### PR DESCRIPTION
Ref:
- jenkins-infra/helpdesk#5170

When rotating file share service principal credentials, the auto-generated PR body doesn't specify how to retrieve the new password from Terraform after merging. This caused issues during the docs.jenkins.io rotation (helpdesk#5120).

- `fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl`: Updated PR description template to include `terraform output` command along with the key to retrieve the password

