### PR TITLE
feat(cert.ci.jenkins.io) set up a new Azure AD to provide an ACR push credential

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -199,6 +199,43 @@ resource "azurerm_network_security_rule" "allow_in_https_from_cert_sponsored_vne
   resource_group_name          = data.azurerm_network_security_group.cert_ci_jenkins_io_sponsored_vnet.resource_group_name
   network_security_group_name  = data.azurerm_network_security_group.cert_ci_jenkins_io_sponsored_vnet.name
 }
+resource "azuread_application" "cert_ci_jenkins_io_acr_dockerhub_mirror" {
+  display_name = "cert-ci-jenkins-io-acr-dockerhub-mirror"
+  owners = [
+    data.azuread_service_principal.terraform_production.client_id,
+  ]
+  tags = [for key, value in local.default_tags : "${key}:${value}"]
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.Read
+      type = "Scope"
+    }
+  }
+  web {
+    homepage_url = "https://cert.ci.jenkins.io/manage/credentials/store/system/domain/_/credential/azure-container-registry-push/"
+  }
+}
+# resource "azuread_service_principal" "cert_ci_jenkins_io_acr_dockerhub_mirror" {
+#   client_id                    = azuread_application.cert_ci_jenkins_io_acr_dockerhub_mirror.client_id
+#   app_role_assignment_required = false
+#   owners = [
+#     data.azuread_service_principal.terraform_production.id,
+#   ]
+# }
+resource "azuread_application_password" "cert_ci_jenkins_io_acr_dockerhub_mirror" {
+  application_id = azuread_application.cert_ci_jenkins_io_acr_dockerhub_mirror.id
+  display_name   = "cert-ci-jenkins-io-acr-dockerhub-mirror"
+  # end_date       = "2026-11-22T00:00:00Z"
+}
+resource "azurerm_role_assignment" "certpush_to_acr" {
+  count                            = var.environment == "staging" ? 0 : 1
+  principal_id                     = azuread_application.cert_ci_jenkins_io_acr_dockerhub_mirror.client_id
+  role_definition_name             = "AcrPush"
+  scope                            = azurerm_container_registry.dockerhub_mirror.id
+  skip_service_principal_aad_check = true
+}
 
 ####################################################################################
 ## Public DNS records in the CDF subscription

--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -217,13 +217,6 @@ resource "azuread_application" "cert_ci_jenkins_io_acr_dockerhub_mirror" {
     homepage_url = "https://cert.ci.jenkins.io/manage/credentials/store/system/domain/_/credential/azure-container-registry-push/"
   }
 }
-# resource "azuread_service_principal" "cert_ci_jenkins_io_acr_dockerhub_mirror" {
-#   client_id                    = azuread_application.cert_ci_jenkins_io_acr_dockerhub_mirror.client_id
-#   app_role_assignment_required = false
-#   owners = [
-#     data.azuread_service_principal.terraform_production.id,
-#   ]
-# }
 resource "azuread_application_password" "cert_ci_jenkins_io_acr_dockerhub_mirror" {
   application_id = azuread_application.cert_ci_jenkins_io_acr_dockerhub_mirror.id
   display_name   = "cert-ci-jenkins-io-acr-dockerhub-mirror"

--- a/dockerhub-mirror.tf
+++ b/dockerhub-mirror.tf
@@ -108,12 +108,3 @@ resource "azurerm_container_registry_cache_rule" "mirror_cache_rules" {
   target_repo           = each.value.target
   credential_set_id     = azurerm_container_registry_credential_set.dockerhub.id
 }
-
-#### Allow provided Principal IDs to push images to the registry
-resource "azurerm_role_assignment" "push_to_acr" {
-  count                            = var.environment == "staging" ? 0 : 1
-  principal_id                     = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents_jenkins_sponsored.principal_id
-  role_definition_name             = "AcrPush"
-  scope                            = azurerm_container_registry.dockerhub_mirror.id
-  skip_service_principal_aad_check = true
-}

--- a/infra.ci.jenkins.io.tf
+++ b/infra.ci.jenkins.io.tf
@@ -453,6 +453,18 @@ resource "azurerm_network_security_rule" "allow_in_https_from_infra_ephemeral_ag
   resource_group_name          = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_rg_name
   network_security_group_name  = module.infra_ci_jenkins_io_azurevm_agents_jenkins_sponsored.ephemeral_agents_nsg_name
 }
+#### Allow provided Principal IDs to push images to the registry
+moved {
+  from = azurerm_role_assignment.push_to_acr
+  to   = azurerm_role_assignment.infra_ci_jenkins_io_push_to_acr
+}
+resource "azurerm_role_assignment" "infra_ci_jenkins_io_push_to_acr" {
+  count                            = var.environment == "staging" ? 0 : 1
+  principal_id                     = azurerm_user_assigned_identity.infra_ci_jenkins_io_agents_jenkins_sponsored.principal_id
+  role_definition_name             = "AcrPush"
+  scope                            = azurerm_container_registry.dockerhub_mirror.id
+  skip_service_principal_aad_check = true
+}
 
 ## Vault
 resource "azurerm_key_vault" "infra_ci_jenkins_io_vault" {


### PR DESCRIPTION
As we don't want all agents of cert.ci.jenkins.io to have the ability to push to the (private) ACR, but only a few selected jobs, let's target a credential.

We create an Azure AD application along with an Azure AD app password, planning to use https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#service-principal.

----

Notes: 
- We tend to use Azure AD password instead of SP passwords so no SP created in this PR: will require testing manually once from a cert.ci.jenkins.io agent first before setting up othe things
- It will require an update on the pipeline library to support login with a credential as it assumes credential-less login using managed identity from agent VM today.