### PR TITLE
fix(cert.ci.jenkins.io)  allow both old and new controllers to manage DNS for letsencrypt

### DIFF
--- a/cert.ci.jenkins.io.tf
+++ b/cert.ci.jenkins.io.tf
@@ -8,7 +8,10 @@ module "cert_ci_jenkins_io_letsencrypt" {
   zone_name        = "cert.ci.jenkins.io"
   dns_rg_name      = data.azurerm_resource_group.proddns_jenkinsio.name
   parent_zone_name = data.azurerm_dns_zone.jenkinsio.name
-  principal_ids    = [module.cert_ci_jenkins_io.controller_service_principal_id]
+  principal_ids = [
+    module.cert_ci_jenkins_io.controller_service_principal_id,
+    module.cert_ci_jenkins_io_sponsored.controller_service_principal_id,
+  ]
 }
 module "cert_ci_jenkins_io" {
   source = "./modules/azure-jenkinsinfra-controller"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5089#issuecomment-5540956527

Fixup of #1530 where I forgot this change

Fixes the error

```
$ certbot --text --agree-tos --non-interactive certonly --rsa-key-size 4096 --cert-name 'cert.ci.jenkins.io' -d 'cert.ci.jenkins.io'
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Requesting a certificate for cert.ci.jenkins.io
Cleanup of cert.ci.jenkins.io failed: azuredns: could not find zone (from discovery): cert.ci.jenkins.io
azuredns: could not find zone (from discovery): cert.ci.jenkins.io
Ask for help or search for solutions at https://community.letsencrypt.org. See the logfile /var/log/letsencrypt/letsencrypt.log or re-run Certbot with -v for more details.
```

From puppet initial bootstrap