### PR TITLE
fix(cert.ci.jenkins.io) ensure the AzureVM agents UAID does not depend on the controller or agent components but on the 'commons' RG instead + cleanup

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -90,17 +90,11 @@ module "cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
     privatevpn_subnet = data.azurerm_subnet.private_vnet_data_tier.address_prefixes
   }
 }
-resource "azurerm_resource_group" "cert_ci_jenkins_io_controller_jenkins_sponsored" {
-  provider = azurerm.jenkins-sponsored
-  name     = module.cert_ci_jenkins_io.controller_resourcegroup_name # Same name on both subscriptions
-  location = data.azurerm_virtual_network.cert_ci_jenkins_io_sponsored.location
-  tags     = local.default_tags
-}
 resource "azurerm_user_assigned_identity" "cert_ci_jenkins_io_azurevm_agents_jenkins_sponsored" {
   provider            = azurerm.jenkins-sponsored
-  location            = azurerm_resource_group.cert_ci_jenkins_io_controller_jenkins_sponsored.location
+  location            = azurerm_resource_group.cert_ci_jenkins_io_sponsored_commons.location
   name                = "cert-ci-jenkins-io-agents-sponsored"
-  resource_group_name = azurerm_resource_group.cert_ci_jenkins_io_controller_jenkins_sponsored.name
+  resource_group_name = azurerm_resource_group.cert_ci_jenkins_io_sponsored_commons.name
 }
 # The Controller identity must be able to operate this identity to assign it to VM agents - https://plugins.jenkins.io/azure-vm-agents/#plugin-content-roles-required-by-feature
 resource "azurerm_role_assignment" "cert_ci_jenkins_io_operate_agent_identity_jenkins_sponsored" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5269#issuecomment-5541021978

⚠️ This PR will break the ability for cert.ci.jenkins.io agents to write into the build report storage. Pagerduty will most probably alert us in ~3h if no new agent health build is executed after changing the controller setup (see issue comment).