### PR TITLE
hotfix(cert.ci.jenkins.io) ensure the correct "commons" subnet is used 

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -119,7 +119,7 @@ data "azurerm_subnet" "cert_ci_jenkins_io_sponsored_ephemeral_agents" {
 }
 data "azurerm_subnet" "cert_ci_jenkins_io_sponsored_commons" {
   provider             = azurerm.jenkins-sponsored
-  name                 = "${data.azurerm_virtual_network.cert_ci_jenkins_io_sponsored.name}-ephemeral-agents"
+  name                 = "${data.azurerm_virtual_network.cert_ci_jenkins_io_sponsored.name}-commons"
   virtual_network_name = data.azurerm_virtual_network.cert_ci_jenkins_io_sponsored.name
   resource_group_name  = data.azurerm_virtual_network.cert_ci_jenkins_io_sponsored.resource_group_name
 }


### PR DESCRIPTION
fixup of 1831e6c (#1521) where I mispelled the subnet name 

Ref. https://github.com/jenkins-infra/helpdesk/issues/5269