### PR TITLE
chore: add prerequisites warning to credential rotation PR and FAQ to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -85,7 +85,8 @@ Error: Backend configuration changed
 
 Remove the local Terraform state and re-initialize:
 
-```bash
+[source,bash]
+----
 rm -rf ./.terraform
-export TF_VAR_environment="production"
 make --directory=.shared-tools/terraform prepare
+----

--- a/README.adoc
+++ b/README.adoc
@@ -74,3 +74,18 @@ A usual change to this repository looks like the following:
 * Edit the Terraform project files
 * Run the command `make --directory=.shared-tools/terraform validate` again to ensure that your changes are OK
 * Commit, push and open a pull request to let the Jenkins pipeline run the test + plan (as per https://github.com/jenkins-infra/shared-tools/blob/main/terraform/README.adoc#jenkins-pipeline)
+
+## FAQ / Troubleshooting
+
+### `Error: Backend configuration changed`
+
+If you see this when running `make --directory=.shared-tools/terraform prepare`:
+
+Error: Backend configuration changed
+
+Remove the local Terraform state and re-initialize:
+
+```bash
+rm -rf ./.terraform
+export TF_VAR_environment="production"
+make --directory=.shared-tools/terraform prepare

--- a/README.adoc
+++ b/README.adoc
@@ -75,9 +75,9 @@ A usual change to this repository looks like the following:
 * Run the command `make --directory=.shared-tools/terraform validate` again to ensure that your changes are OK
 * Commit, push and open a pull request to let the Jenkins pipeline run the test + plan (as per https://github.com/jenkins-infra/shared-tools/blob/main/terraform/README.adoc#jenkins-pipeline)
 
-## FAQ / Troubleshooting
+== FAQ / Troubleshooting
 
-### `Error: Backend configuration changed`
+=== `Error: Backend configuration changed`
 
 If you see this when running `make --directory=.shared-tools/terraform prepare`:
 

--- a/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
+++ b/updatecli/updatecli.d/fs-sp-writer-end-dates_infra.ci.jenkins.io.tf.tpl
@@ -63,6 +63,10 @@ actions:
 
         After merging this PR, a new password will be generated.
 
+        > [!WARNING]
+        > **Before merging**, ensure you have all [prerequisites](https://github.com/jenkins-infra/azure#requirements) and can complete the full rotation immediately.
+        > Merging rotates the credential — if you don't update charts-secrets promptly, website deployments will fail.
+
         > [!IMPORTANT]
         > You'll have to ensure that `{{ $val.secret }}` is updated with this new password
         > in https://github.com/jenkins-infra/charts-secrets/blob/main/config/infra.ci.jenkins.io/jenkins-secrets.yaml.


### PR DESCRIPTION
Ref: 
- jenkins-infra/helpdesk#5170

During the docs.jenkins.io credential rotation (helpdesk#5120), the credential was rotated without completing the full workflow, causing website deployment failures. Additionally, the "Backend configuration changed" error when running Terraform locally wasn't documented.
