### PR TITLE
feat(build.reports) allow access from cert.ci (sponsored) agents subnet

### DIFF
--- a/builds.reports.jenkins.io.tf
+++ b/builds.reports.jenkins.io.tf
@@ -29,6 +29,8 @@ resource "azurerm_storage_account" "builds_reports_jenkins_io" {
       local.app_subnets["release.ci.jenkins.io"].agents,
       # Required for populating the resource
       local.app_subnets["trusted.ci.jenkins.io"].agents,
+      # Required for populating the resource
+      local.app_subnets["cert.ci.jenkins.io"].agents,
     )
     bypass = ["AzureServices"]
   }

--- a/locals.tf
+++ b/locals.tf
@@ -357,6 +357,13 @@ locals {
         data.azurerm_subnet.trusted_ci_jenkins_io_sponsored_ephemeral_agents.id,
       ],
     },
+    "cert.ci.jenkins.io" = {
+      "controller" = [data.azurerm_subnet.cert_ci_jenkins_io_controller.id],
+      "agents" = [
+        # VM agents (Jenkins Sponsored subscription)
+        data.azurerm_subnet.cert_ci_jenkins_io_sponsored_ephemeral_agents.id,
+      ],
+    }
   }
 
   infra_ci_jenkins_io_fqdn                        = "infra.ci.jenkins.io"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5123

We can allow the subnet (located in Sweden) since https://github.com/jenkins-infra/azure-net/pull/552 (its fixup https://github.com/jenkins-infra/azure-net/pull/553):

<img width="399" height="451" alt="Capture d’écran 2026-07-27 à 18 18 03" src="https://github.com/user-attachments/assets/f28b6869-67de-4ec9-891b-33b27938debd" />


(no more warning message related to missing service endpoint)