### PR TITLE
chore(terraform/outputs) add reports.jenkins.io fileshare service principal outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -190,3 +190,4 @@ output "infraci_reportsjenkinsio_fileshare_serviceprincipal_writer_application_c
 output "infraci_reportsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
   sensitive = true
   value     = module.infraci_reportsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -184,3 +184,9 @@ output "infraci_statsjenkinsio_fileshare_serviceprincipal_writer_application_cli
   sensitive = true
   value     = module.infraci_statsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password
 }
+output "infraci_reportsjenkinsio_fileshare_serviceprincipal_writer_application_client_id" {
+  value = module.infraci_reportsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_id
+}
+output "infraci_reportsjenkinsio_fileshare_serviceprincipal_writer_application_client_password" {
+  sensitive = true
+  value     = module.infraci_reportsjenkinsio_fileshare_serviceprincipal_writer.fileshare_serviceprincipal_writer_application_client_password


### PR DESCRIPTION
Ref: 
- jenkins-infra/helpdesk#5152

Restoring Terraform outputs for reports.jenkins.io file share service principal (previously added in #1333 and reverted). Needed to retrieve credentials during rotation without digging into state.
