### PR TITLE
feat(release.ci.jenkins.io) allow vault access from agents using workload identity instead of credentials

### DIFF
--- a/release.ci.jenkins.io.tf
+++ b/release.ci.jenkins.io.tf
@@ -53,6 +53,31 @@ resource "azurerm_key_vault" "prodreleasecore" {
       "List",
     ]
   }
+
+  # Agents UAID (credential-less)
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsored.principal_id
+
+    certificate_permissions = [
+      "Get",
+      "List",
+      "GetIssuers",
+      "ListIssuers",
+    ]
+
+    key_permissions = [
+      "Get",
+      "List",
+      "Decrypt",
+      "Verify",
+      "Encrypt",
+    ]
+    secret_permissions = [
+      "Get",
+      "List",
+    ]
+  }
 }
 ###################################################################################
 # Ressources for release.ci.jenkins.io sponsored subscription
@@ -116,5 +141,13 @@ resource "azurerm_role_assignment" "release_ci_jenkins_io_azurevm_agents_write_b
   scope = azurerm_storage_account.builds_reports_jenkins_io.id
   # Allow writing
   role_definition_name = "Storage File Data Privileged Contributor"
+  principal_id         = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsored.principal_id
+}
+resource "azurerm_role_assignment" "release_ci_jenkins_io_agents_read_prodreleasecore_vault" {
+  provider = azurerm.jenkins-sponsored
+
+  scope = azurerm_key_vault.prodreleasecore.id
+  # Allow reading (not sufficient: check access policies on the Vault)
+  role_definition_name = "Reader"
   principal_id         = azurerm_user_assigned_identity.release_ci_jenkins_io_agents_sponsored.principal_id
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5181

Tested manually with a local `terraform apply` and a replay of the `infra-health-agent` pipeline:

```
pipeline {
  agent none

  triggers {
    cron('0 2 * * *')
  }

  options {
    disableConcurrentBuilds()
  }

  environment {
    RELEASE_PROFILE           = 'weekly'
    AZURE_VAULT_NAME          = 'prodreleasecore'
    GPG_FILE                  = 'jenkins-release.gpg'
    GPG_VAULT_NAME            = 'jenkins-release-pgp-2026'
    WORKING_DIRECTORY         = "release"
  }

  stages {
    stage('Test Agents Health'){
      parallel {
        stage('Test Linux Agent `release-linux`') {
          agent {
            kubernetes {
              yamlFile 'PodTemplates.d/release-linux.yaml'
            }
          }
          steps {
            sh '''
            az login --federated-token "$(cat $AZURE_FEDERATED_TOKEN_FILE)" --service-principal -u "$AZURE_CLIENT_ID" -t "$AZURE_TENANT_ID"
            az keyvault secret download \
        		--vault-name "${AZURE_VAULT_NAME}" \
        		--name "${GPG_VAULT_NAME}" \
        		--file "${GPG_FILE}" \
        		--encoding base64
            '''
          }
        }
      }
    }
  }
}

```